### PR TITLE
InteractionHelper.postEventForCollection: Phase parameter is null

### DIFF
--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/InteractionHelper.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/InteractionHelper.java
@@ -216,7 +216,7 @@ public class InteractionHelper {
             } else {
                 final Object source = ObjectAdapter.Util.unwrap(targetAdapter);
                 final Identifier identifier = identified.getIdentifier();
-                event = newCollectionInteractionEvent(eventType, null, identifier, source, of, reference);
+                event = newCollectionInteractionEvent(eventType, phase, identifier, source, of, reference);
             }
             event.setPhase(phase);
             getEventBusService().post(event);


### PR DESCRIPTION
When invoking newCollectionInteractionEvent(...) a null value is passed to the phase, causing an exception to be thrown.