### PR TITLE
ISIS-1162 Add attribute for permission ldap extraction

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1935,7 +1935,6 @@ ${license.additional-notes}
         </site>
     </distributionManagement>
     -->
-
     <profiles>
         <profile>
             <id>m2e</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -920,7 +920,7 @@
                     <configuration>
                         <rules>
                             <requireMavenVersion>
-                                <version>[3.0.5,)</version>
+                                <version>[3.0.4,)</version>
                             </requireMavenVersion>
                             <requireJavaVersion>
                                 <version>[1.8.0,)</version>

--- a/core/security-shiro/src/main/java/org/apache/isis/security/shiro/IsisLdapRealm.java
+++ b/core/security-shiro/src/main/java/org/apache/isis/security/shiro/IsisLdapRealm.java
@@ -67,7 +67,6 @@ import org.apache.shiro.util.StringUtils;
  *
  * ldapRealm.searchUserBase = ou=users,o=mojo
  * ldapRealm.userObjectClass=inetOrgPerson
- * ldapRealm.userObjectClass=organizationnalPerson
  * ldapRealm.groupExtractedAttribute=street,country
  * ldapRealm.userExtractedAttribute=street,country
  * ldapRealm.permissionByGroupAttribute=attribute:Folder.{street}:Read,attribute:Portfolio.{country}

--- a/core/security-shiro/src/main/java/org/apache/isis/security/shiro/IsisLdapRealm.java
+++ b/core/security-shiro/src/main/java/org/apache/isis/security/shiro/IsisLdapRealm.java
@@ -18,11 +18,7 @@
  */
 package org.apache.isis.security.shiro;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import java.util.*;
 import javax.naming.AuthenticationException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -31,23 +27,20 @@ import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.isis.security.shiro.permrolemapper.PermissionToRoleMapper;
 import org.apache.isis.security.shiro.permrolemapper.PermissionToRoleMapperFromIni;
 import org.apache.isis.security.shiro.permrolemapper.PermissionToRoleMapperFromString;
-import org.apache.isis.security.shiro.util.Util;
-
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.config.Ini;
 import org.apache.shiro.realm.ldap.JndiLdapRealm;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
 import org.apache.shiro.realm.ldap.LdapUtils;
-import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.util.StringUtils;
-
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Implementation of {@link org.apache.shiro.realm.ldap.JndiLdapRealm} that also
@@ -71,6 +64,14 @@ import com.google.common.collect.Sets;
  * ldapRealm.groupObjectClass = groupOfUniqueNames
  * ldapRealm.uniqueMemberAttribute = uniqueMember
  * ldapRealm.uniqueMemberAttributeValueTemplate = uid={0}
+ *
+ * ldapRealm.searchUserBase = ou=users,o=mojo
+ * ldapRealm.userObjectClass=inetOrgPerson
+ * ldapRealm.userObjectClass=organizationnalPerson
+ * ldapRealm.groupExtractedAttribute=street,country
+ * ldapRealm.userExtractedAttribute=street,country
+ * ldapRealm.permissionByGroupAttribute=attribute:Folder.{street}:Read,attribute:Portfolio.{country}
+ * ldapRealm.permissionByUserAttribute=attribute:Folder.{street}:Read,attribute:Portfolio.{country}
  *
  * # optional mapping from physical groups to logical application roles
  * ldapRealm.rolesByGroup = \
@@ -110,18 +111,28 @@ import com.google.common.collect.Sets;
  * Alternatively, permissions can be set directly using {@link #setPermissionsByRole(String)},
  * where the string is the same information, formatted thus:
  * 
- * <re>
+ * <pre>
  * ldapRealm.permissionsByRole=\
  *    user_role = *:ToDoItemsJdo:*:*,\
  *                *:ToDoItem:*:*; \
  *    self-install_role = *:ToDoItemsFixturesService:install:* ; \
  *    admin_role = *
  * </pre>
+ *
+ * <p>
+ * Alternatively, permissions can be extracted from the base itself with the parameter searchUserBase,
+ * the attribute list as userExtractedAttribute and the permission url as permissionByUserAttribute.
+ * The idea is to extract attribute from the user or the group of the user and map directly to permission rule in
+ * replacing the string {attribute} by the extracted attribute (can me multiple).
+ * See the sample for group and user attribute and mapping.
+ *
+ * </p>
  */
 public class IsisLdapRealm extends JndiLdapRealm {
 
     private static final String UNIQUEMEMBER_SUBSTITUTION_TOKEN = "{0}";
     private final static SearchControls SUBTREE_SCOPE = new SearchControls();
+
     static {
         SUBTREE_SCOPE.setSearchScope(SearchControls.SUBTREE_SCOPE);
     }
@@ -131,10 +142,51 @@ public class IsisLdapRealm extends JndiLdapRealm {
     private String uniqueMemberAttribute = "uniqueMember";
     private String uniqueMemberAttributeValuePrefix;
     private String uniqueMemberAttributeValueSuffix;
-    
+
+    /**
+     * For Group Extracted attribute name with mapping name in parenthesis. Ex: street,country
+     */
+    protected Set<String> groupExtractedAttribute = Sets.newConcurrentHashSet();
+
+    /**
+     * For User Extracted attribute name with mapping name in parenthesis. Ex: street,country
+     */
+    protected Set<String> userExtractedAttribute = Sets.newConcurrentHashSet();
+
+    /**
+     * For Group Mapping of attributes. Ex:
+     * attribute:Folder.{street}:Read,attribute:Portfolio.{country}:*
+     */
+    protected Set<String> permissionByGroupAttribute = Sets.newConcurrentHashSet();
+
+    /**
+     * For User Mapping of attributes. Ex:
+     * attribute:Folder.{street}:Read,attribute:Portfolio.{country}:*
+     */
+    protected Set<String> permissionByUserAttribute = Sets.newConcurrentHashSet();
+
+    /**
+     * For search ldap on user
+     */
+    private String searchUserBase = "";
+
+    /**
+     * The object className as person
+     */
+    private String userObjectClass;
+
+
+
     private final Map<String,String> rolesByGroup = Maps.newLinkedHashMap();
     
     private PermissionToRoleMapper permissionToRoleMapper;
+
+
+
+    /**
+     * cn attribute
+     */
+    private String cnAttribute="cn";
 
     public IsisLdapRealm() {
         setGroupObjectClass("groupOfUniqueNames");
@@ -160,8 +212,97 @@ public class IsisLdapRealm extends JndiLdapRealm {
         final Set<String> roleNames = getRoles(principals, ldapContextFactory);
         SimpleAuthorizationInfo simpleAuthorizationInfo = new SimpleAuthorizationInfo(roleNames);
         Set<String> stringPermissions = permsFor(roleNames);
+        final String username = (String) getAvailablePrincipal(principals);
+        final LdapContext finalLdapContext = ldapContextFactory.getSystemLdapContext();
+        stringPermissions.addAll(getPermissionForUser(username, finalLdapContext));
+        stringPermissions.addAll(getPermissionForRole(username, finalLdapContext));
         simpleAuthorizationInfo.setStringPermissions(stringPermissions);
+
         return simpleAuthorizationInfo;
+    }
+
+    private Set<String>
+    getPermissionForRole(String username, LdapContext ldapContext)
+            throws NamingException {
+        final Set<String> permissions = Sets.newLinkedHashSet();
+
+        Set<String> groups = groupFor(username, ldapContext);
+        final NamingEnumeration<SearchResult> searchResultEnum = ldapContext.search(searchBase,
+                "objectClass=" + groupObjectClass, SUBTREE_SCOPE);
+        while (searchResultEnum.hasMore()) {
+            final SearchResult group = searchResultEnum.next();
+            if(memberOf(group,groups)) {
+                addPermIfFound(group, permissions, groupExtractedAttribute, permissionByGroupAttribute);
+            }
+        }
+        return permissions;
+    }
+
+    protected Set<String> groupFor(final String userName, final LdapContext ldapCtx)
+            throws NamingException {
+        final Set<String> roleNames = Sets.newLinkedHashSet();
+        final NamingEnumeration<SearchResult> searchResultEnum = ldapCtx.search(searchBase,
+                "objectClass=" + groupObjectClass, SUBTREE_SCOPE);
+        while (searchResultEnum.hasMore()) {
+            final SearchResult group = searchResultEnum.next();
+            addRoleIfMember(userName, group, roleNames);
+        }
+        return roleNames;
+    }
+
+    protected boolean memberOf(SearchResult group, Set<String> groups) throws NamingException {
+        Attribute attribute = group.getAttributes().get(cnAttribute);
+        String groupName = attribute.get().toString();
+        return groups.contains(groupName);
+    }
+
+    private Collection<String> getPermissionForUser( String username,
+                                                     LdapContext ldapContextFactory) throws NamingException {
+
+        try {
+            return permUser(username, ldapContextFactory);
+        } catch (org.apache.shiro.authc.AuthenticationException ex) {
+            return Collections.emptySet();
+        }
+    }
+
+    private Collection<String> permUser(String username, LdapContext systemLdapCtx)
+            throws NamingException {
+        final Set<String> permissions = Sets.newLinkedHashSet();
+        final NamingEnumeration<SearchResult> searchResultEnum = systemLdapCtx.search(
+                searchUserBase, "objectClass=" + userObjectClass, SUBTREE_SCOPE);
+        while (searchResultEnum.hasMore()) {
+            final SearchResult group = searchResultEnum.next();
+            addPermIfFound(group, permissions, userExtractedAttribute, permissionByUserAttribute);
+        }
+        return permissions;
+    }
+
+    private void addPermIfFound( SearchResult group, Set<String> permissions,
+                                 Set<String> extractedAttributeP, Set<String> permissionByAttributeP)
+            throws NamingException {
+        final NamingEnumeration<? extends Attribute> attributeEnum = group.getAttributes().getAll();
+        Map<String, Set<String>> keyValues = Maps.newHashMap();
+        while (attributeEnum.hasMore()) {
+            final Attribute attr = attributeEnum.next();
+            if (extractedAttributeP.contains(attr.getID())) {
+                final NamingEnumeration<?> e = attr.getAll();
+                keyValues.put(attr.getID(), new HashSet<String>());
+                while (e.hasMore()) {
+                    String attrValue = e.next().toString();
+                    keyValues.get(attr.getID()).add(attrValue);
+                }
+            }
+        }
+        for (String permTempl : permissionByAttributeP) {
+            for (String key : keyValues.keySet()) {
+                if (permTempl.contains("{" + key + "}")) {
+                    for (String value : keyValues.get(key)) {
+                        permissions.add(permTempl.replaceAll("\\{" + key + "\\}", value));
+                    }
+                }
+            }
+        }
     }
 
     private Set<String> getRoles(final PrincipalCollection principals, final LdapContextFactory ldapContextFactory) throws NamingException {
@@ -325,5 +466,37 @@ public class IsisLdapRealm extends JndiLdapRealm {
         this.permissionToRoleMapper = new PermissionToRoleMapperFromString(permissionsByRoleStr);
     }
 
+
+    public void setPermissionByUserAttribute(String permissionByUserAttr) {
+        String[] list = permissionByUserAttr.split(",");
+        this.permissionByUserAttribute.addAll(Lists.newArrayList(list));
+    }
+
+    public void setPermissionByGroupAttribute(String permissionByGroupAttribute) {
+        String[] list = permissionByGroupAttribute.split(",");
+        this.permissionByGroupAttribute.addAll(Lists.newArrayList(list));
+    }
+
+    public void setUserExtractedAttribute(String userExtractedAttribute) {
+        String[] list = userExtractedAttribute.split(",");
+        this.userExtractedAttribute.addAll(Lists.newArrayList(list));
+    }
+
+    public void setGroupExtractedAttribute(String groupExtractedAttribute) {
+        String[] list = groupExtractedAttribute.split(",");
+        this.groupExtractedAttribute.addAll(Lists.newArrayList(list));
+    }
+
+    public void setSearchUserBase(String searchUserBase) {
+        this.searchUserBase = searchUserBase;
+    }
+
+    public void setUserObjectClass(String userObjectClass) {
+        this.userObjectClass = userObjectClass;
+    }
+
+    public void setCnAttribute(String cnAttribute) {
+        this.cnAttribute = cnAttribute;
+    }
 
 }


### PR DESCRIPTION
I propose new permisions creation from LDAP attribute
Alternatively, permissions can be extracted from the base itself with the parameter searchUserBase,
the attribute list as userExtractedAttribute and the permission url as permissionByUserAttribute.
The idea is to extract attribute from the user or the group of the user and map directly to permission rule in replacing the string {attribute} by the extracted attribute (can me multiple).
See the sample for group and user attribute and mapping:
ldapRealm.searchUserBase = ou=users,o=mojo
ldapRealm.userObjectClass=inetOrgPerson
ldapRealm.userObjectClass=organizationnalPerson
ldapRealm.groupExtractedAttribute=street,country
ldapRealm.userExtractedAttribute=street,country
ldapRealm.permissionByGroupAttribute=attribute:Folder.{street}:Read,attribute:Portfolio.{country}
ldapRealm.permissionByUserAttribute=attribute:Folder.{street}:Read,attribute:Portfolio.{country}