### PR TITLE
Fix 'svg' suffix in ImageResourceCacheClassPath

### DIFF
--- a/core/viewer-wicket-impl/src/main/java/org/apache/isis/viewer/wicket/viewer/imagecache/ImageResourceCacheClassPath.java
+++ b/core/viewer-wicket-impl/src/main/java/org/apache/isis/viewer/wicket/viewer/imagecache/ImageResourceCacheClassPath.java
@@ -48,7 +48,7 @@ public class ImageResourceCacheClassPath implements ImageResourceCache {
 
     private static final long serialVersionUID = 1L;
     
-    private static final List<String> IMAGE_SUFFICES = Arrays.asList("png", "gif", "jpeg", "jpg", ".svg");
+    private static final List<String> IMAGE_SUFFICES = Arrays.asList("png", "gif", "jpeg", "jpg", "svg");
     private static final String FALLBACK_IMAGE = "Default.png";
 
     private final Map<ImageResourceCacheKey, ResourceReference> resourceReferenceByKey = Maps.newConcurrentMap();


### PR DESCRIPTION
Fixes a typo in the image suffix list. ".svg" -> "svg"
