### PR TITLE
To fix bug to run in eclipse with *.launch files

### DIFF
--- a/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-PROTOTYPE-with-fixtures-bypass-security.launch
+++ b/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-PROTOTYPE-with-fixtures-bypass-security.launch
@@ -15,8 +15,8 @@
   <stringAttribute value="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector" key="org.eclipse.debug.core.source_locator_id"/>
   <booleanAttribute value="true" key="org.eclipse.jdt.debug.ui.INCLUDE_EXTERNAL_JARS"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.classpathProvider" key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER"/>
-  <stringAttribute value="org.apache.isis.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
+  <stringAttribute value="org.apache.isis.core.webserver.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
   <stringAttribute value="--type SERVER_PROTOTYPE --port 8080 --manifest domainapp.app.DomainAppAppManifestWithFixturesBypassSecurity" key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS"/>
-  <stringAttribute value="${rootArtifactId}-webapp" key="org.eclipse.jdt.launching.PROJECT_ATTR"/>
+  <stringAttribute value="${rootArtifactId}-webapp" key="org.eclipse.jdt.launching.PROJECT  _ATTR"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.sourcepathProvider" key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER"/>
 </launchConfiguration>

--- a/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-PROTOTYPE-with-fixtures.launch
+++ b/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-PROTOTYPE-with-fixtures.launch
@@ -15,7 +15,7 @@
   <stringAttribute value="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector" key="org.eclipse.debug.core.source_locator_id"/>
   <booleanAttribute value="true" key="org.eclipse.jdt.debug.ui.INCLUDE_EXTERNAL_JARS"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.classpathProvider" key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER"/>
-  <stringAttribute value="org.apache.isis.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
+  <stringAttribute value="org.apache.isis.core.webserver.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
   <stringAttribute value="--type SERVER_PROTOTYPE --port 8080 --manifest domainapp.app.DomainAppAppManifestWithFixtures" key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS"/>
   <stringAttribute value="${rootArtifactId}-webapp" key="org.eclipse.jdt.launching.PROJECT_ATTR"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.sourcepathProvider" key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER"/>

--- a/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-PROTOTYPE.launch
+++ b/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-PROTOTYPE.launch
@@ -15,7 +15,7 @@
   <stringAttribute value="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector" key="org.eclipse.debug.core.source_locator_id"/>
   <booleanAttribute value="true" key="org.eclipse.jdt.debug.ui.INCLUDE_EXTERNAL_JARS"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.classpathProvider" key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER"/>
-  <stringAttribute value="org.apache.isis.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
+  <stringAttribute value="org.apache.isis.core.webserver.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
   <stringAttribute value="--type SERVER_PROTOTYPE --port 8080" key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS"/>
   <stringAttribute value="${rootArtifactId}-webapp" key="org.eclipse.jdt.launching.PROJECT_ATTR"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.sourcepathProvider" key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER"/>

--- a/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-SERVER.launch
+++ b/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/ide/eclipse/launch/SimpleApp-SERVER.launch
@@ -15,7 +15,7 @@
   <stringAttribute value="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector" key="org.eclipse.debug.core.source_locator_id"/>
   <booleanAttribute value="true" key="org.eclipse.jdt.debug.ui.INCLUDE_EXTERNAL_JARS"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.classpathProvider" key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER"/>
-  <stringAttribute value="org.apache.isis.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
+  <stringAttribute value="org.apache.isis.core.webserver.WebServer" key="org.eclipse.jdt.launching.MAIN_TYPE"/>
   <stringAttribute value="--type SERVER --port 8080" key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS"/>
   <stringAttribute value="${rootArtifactId}-webapp" key="org.eclipse.jdt.launching.PROJECT_ATTR"/>
   <stringAttribute value="org.eclipse.m2e.launchconfig.sourcepathProvider" key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER"/>

--- a/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/pom.xml
+++ b/example/archetype/simpleapp/src/main/resources/archetype-resources/webapp/pom.xml
@@ -83,6 +83,13 @@
             <artifactId>geronimo-servlet_3.0_spec</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.isis.core</groupId>
+            <artifactId>isis-core-webserver</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
To fix a bug to run in eclipse with *.launch files:

1. isis-core-webserver was added to dependencies of pom.xml file of webapp

2. in launch files org.apache.isis.WebServer renamed to org.apache.isis.core.webserver.WebServer