### PR TITLE
Use LinkedHashSet to preserve the order of the elements. Always render "...

### DIFF
--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/members/cssclassfa/CssClassFaFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/members/cssclassfa/CssClassFaFacetAbstract.java
@@ -44,9 +44,12 @@ public class CssClassFaFacetAbstract extends SingleStringValueFacetAbstract impl
      */
     static String sanitize(String value) {
         Iterable<String> classes = Splitter.on(WHITESPACE).split(value);
-        Set<String> cssClassesSet = Sets.newHashSet(classes);
+        Set<String> cssClassesSet = Sets.newLinkedHashSet();
         cssClassesSet.add("fa");
         cssClassesSet.add("fa-fw");
+        for (String cssClass : classes) {
+            cssClassesSet.add(cssClass);
+        }
         return Joiner.on(' ').join(cssClassesSet);
     }
 

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/members/cssclassfa/CssClassFaAnnotationOnMemberFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/members/cssclassfa/CssClassFaAnnotationOnMemberFacetFactoryTest.java
@@ -57,6 +57,6 @@ public class CssClassFaAnnotationOnMemberFacetFactoryTest extends AbstractFacetF
         assertThat(facet, is(not(nullValue())));
         assertThat(facet instanceof CssClassFaFacetAbstract, is(true));
         final CssClassFaFacetAbstract cssClassFacetAbstract = (CssClassFaFacetAbstract) facet;
-        assertThat(cssClassFacetAbstract.value(), equalTo("fa fa-foo fa-fw"));
+        assertThat(cssClassFacetAbstract.value(), equalTo("fa fa-fw fa-foo"));
     }
 }

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/cssclassfa/CssClassFaFacetOnTypeAnnotationFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/cssclassfa/CssClassFaFacetOnTypeAnnotationFactoryTest.java
@@ -50,6 +50,6 @@ public class CssClassFaFacetOnTypeAnnotationFactoryTest extends AbstractFacetFac
         assertThat(facet, is(not(nullValue())));
         assertThat(facet instanceof CssClassFaFacetAbstract, is(true));
         final CssClassFaFacetAbstract cssClassFacetAbstract = (CssClassFaFacetAbstract) facet;
-        assertThat(cssClassFacetAbstract.value(), equalTo("fa fa-foo fa-fw"));
+        assertThat(cssClassFacetAbstract.value(), equalTo("fa fa-fw fa-foo"));
     }
 }


### PR DESCRIPTION
...fa fa-fw" in front of the custom FontAwesome classes
