### PR TITLE
ExceptionRecognizerComposite: NPE if container is null

### DIFF
--- a/core/applib/src/main/java/org/apache/isis/applib/services/exceprecog/ExceptionRecognizerComposite.java
+++ b/core/applib/src/main/java/org/apache/isis/applib/services/exceprecog/ExceptionRecognizerComposite.java
@@ -117,7 +117,8 @@ public class ExceptionRecognizerComposite implements ExceptionRecognizer2 {
     private void injectServicesIfNecessary() {
         if(!injected) {
             for (final ExceptionRecognizer ers : exceptionRecognizers) {
-                container.injectServicesInto(ers);
+                if (container != null)
+                    container.injectServicesInto(ers);
             }
             injected = true;
         }


### PR DESCRIPTION
I have implemented ApplicationTenancy.
When directly introducing the URL of an entity whose access is forbidden for me (i.e., http://localhost:8080/entity/KIT_:L_2) throws a NullPointerException.
Perhaps the root cause is different.
But simply by evaluating if is null, it properly shows the error message ("Not authorized or no such object") instead of a HTTP 500 with a NullPointerException in the log.