### PR TITLE
ISIS-1738: ObjectMember's compator is not transitive

### DIFF
--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/spec/feature/ObjectMember.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/spec/feature/ObjectMember.java
@@ -214,9 +214,16 @@ public interface ObjectMember extends ObjectFeature {
                     String memberId2 = o2.getId();
                     String o1Sequence = o1Facet != null ? o1Facet.sequence() : "0";
                     String o2Sequence = o2Facet != null ? o2Facet.sequence() : "0";
-                    return o1Facet == null? +1:
-                            o2Facet == null? -1:
-                                    deweyOrderComparator.compare(o1Sequence, o2Sequence);
+                    if (o1Sequence == o2Sequence) {
+                        return 0;
+                    }
+                    if (o1Sequence == null) {
+                        return -1;
+                    }
+                    if (o2Sequence == null) {
+                        return 1;
+                    }
+                    return deweyOrderComparator.compare(o1Sequence, o2Sequence);
                 }
             };
         }


### PR DESCRIPTION
If both elements are null, depending on the order they're passed as params, it would return one result or another.

It failed on the TimeSort in some cases, throwing the following stacktrace:

java.lang.IllegalArgumentException: Comparison method violates its general contract!
   at java.util.TimSort.mergeLo(TimSort.java:773)
   at java.util.TimSort.mergeAt(TimSort.java:510)
   at java.util.TimSort.mergeCollapse(TimSort.java:437)
   at java.util.TimSort.sort(TimSort.java:241)
   at java.util.Arrays.sort(Arrays.java:1438)
   at com.google.common.collect.Ordering.immutableSortedCopy(Ordering.java:888)
   at com.google.common.collect.FluentIterable.toSortedList(FluentIterable.java:501)
   at org.apache.isis.core.metamodel.services.grid.bootstrap3.GridSystemServiceBS3.validateAndNormalize(GridSystemServiceBS3.java:467)
   at org.apache.isis.core.metamodel.services.grid.GridSystemServiceAbstract.normalize(GridSystemServiceAbstract.java:165)
   at org.apache.isis.core.metamodel.services.grid.GridServiceDefault.normalize(GridServiceDefault.java:102)
   at org.apache.isis.core.metamodel.facets.object.grid.GridFacetDefault.load(GridFacetDefault.java:75)
   at org.apache.isis.core.metamodel.facets.object.grid.GridFacetDefault.getGrid(GridFacetDefault.java:65)
   at org.apache.isis.viewer.wicket.ui.components.collectioncontents.ajaxtable.CollectionContentsAsAjaxTablePanel.addPropertyColumnsIfRequired(CollectionContentsAsAjaxTablePanel.java:167)
   at org.apache.isis.viewer.wicket.ui.components.collectioncontents.ajaxtable.CollectionContentsAsAjaxTablePanel.buildGui(CollectionContentsAsAjaxTablePanel.java:102)
   at org.apache.isis.viewer.wicket.ui.components.collectioncontents.ajaxtable.CollectionContentsAsAjaxTablePanel.onInitialize(CollectionContentsAsAjaxTablePanel.java:80)
   at org.apache.wicket.Component.fireInitialize(Component.java:878)
   at org.apache.wicket.MarkupContainer.internalInitialize(MarkupContainer.java:1070)
   at org.apache.wicket.MarkupContainer.addedComponent(MarkupContainer.java:1047)
   at org.apache.wicket.MarkupContainer.add(MarkupContainer.java:241)
   at org.apache.wicket.MarkupContainer.addOrReplace(MarkupContainer.java:265)
   at org.apache.isis.viewer.wicket.ui.components.collectioncontents.multiple.CollectionContentsMultipleViewsPanel.addUnderlyingViews(CollectionContentsMultipleViewsPanel.java:118)
   at org.apache.isis.viewer.wicket.ui.components.collectioncontents.multiple.CollectionContentsMultipleViewsPanel.onInitialize(CollectionContentsMultipleViewsPanel.java:87)
   at org.apache.wicket.Component.fireInitialize(Component.java:878)
   at org.apache.wicket.MarkupContainer$3.component(MarkupContainer.java:1076)
   at org.apache.wicket.MarkupContainer$3.component(MarkupContainer.java:1072)
   at org.apache.wicket.util.visit.Visits.visitChildren(Visits.java:144)
   at org.apache.wicket.util.visit.Visits.visitChildren(Visits.java:162)
   at org.apache.wicket.util.visit.Visits.visitChildren(Visits.java:162)
   at org.apache.wicket.util.visit.Visits.visitChildren(Visits.java:162)
   at org.apache.wicket.util.visit.Visits.visitChildren(Visits.java:123)
   at org.apache.wicket.util.visit.Visits.visitChildren(Visits.java:192)
   at org.apache.wicket.MarkupContainer.visitChildren(MarkupContainer.java:983)
   at org.apache.wicket.MarkupContainer.internalInitialize(MarkupContainer.java:1071)
   at org.apache.wicket.Page.internalPrepareForRender(Page.java:240)
   at org.apache.wicket.Component.render(Component.java:2325)
   at org.apache.wicket.Page.renderPage(Page.java:1018)
   at org.apache.wicket.request.handler.render.WebPageRenderer.renderPage(WebPageRenderer.java:124)
   at org.apache.wicket.request.handler.render.WebPageRenderer.respond(WebPageRenderer.java:195)
   at org.apache.wicket.core.request.handler.RenderPageRequestHandler.respond(RenderPageRequestHandler.java:175)
   at org.apache.wicket.request.cycle.RequestCycle$HandlerExecutor.respond(RequestCycle.java:895)
   at org.apache.wicket.request.RequestHandlerStack.execute(RequestHandlerStack.java:64)
   at org.apache.wicket.request.cycle.RequestCycle.execute(RequestCycle.java:265)
   at org.apache.wicket.request.cycle.RequestCycle.processRequest(RequestCycle.java:222)
   at org.apache.wicket.request.cycle.RequestCycle.processRequestAndDetach(RequestCycle.java:293)
   at org.apache.wicket.protocol.http.WicketFilter.processRequestCycle(WicketFilter.java:261)
   at org.apache.wicket.protocol.http.WicketFilter.processRequest(WicketFilter.java:203)
   at org.apache.wicket.protocol.http.WicketFilter.doFilter(WicketFilter.java:284)
   at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1676)
   at org.apache.isis.core.webapp.diagnostics.IsisLogOnExceptionFilter.doFilter(IsisLogOnExceptionFilter.java:52)
   at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1676)
   at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain(AbstractShiroFilter.java:449)
   at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call(AbstractShiroFilter.java:365)
   at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90)
   at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83)
   at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:383)
   at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal(AbstractShiroFilter.java:362)
   at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:125)
   at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1668)
   at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:581)
   at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
   at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
   at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:226)
   at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1180)
   at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:511)
   at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
   at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1112)
   at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
   at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:134)
   at org.eclipse.jetty.server.Server.handle(Server.java:524)
   at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:319)
   at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:253)
   at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:273)
   at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95)
   at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:93)
   at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.executeProduceConsume(ExecuteProduceConsume.java:303)
   at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceConsume(ExecuteProduceConsume.java:148)
   at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:136)
   at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:671)
   at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:589)
   at java.lang.Thread.run(Thread.java:745)