### PR TITLE
Replaced deprecated getPhase() with getEventPhase() in documentation

### DIFF
--- a/adocs/documentation/src/main/asciidoc/guides/_rgant-Action_domainEvent.adoc
+++ b/adocs/documentation/src/main/asciidoc/guides/_rgant-Action_domainEvent.adoc
@@ -109,7 +109,7 @@ The subscriber can distinguish these by calling `ev.getEventPhase()`. Thus the g
 @Programmatic
 @com.google.common.eventbus.Subscribe
 public void on(ActionDomainEvent ev) {
-    switch(ev.getPhase()) {
+    switch(ev.getEventPhase()) {
         case HIDE:
             // call ev.hide() or ev.veto("") to hide the action
             break;

--- a/adocs/documentation/src/main/asciidoc/guides/_rgant-Collection_domainEvent.adoc
+++ b/adocs/documentation/src/main/asciidoc/guides/_rgant-Collection_domainEvent.adoc
@@ -114,14 +114,14 @@ The subscriber's method is called (up to) 5 times:
 * steps to perform prior to the collection being added to/removed from
 * steps to perform after the collection has been added to/removed from.
 
-The subscriber can distinguish these by calling `ev.getPhase()`. Thus the general form is:
+The subscriber can distinguish these by calling `ev.getEventPhase()`. Thus the general form is:
 
 [source,java]
 ----
 @Programmatic
 @com.google.common.eventbus.Subscribe
 public void on(CollectionDomainEvent ev) {
-    switch(ev.getPhase()) {
+    switch(ev.getEventPhase()) {
         case HIDE:
             // call ev.hide() or ev.veto("") to hide the collection
             break;

--- a/adocs/documentation/src/main/asciidoc/guides/_rgant-Property_domainEvent.adoc
+++ b/adocs/documentation/src/main/asciidoc/guides/_rgant-Property_domainEvent.adoc
@@ -97,14 +97,14 @@ The subscriber's method is called (up to) 5 times:
 * steps to perform prior to the property being modified
 * steps to perform after the property has been modified.
 
-The subscriber can distinguish these by calling `ev.getPhase()`. Thus the general form is:
+The subscriber can distinguish these by calling `ev.getEventPhase()`. Thus the general form is:
 
 [source,java]
 ----
 @Programmatic
 @com.google.common.eventbus.Subscribe
 public void on(PropertyDomainEvent ev) {
-    switch(ev.getPhase()) {
+    switch(ev.getEventPhase()) {
         case HIDE:
             // call ev.hide() or ev.veto("") to hide the property
             break;


### PR DESCRIPTION
Ran into some deprecated statements in the isis documentation. 