### PR TITLE
ISIS-1475: Named-annotation disappeared on AccountManagementPageAbstract

### DIFF
--- a/core/viewer-wicket-ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/accmngt/AccountManagementPageAbstract.java
+++ b/core/viewer-wicket-ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/accmngt/AccountManagementPageAbstract.java
@@ -73,6 +73,7 @@ public class AccountManagementPageAbstract extends WebPage {
      * {@link com.google.inject.Inject}ed when {@link #init() initialized}.
      */
     @com.google.inject.Inject
+    @Named("applicationName")
     private String applicationName;
 
     /**


### PR DESCRIPTION
Checked the ToDo-app first and the screencast for changing the application name. It seems the annotation should be there.