### PR TITLE
Fixed link in docs

### DIFF
--- a/adocs/documentation/src/main/asciidoc/guides/_ugfun_object-layout_dynamic_xml.adoc
+++ b/adocs/documentation/src/main/asciidoc/guides/_ugfun_object-layout_dynamic_xml.adoc
@@ -102,7 +102,7 @@ This corresponds to the following XML:
 ----
 
 
-You will notice that one of the ``col``umns has an ``unreferencedActions`` attribute, while one of the ``tabGroup``s has a similar ``unreferencedCollections`` attribute.  This topic is discussed in more detail xref:rgcms.adoc#_ugfun_object-layout_dynamic_xml-unreferenced[below].
+You will notice that one of the ``col``umns has an ``unreferencedActions`` attribute, while one of the ``tabGroup``s has a similar ``unreferencedCollections`` attribute.  This topic is discussed in more detail xref:ugfun.adoc#_ugfun_object-layout_dynamic_xml-unreferenced[below].
 
 
 
@@ -145,7 +145,7 @@ In the first column there is a single fieldset.  Notice how actions - such as `d
 
 Thereafter the fieldset lists the properties in order.  Actions can be associated with properties too; here they are rendered underneath or to the right of the field.
 
-Note also the `unreferencedProperties` attribute for the fieldset; this topic is discussed in more detail xref:rgcms.adoc#_ugfun_object-layout_dynamic_xml-unreferenced[below].
+Note also the `unreferencedProperties` attribute for the fieldset; this topic is discussed in more detail xref:ugfun.adoc#_ugfun_object-layout_dynamic_xml-unreferenced[below].
 
 
 === Collections


### PR DESCRIPTION
Link to unreferenced members was pointing towards the classes, methods and schema guide rather than the fundamentals guide