### PR TITLE
add svg image suffix support

### DIFF
--- a/core/viewer-wicket-impl/src/main/java/org/apache/isis/viewer/wicket/viewer/imagecache/ImageResourceCacheClassPath.java
+++ b/core/viewer-wicket-impl/src/main/java/org/apache/isis/viewer/wicket/viewer/imagecache/ImageResourceCacheClassPath.java
@@ -45,7 +45,7 @@ public class ImageResourceCacheClassPath implements ImageResourceCache {
 
     private static final long serialVersionUID = 1L;
     
-    private static final List<String> IMAGE_SUFFICES = Arrays.asList("png", "gif", "jpeg", "jpg");
+    protected static final List<String> IMAGE_SUFFICES = Arrays.asList("png", "gif", "jpeg", "jpg", "svg");
     private static final String FALLBACK_IMAGE = "Default.png";
 
     private final Map<ImageResourceCacheKey, ResourceReference> resourceReferenceByKey = Maps.newConcurrentMap();


### PR DESCRIPTION
### Changes:
1. Add svg image suffix support to the image cache. 
2. Allow sub-classes of ImageResourceCacheClassPath to access/modify the IMAGE_SUFFICES field.

### Note:
I'm not sure though, whether the web.xml has to be extended accordingly ...
```xml
<web-app ...>
...
<servlet>
    <servlet-name>Resource</servlet-name>
    <servlet-class>org.apache.isis.core.webapp.content.ResourceServlet</servlet-class>
  </servlet>
  <servlet-mapping>
    <servlet-name>Resource</servlet-name>
    <url-pattern>*.svg</url-pattern>
  </servlet-mapping>
...
</web-app>
```
(This would affect the simple-app template and the like.)