### PR TITLE
ISIS-1181: Fix broken link on main http://isis.apache.org

### DIFF
--- a/adocs/documentation/src/main/asciidoc/index.html
+++ b/adocs/documentation/src/main/asciidoc/index.html
@@ -612,7 +612,7 @@
                     <div class="large-12 medium-12 columns">
                         <h4>Getting started</h4>
                         <br/>
-                        <p>Start developing your own Apache Isis application using our <a href="intro/getting-started/simpleapp-archetype.html">simpleapp archetype</a>:</p>
+                        <p>Start developing your own Apache Isis application using our <a href="guides/ug.html#_ug_getting-started_simpleapp-archetype.html">simpleapp archetype</a>:</p>
                     </div>
                 </div>
                 <div class="row">


### PR DESCRIPTION
Fix the broken link under simpleapp-archetype on the main http://isis.apache.org page by linking it correctly to "guides/ug.html#_ug_getting-started_simpleapp-archetype" URL fragment instead of the current non-existent one.