### PR TITLE
ISIS-537 Remove 'form-control' for the BooleanPanel's checkbox to avoid ...

### DIFF
--- a/component/viewer/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/primitive/BooleanPanel.html
+++ b/component/viewer/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/primitive/BooleanPanel.html
@@ -27,11 +27,11 @@
             <div class="booleanPanel scalarNameAndValueComponentType">
                 <div class="form-group" wicket:id="scalarIfRegular">
                     <label wicket:id="scalarName" class="scalarName control-label">[Label text]</label>
-                    <span class="scalarValueWrapper">
-                        <input type="checkbox" name="scalarValue" class="form-control scalarValue" wicket:id="scalarValue" />
+                    <div class="scalarValueWrapper">
+                        <input type="checkbox" name="scalarValue" class="scalarValue" wicket:id="scalarValue" />
                         <span wicket:id="feedback" class="help-block"></span>
                         <span wicket:id="associatedActionLinksBelow"></span>
-                    </span>
+                    </div>
                     <span wicket:id="associatedActionLinksRight"></span>
                 </div>
                 <input type="checkbox" wicket:id="scalarIfCompact" />


### PR DESCRIPTION
...flickering - initially it appears as a larger box then it is resized and moved to the left.

Now it appears as a normal checkbox and then it is styled. There is again flickering but not so intrusive. Select2 also behaves this way.
