### PR TITLE
Define explicit dependency on jackson-annotations because otherwise an o...

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,7 +112,7 @@
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <commons-codec.version>1.9</commons-codec.version>
 
-        <jackson.version>2.4.3</jackson.version>
+        <jackson.version>2.4.4</jackson.version>
         <gson.version>2.2.4</gson.version>
 
         <!-- using 2.3.2 throws strange error about not finding org.hsqldb.jdbcDriver -->
@@ -1289,6 +1289,11 @@ ${license.additional-notes}
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>

--- a/core/viewer-restfulobjects-applib/pom.xml
+++ b/core/viewer-restfulobjects-applib/pom.xml
@@ -91,6 +91,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
             
 	</dependencies>
 


### PR DESCRIPTION
...ld version of it may be picked

Kitchensink app used jackson-annotations:2.0.5 due to transitive dependency via wickedcharts.

Additionally update Jackson to 2.4.4
