### PR TITLE
Isis 1976 rethink object adapters

### DIFF
--- a/core/commons/src/main/java/org/apache/isis/commons/internal/exceptions/_Exceptions.java
+++ b/core/commons/src/main/java/org/apache/isis/commons/internal/exceptions/_Exceptions.java
@@ -81,6 +81,26 @@ public final class _Exceptions {
     public static IllegalStateException notImplemented() {
         return new IllegalStateException("internal error: code was reached, that is not implemented yet");
     }
+    
+    /**
+    * Used to hide from the compiler the fact, that this call always throws.
+    *
+    * <pre>{
+    *    throw unexpectedCodeReach();
+    *    return 0; // won't compile: unreachable code
+    *}</pre>
+    *
+    * hence ...
+    *
+    * <pre>{
+    *    throwUnexpectedCodeReach();
+    *    return 0;
+    *}</pre>
+    *
+    */
+    public static void throwUnexpectedCodeReach() {
+        throw unexpectedCodeReach();
+    }
 
     /**
      * Used to hide from the compiler the fact, that this call always throws.

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapter.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapter.java
@@ -487,18 +487,18 @@ public interface ObjectAdapter extends Instance {
      */
     ObjectAdapter withPojo(Object newPojo);
 
-    @Deprecated
-    public static interface Friend {
-      /**
-      * Sometimes it is necessary to manage the replacement of the underlying
-      * domain object (by another component such as an object store). This method
-      * allows the adapter to be kept while the domain object is replaced.
-      */
-     void replacePojo(Object pojo);
-    }
-    
-    @Deprecated
-    Friend friend();
+//    @Deprecated
+//    public static interface Friend {
+//      /**
+//      * Sometimes it is necessary to manage the replacement of the underlying
+//      * domain object (by another component such as an object store). This method
+//      * allows the adapter to be kept while the domain object is replaced.
+//      */
+//     void replacePojo(Object pojo);
+//    }
+//    
+//    @Deprecated
+//    Friend friend();
 
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapter.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapter.java
@@ -469,19 +469,6 @@ public interface ObjectAdapter extends Instance {
             return Util::unwrap;
         }
 
-        public static Function<Object, ObjectAdapter> adapterForUsing(final ObjectAdapterProvider adapterProvider) {
-            return adapterProvider::adapterFor;
-        }
-
-        @Deprecated
-        public static com.google.common.base.Function<Object, ObjectAdapter> adapter_ForUsing(final ObjectAdapterProvider adapterProvider) {
-            return new com.google.common.base.Function<Object, ObjectAdapter>() {
-                @Override
-                public ObjectAdapter apply(final Object pojo) {
-                    return adapterProvider.adapterFor(pojo);
-                }
-            };
-        }
     }
 
     /**

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapter.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapter.java
@@ -108,13 +108,6 @@ public interface ObjectAdapter extends Instance {
     Instance getInstance(Specification specification);
 
     /**
-     * Sometimes it is necessary to manage the replacement of the underlying
-     * domain object (by another component such as an object store). This method
-     * allows the adapter to be kept while the domain object is replaced.
-     */
-    void replacePojo(Object pojo);
-
-    /**
      * For (stand-alone) collections, returns the element type.
      *
      * <p>
@@ -168,12 +161,6 @@ public interface ObjectAdapter extends Instance {
      * are not mapped and have a <tt>null</tt> oid.
      */
     Oid getOid();
-
-//    /**
-//     * Since {@link Oid}s are now immutable, it is the reference from the
-//     * {@link ObjectAdapter} to its {@link Oid} that must now be updated.
-//     */
-//    void replaceOid(Oid persistedOid);
 
     /**
      * Returns either itself (if this is a root) or the parented collections, the
@@ -499,11 +486,32 @@ public interface ObjectAdapter extends Instance {
 
     /**
      * 
-     * @param persistedRootOid
+     * @param newOid
      * @return a copy of this adapter, having a new RootOid 
      * @since 2.0.0-M2
      */
     ObjectAdapter withOid(RootOid newOid);
+
+    /**
+     * 
+     * @param newPojo
+     * @return a copy of this adapter, having a new Pojo 
+     * @since 2.0.0-M2
+     */
+    ObjectAdapter withPojo(Object newPojo);
+
+    @Deprecated
+    public static interface Friend {
+      /**
+      * Sometimes it is necessary to manage the replacement of the underlying
+      * domain object (by another component such as an object store). This method
+      * allows the adapter to be kept while the domain object is replaced.
+      */
+     void replacePojo(Object pojo);
+    }
+    
+    @Deprecated
+    Friend friend();
 
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapterProvider.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapterProvider.java
@@ -37,11 +37,11 @@ public interface ObjectAdapterProvider {
     
     // -- INTERFACE
 
-    /**
-     * @param pojo
-     * @return oid for the given domain object 
-     */
-    Oid oidFor(Object domainObject);
+//    /**
+//     * @param pojo
+//     * @return oid for the given domain object 
+//     */
+//    Oid oidFor(Object domainObject);
     
     /**
      * @return standalone (value) or root adapter
@@ -86,10 +86,10 @@ public interface ObjectAdapterProvider {
         @Programmatic
         ObjectAdapterProvider getObjectAdapterProvider();
         
-        @Programmatic
-        default Oid oidFor(Object domainObject) {
-            return getObjectAdapterProvider().oidFor(domainObject);
-        }
+//        @Programmatic
+//        default Oid oidFor(Object domainObject) {
+//            return getObjectAdapterProvider().oidFor(domainObject);
+//        }
         
         @Programmatic
         default ObjectAdapter adapterFor(Object domainObject) {

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapterProvider.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapterProvider.java
@@ -25,6 +25,7 @@ import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.RootOid;
 import org.apache.isis.core.metamodel.spec.ObjectSpecId;
+import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
 
 /**
@@ -56,12 +57,19 @@ public interface ObjectAdapterProvider {
             OneToManyAssociation collection);
 
     /**
-     * @param viewModelPojo
-     * @return an ObjectAdapter 'bypassing mapping', that holds the ObjectSpecification
-     * FIXME[ISIS-1976] Note: whether or not 'bypassing mapping' should not be exposed by the API.
-     * So this further needs refactoring. 
+     * Returns an ObjectAdapter that holds the ObjectSpecification used for 
+     * interrogating the domain object's metadata. 
+     * <p>
+     * Does _not_ perform dependency injection on the domain object. Also bypasses 
+     * caching (if any), that is each call to this method creates a new unique instance.
+     * </p>
+     * 
+     * @param viewModelPojo domain object
+     * @return  
      */
-    ObjectAdapter specificationForViewModel(final Object viewModelPojo);
+    ObjectAdapter disposableAdapterForViewModel(Object viewModelPojo);
+    
+    ObjectSpecification specificationForViewModel(Object viewModelPojo);
 
     ObjectAdapter adapterForViewModel(
             final Object viewModelPojo, 
@@ -97,7 +105,12 @@ public interface ObjectAdapterProvider {
         }
 
         @Programmatic
-        default ObjectAdapter specificationForViewModel(final Object viewModelPojo) {
+        default ObjectAdapter disposableAdapterForViewModel(final Object viewModelPojo) {
+            return getObjectAdapterProvider().disposableAdapterForViewModel(viewModelPojo);
+        }
+        
+        @Programmatic
+        default ObjectSpecification specificationForViewModel(Object viewModelPojo) {
             return getObjectAdapterProvider().specificationForViewModel(viewModelPojo);
         }
 
@@ -114,6 +127,9 @@ public interface ObjectAdapterProvider {
         }
         
     }
+
+
+   
 
 
     

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapterProvider.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/adapter/ObjectAdapterProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.apache.isis.applib.annotation.Programmatic;
+import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.RootOid;
 import org.apache.isis.core.metamodel.spec.ObjectSpecId;
 import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
@@ -36,6 +37,12 @@ public interface ObjectAdapterProvider {
     // -- INTERFACE
 
     /**
+     * @param pojo
+     * @return oid for the given domain object 
+     */
+    Oid oidFor(Object domainObject);
+    
+    /**
      * @return standalone (value) or root adapter
      */
     ObjectAdapter adapterFor(Object domainObject);
@@ -44,7 +51,7 @@ public interface ObjectAdapterProvider {
      * @return collection adapter.
      */
     ObjectAdapter adapterFor(
-            final Object pojo,
+            final Object domainObject,
             final ObjectAdapter parentAdapter,
             OneToManyAssociation collection);
 
@@ -70,6 +77,11 @@ public interface ObjectAdapterProvider {
         
         @Programmatic
         ObjectAdapterProvider getObjectAdapterProvider();
+        
+        @Programmatic
+        default Oid oidFor(Object domainObject) {
+            return getObjectAdapterProvider().oidFor(domainObject);
+        }
         
         @Programmatic
         default ObjectAdapter adapterFor(Object domainObject) {
@@ -102,6 +114,9 @@ public interface ObjectAdapterProvider {
         }
         
     }
+
+
+    
     
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/actions/action/invocation/CommandUtil.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/actions/action/invocation/CommandUtil.java
@@ -103,7 +103,7 @@ public class CommandUtil {
 
     public static ObjectAdapter[] adaptersFor(final Object[] args, final ObjectAdapterProvider adapterProvider) {
         return _NullSafe.stream(args)
-                .map(ObjectAdapter.Functions.adapterForUsing(adapterProvider))
+                .map(adapterProvider::adapterFor)
                 .collect(_Arrays.toArray(ObjectAdapter.class, _NullSafe.size(args)));
     }
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaArrayFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaArrayFacet.java
@@ -43,13 +43,14 @@ public class JavaArrayFacet extends CollectionFacetAbstract {
      * Expected to be called with a {@link ObjectAdapter} wrapping an array.
      */
     @Override
-    public void init(final ObjectAdapter arrayAdapter, final ObjectAdapter[] initData) {
+    public ObjectAdapter init(final ObjectAdapter arrayAdapter, final ObjectAdapter[] initData) {
         final int length = initData.length;
         final Object[] array = new Object[length];
         for (int i = 0; i < length; i++) {
             array[i] = initData[i].getObject();
         }
         arrayAdapter.friend().replacePojo(array);
+        return arrayAdapter;
     }
 
     /**

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaArrayFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaArrayFacet.java
@@ -49,8 +49,7 @@ public class JavaArrayFacet extends CollectionFacetAbstract {
         for (int i = 0; i < length; i++) {
             array[i] = initData[i].getObject();
         }
-        arrayAdapter.friend().replacePojo(array);
-        return arrayAdapter;
+        return arrayAdapter.withPojo(array);  
     }
 
     /**

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaArrayFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaArrayFacet.java
@@ -49,7 +49,7 @@ public class JavaArrayFacet extends CollectionFacetAbstract {
         for (int i = 0; i < length; i++) {
             array[i] = initData[i].getObject();
         }
-        arrayAdapter.replacePojo(array);
+        arrayAdapter.friend().replacePojo(array);
     }
 
     /**

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaCollectionFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaCollectionFacet.java
@@ -21,7 +21,6 @@ package org.apache.isis.core.metamodel.facets.collections.javautilcollection;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.function.Function;
 
 import com.google.common.collect.Collections2;
 
@@ -77,14 +76,6 @@ public class JavaCollectionFacet extends CollectionFacetAbstract {
     @SuppressWarnings("unchecked")
     private Collection<? super Object> pojoCollection(final ObjectAdapter collectionAdapter) {
         return (Collection<? super Object>) collectionAdapter.getObject();
-    }
-
-    // //////////////////////////////////////////////////////////////////////
-    // Dependencies (from constructor)
-    // //////////////////////////////////////////////////////////////////////
-
-    private ObjectAdapterProvider getObjectAdapterProvider() {
-        return adapterProvider;
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaCollectionFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/javautilcollection/JavaCollectionFacet.java
@@ -21,10 +21,10 @@ package org.apache.isis.core.metamodel.facets.collections.javautilcollection;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.Function;
 
 import com.google.common.collect.Collections2;
 
-import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapterProvider;
 import org.apache.isis.core.metamodel.facetapi.FacetHolder;
@@ -40,13 +40,14 @@ public class JavaCollectionFacet extends CollectionFacetAbstract {
     }
     
     @Override
-    public void init(final ObjectAdapter collection, final ObjectAdapter[] initData) {
+    public ObjectAdapter init(final ObjectAdapter collection, final ObjectAdapter[] initData) {
         final Collection<? super Object> pojoCollection = pojoCollection(collection);
         pojoCollection.clear();
         for (final ObjectAdapter element : initData) {
             final Object pojo = element.getObject();
             pojoCollection.add(pojo);
         }
+        return collection;
     }
     
     @Override
@@ -55,8 +56,8 @@ public class JavaCollectionFacet extends CollectionFacetAbstract {
         
         //TODO [ahuber] java doc states, this is a live view, don't know if this is needed, 
         // or if a copy is sufficient
-        return Collections2.transform(pojoCollection,
-                ObjectAdapter.Functions.adapter_ForUsing(getObjectAdapterProvider()));
+        return Collections2.transform(pojoCollection, adapterProvider::adapterFor);
+                
     }
 
     @Override

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/modify/CollectionFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/collections/modify/CollectionFacet.java
@@ -56,8 +56,9 @@ public interface CollectionFacet extends Facet {
 
     /**
      * Set the contents of this collection.
+     * @return a possibly new instance
      */
-    void init(ObjectAdapter collectionAdapter, ObjectAdapter[] elements);
+    ObjectAdapter init(ObjectAdapter collectionAdapter, ObjectAdapter[] elements);
 
     /**
      * Convenience method that returns the {@link TypeOfFacet} on this facet's

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/recreatable/RecreatableObjectFacetDeclarativeInitializingAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/recreatable/RecreatableObjectFacetDeclarativeInitializingAbstract.java
@@ -21,6 +21,7 @@ package org.apache.isis.core.metamodel.facets.object.recreatable;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.isis.applib.services.urlencoding.UrlEncodingService;
 import org.apache.isis.commons.internal.memento._Mementos;
@@ -97,7 +98,7 @@ extends RecreatableObjectFacetAbstract {
 
         final _Mementos.Memento memento = _Mementos.create(codec, serializer);
 
-        final ObjectAdapter ownerAdapter = adapterProvider.specificationForViewModel(viewModelPojo);
+        final ObjectAdapter ownerAdapter = adapterProvider.disposableAdapterForViewModel(viewModelPojo);
         final ObjectSpecification spec = ownerAdapter.getSpecification();
         
         final List<OneToOneAssociation> properties = spec.getProperties(Contributed.EXCLUDED);

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/value/booleans/BooleanPrimitiveValueSemanticsProvider.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/value/booleans/BooleanPrimitiveValueSemanticsProvider.java
@@ -56,21 +56,21 @@ public class BooleanPrimitiveValueSemanticsProvider extends BooleanValueSemantic
     // BooleanValueFacet impl
     // //////////////////////////////////////////////////////////////////
 
-    @Override
-    public void reset(final ObjectAdapter object) {
-        object.replacePojo(Boolean.FALSE);
-    }
-
-    @Override
-    public void set(final ObjectAdapter object) {
-        object.replacePojo(Boolean.TRUE);
-    }
-
-    @Override
-    public void toggle(final ObjectAdapter object) {
-        final boolean current = ((Boolean) object.getObject()).booleanValue();
-        final boolean toggled = !current;
-        object.replacePojo(Boolean.valueOf(toggled));
-    }
+//    @Override
+//    public void reset(final ObjectAdapter object) {
+//        object.replacePojo(Boolean.FALSE);
+//    }
+//
+//    @Override
+//    public void set(final ObjectAdapter object) {
+//        object.replacePojo(Boolean.TRUE);
+//    }
+//
+//    @Override
+//    public void toggle(final ObjectAdapter object) {
+//        final boolean current = ((Boolean) object.getObject()).booleanValue();
+//        final boolean toggled = !current;
+//        object.replacePojo(Boolean.valueOf(toggled));
+//    }
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/value/booleans/BooleanValueFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/value/booleans/BooleanValueFacet.java
@@ -26,9 +26,9 @@ public interface BooleanValueFacet extends Facet {
 
     boolean isSet(ObjectAdapter object);
 
-    void set(ObjectAdapter object);
-
-    void reset(ObjectAdapter object);
-
-    void toggle(ObjectAdapter object);
+//    void set(ObjectAdapter object);
+//
+//    void reset(ObjectAdapter object);
+//
+//    void toggle(ObjectAdapter object);
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/value/booleans/BooleanWrapperValueSemanticsProvider.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/value/booleans/BooleanWrapperValueSemanticsProvider.java
@@ -46,26 +46,26 @@ public class BooleanWrapperValueSemanticsProvider extends BooleanValueSemanticsP
     // BooleanValueFacet impl
     // //////////////////////////////////////////////////////////////////
 
-    @Override
-    public void reset(final ObjectAdapter adapter) {
-        adapter.replacePojo(Boolean.FALSE);
-    }
-
-    @Override
-    public void set(final ObjectAdapter adapter) {
-        adapter.replacePojo(Boolean.TRUE);
-    }
-
-    @Override
-    public void toggle(final ObjectAdapter adapter) {
-        final Object currentObj = adapter.getObject();
-        if (currentObj == null) {
-            set(adapter);
-            return;
-        }
-        final boolean current = ((Boolean) currentObj).booleanValue();
-        final boolean toggled = !current;
-        adapter.replacePojo(Boolean.valueOf(toggled));
-    }
+//    @Override
+//    public void reset(final ObjectAdapter adapter) {
+//        adapter.replacePojo(Boolean.FALSE);
+//    }
+//
+//    @Override
+//    public void set(final ObjectAdapter adapter) {
+//        adapter.replacePojo(Boolean.TRUE);
+//    }
+//
+//    @Override
+//    public void toggle(final ObjectAdapter adapter) {
+//        final Object currentObj = adapter.getObject();
+//        if (currentObj == null) {
+//            set(adapter);
+//            return;
+//        }
+//        final boolean current = ((Boolean) currentObj).booleanValue();
+//        final boolean toggled = !current;
+//        adapter.replacePojo(Boolean.valueOf(toggled));
+//    }
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/ServicesInjector.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/ServicesInjector.java
@@ -146,15 +146,6 @@ public class ServicesInjector implements ApplicationScopedComponent {
         serviceByConcreteType.clear();
         autowire();
     }
-    
-    private Map<Class<?>, Object> initServiceByConcreteType(){
-        final Map<Class<?>, Object> map = _Maps.newHashMap();
-        for (Object service : services) {
-            final Class<?> concreteType = service.getClass();
-            map.put(concreteType, service);
-        }
-        return map;
-    }
 
     public boolean isRegisteredService(final Class<?> cls) {
         return serviceByConcreteType.get().containsKey(cls);
@@ -457,6 +448,17 @@ public class ServicesInjector implements ApplicationScopedComponent {
         .forEach(filteredServicesAndContainer::add);
     }
 
+    // -- LAZY INIT
+    
+    private Map<Class<?>, Object> initServiceByConcreteType(){
+        final Map<Class<?>, Object> map = _Maps.newHashMap();
+        for (Object service : services) {
+            final Class<?> concreteType = service.getClass();
+            map.put(concreteType, service);
+        }
+        return map;
+    }
+    
     // -- REFLECTIVE PREDICATES
 
     private static final Predicate<Object> isOfType(final Class<?> cls) {

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/ServicesInjector.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/ServicesInjector.java
@@ -23,11 +23,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.services.exceprecog.ExceptionRecognizer;
+import org.apache.isis.commons.internal.base._Lazy;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.collections._Collections;
 import org.apache.isis.commons.internal.collections._Lists;
@@ -48,8 +53,6 @@ import org.apache.isis.core.metamodel.specloader.InjectorMethodEvaluatorDefault;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.runtime.authentication.AuthenticationManager;
 import org.apache.isis.core.runtime.authorization.AuthorizationManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The repository of services, also able to inject into any object.
@@ -78,7 +81,7 @@ public class ServicesInjector implements ApplicationScopedComponent {
      * services that are assignable to the type.  It's possible that this is an empty list.
      */
     private final Map<Class<?>, List<Object>> servicesAssignableToType = _Maps.newHashMap();
-    private final Map<Class<?>, Object> serviceByConcreteType = _Maps.newHashMap();
+    private final _Lazy<Map<Class<?>, Object>> serviceByConcreteType = _Lazy.of(this::initServiceByConcreteType);
     private final Map<Class<?>, Method[]> methodsByClassCache = _Maps.newHashMap();
     private final Map<Class<?>, Field[]> fieldsByClassCache = _Maps.newHashMap();
 
@@ -143,18 +146,30 @@ public class ServicesInjector implements ApplicationScopedComponent {
         serviceByConcreteType.clear();
         autowire();
     }
-
-    public boolean isRegisteredService(final Class<?> cls) {
-        // lazily construct cache
-        if(serviceByConcreteType.isEmpty()) {
-            for (Object service : services) {
-                final Class<?> concreteType = service.getClass();
-                serviceByConcreteType.put(concreteType, service);
-            }
+    
+    private Map<Class<?>, Object> initServiceByConcreteType(){
+        final Map<Class<?>, Object> map = _Maps.newHashMap();
+        for (Object service : services) {
+            final Class<?> concreteType = service.getClass();
+            map.put(concreteType, service);
         }
-        return serviceByConcreteType.containsKey(cls);
+        return map;
     }
 
+    public boolean isRegisteredService(final Class<?> cls) {
+        return serviceByConcreteType.get().containsKey(cls);
+    }
+
+    public boolean isRegisteredServiceInstance(final Object pojo) {
+        if(pojo==null) {
+            return false;
+        }
+        final Class<?> key = pojo.getClass();
+        final Object serviceInstance = serviceByConcreteType.get().get(key);
+        return Objects.equals(pojo, serviceInstance);
+    }
+    
+    
     public <T> void addFallbackIfRequired(final Class<T> serviceClass, final T serviceInstance) {
         if(!contains(services, serviceClass)) {
             // add to beginning;
@@ -206,7 +221,7 @@ public class ServicesInjector implements ApplicationScopedComponent {
     public List<Object> getRegisteredServices() {
         return Collections.unmodifiableList(services);
     }
-
+    
     // -- INJECT SERVICES INTO
 
     /**

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/ServicesInjector.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/ServicesInjector.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -211,6 +212,13 @@ public class ServicesInjector implements ApplicationScopedComponent {
      */
     public List<Object> getRegisteredServices() {
         return Collections.unmodifiableList(services);
+    }
+    
+    /**
+     * @return Stream of all currently registered service instances.
+     */
+    public Stream<Object> streamRegisteredServiceInstances() {
+        return services.stream();
     }
     
     // -- INJECT SERVICES INTO

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/specloader/specimpl/OneToOneAssociationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/specloader/specimpl/OneToOneAssociationDefault.java
@@ -272,7 +272,7 @@ public class OneToOneAssociationDefault extends ObjectAssociationAbstract implem
                 getSpecificationLoader(),
                 interactionInitiatedBy);
         List<ObjectAdapter> adapters = _NullSafe.stream(pojoOptions)
-                .map( ObjectAdapter.Functions.adapterForUsing( getObjectAdapterProvider() ) )
+                .map(  getObjectAdapterProvider()::adapterFor )
                 .collect(Collectors.toList());
         return adapters.toArray(new ObjectAdapter[]{});
     }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/specloader/specimpl/standalonelist/CollectionFacetOnStandaloneList.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/specloader/specimpl/standalonelist/CollectionFacetOnStandaloneList.java
@@ -64,7 +64,8 @@ public class CollectionFacetOnStandaloneList extends CollectionFacetAbstract {
      * Does nothing.
      */
     @Override
-    public void init(final ObjectAdapter collection, final ObjectAdapter[] initData) {
+    public ObjectAdapter init(final ObjectAdapter collection, final ObjectAdapter[] initData) {
+        return collection;
     }
 
 }

--- a/core/plugins/jdo-datanucleus-4/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession4.java
+++ b/core/plugins/jdo-datanucleus-4/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession4.java
@@ -1175,7 +1175,7 @@ implements IsisLifecycleListener.PersistenceSessionLifecycleManagement {
             }
             
         } else {
-            originalOid = createPersistentOrViewModelOid(pojo);
+            originalOid = objectAdapterContext.createPersistentOrViewModelOid(pojo);
 
             ObjectAdapter adapter;
             
@@ -1200,69 +1200,12 @@ implements IsisLifecycleListener.PersistenceSessionLifecycleManagement {
         return objectAdapterContext.lookupAdapterFor(pojo);
     }
 
-    // -- create...Oid (main API)
-    /**
-     * Create a new {@link Oid#isTransient() transient} {@link Oid} for the
-     * supplied pojo, uniquely distinguishable from any other {@link Oid}.
-     */
     @Override
-    public final RootOid createTransientOrViewModelOid(final Object pojo) {
-        return newIdentifier(pojo, Type.TRANSIENT);
-    }
-
-    /**
-     * Return an equivalent {@link RootOid}, but being persistent.
-     *
-     * <p>
-     * It is the responsibility of the implementation to determine the new unique identifier.
-     * For example, the generator may simply assign a new value from a sequence, or a GUID;
-     * or, the generator may use the oid to look up the object and inspect the object in order
-     * to obtain an application-defined value.
-     *
-     * @param pojo - being persisted
-     */
-    @Override
-    public final RootOid createPersistentOrViewModelOid(Object pojo) {
-        return newIdentifier(pojo, Type.PERSISTENT);
-    }
-
-    private RootOid newIdentifier(final Object pojo, final Type type) {
-        final ObjectSpecification spec = objectSpecFor(pojo);
-        if(spec.isService()) {
-            return newRootId(spec, SERVICE_IDENTIFIER, type);
-        }
-
-        final ViewModelFacet recreatableObjectFacet = spec.getFacet(ViewModelFacet.class);
-        final String identifier =
-                recreatableObjectFacet != null
-                ? recreatableObjectFacet.memento(pojo)
-                        : newIdentifierFor(pojo, type);
-
-                return newRootId(spec, identifier, type);
-    }
-
-    private String newIdentifierFor(final Object pojo, final Type type) {
-        return type == Type.TRANSIENT
+    public String identifierFor(final Object pojo, final Oid.State type) {
+        return type == Oid.State.TRANSIENT
                 ? UUID.randomUUID().toString()
                         : JdoObjectIdSerializer.toOidIdentifier(getPersistenceManager().getObjectId(pojo));
     }
-
-    private RootOid newRootId(final ObjectSpecification spec, final String identifier, final Type type) {
-        final Oid.State state =
-                spec.containsDoOpFacet(ViewModelFacet.class)
-                ? Oid.State.VIEWMODEL
-                        : type == Type.TRANSIENT
-                        ? Oid.State.TRANSIENT
-                                : Oid.State.PERSISTENT;
-        final ObjectSpecId objectSpecId = spec.getSpecId();
-        return new RootOid(objectSpecId, identifier, state);
-    }
-
-    private ObjectSpecification objectSpecFor(final Object pojo) {
-        final Class<?> pojoClass = pojo.getClass();
-        return getSpecificationLoader().loadSpecification(pojoClass);
-    }
-
 
 
     /**
@@ -1313,7 +1256,7 @@ implements IsisLifecycleListener.PersistenceSessionLifecycleManagement {
 
         if (rootOid.isTransient()) {
             // persisting
-            final RootOid persistentOid = createPersistentOrViewModelOid(pojo);
+            final RootOid persistentOid = objectAdapterContext.createPersistentOrViewModelOid(pojo);
 
             objectAdapterContext.remapAsPersistent(adapter, persistentOid, this);
 

--- a/core/plugins/jdo-datanucleus-5/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession5.java
+++ b/core/plugins/jdo-datanucleus-5/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession5.java
@@ -1132,15 +1132,17 @@ implements IsisLifecycleListener.PersistenceSessionLifecycleManagement {
         final Version datastoreVersion = getVersionIfAny(pc);
 
         final RootOid originalOid;
-        ObjectAdapter adapter = objectAdapterContext.lookupAdapterFor(pojo);
-        if (adapter != null) {
+        final ObjectAdapter originalAdapter = objectAdapterContext.lookupAdapterFor(pojo);
+        final ObjectAdapter newAdapter;
+        
+        if (originalAdapter != null) {
             ensureRootObject(pojo); //[ahuber] while already mapped has no side-effect
-            originalOid = (RootOid) adapter.getOid();
+            originalOid = (RootOid) originalAdapter.getOid();
 
-            final Version originalVersion = adapter.getVersion();
+            final Version originalVersion = originalAdapter.getVersion();
 
             // sync the pojo held by the adapter with that just loaded
-            objectAdapterContext.remapRecreatedPojo(adapter, pojo);
+            newAdapter = objectAdapterContext.remapRecreatedPojo(originalAdapter, pojo);
 
             // since there was already an adapter, do concurrency check
             // (but don't set abort cause if checking is suppressed through thread-local)
@@ -1163,24 +1165,30 @@ implements IsisLifecycleListener.PersistenceSessionLifecycleManagement {
                     LOG.info("concurrency conflict detected but suppressed, on {} ({})", thisOid, otherVersion);
                 }
             }
+            
         } else {
             originalOid = createPersistentOrViewModelOid(pojo);
 
+            ObjectAdapter adapter;
+            
             // it appears to be possible that there is already an adapter for this Oid,
             // ie from ObjectStore#resolveImmediately()
             adapter = objectAdapterContext.lookupAdapterFor(originalOid);
             if (adapter != null) {
-                objectAdapterContext.remapRecreatedPojo(adapter, pojo);
+                adapter = objectAdapterContext.remapRecreatedPojo(adapter, pojo);
             } else {
                 adapter = objectAdapterContext.addRecreatedPojoToCache(originalOid, pojo);
 
                 CallbackFacet.Util.callCallback(adapter, LoadedCallbackFacet.class);
                 postLifecycleEventIfRequired(adapter, LoadedLifecycleEventFacet.class);
             }
+        
+            newAdapter = adapter;
+            
         }
-
-        adapter.setVersion(datastoreVersion);
-
+        
+        newAdapter.setVersion(datastoreVersion);
+        
         return objectAdapterContext.lookupAdapterFor(pojo);
     }
 

--- a/core/plugins/jdo-datanucleus-5/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession5_Decouple.java
+++ b/core/plugins/jdo-datanucleus-5/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession5_Decouple.java
@@ -82,7 +82,13 @@ class PersistenceSession5_Decouple  {
     public ObjectAdapter adapterFor(
             final RootOid rootOid,
             final ConcurrencyChecking concurrencyChecking) {
-
+        
+        //FIXME[ISIS-1976] guard against service lookup
+        final ObjectAdapter serviceAdapter = objectAdapterContext.lookupServiceAdapterFor(rootOid);
+        if (serviceAdapter != null) {
+            return serviceAdapter;
+        }
+        
         // attempt to locate adapter for the Oid
         ObjectAdapter adapter = objectAdapterContext.lookupAdapterFor(rootOid);
         if (adapter == null) {
@@ -98,6 +104,14 @@ class PersistenceSession5_Decouple  {
             } catch(ObjectNotFoundException ex) {
                 throw ex; // just rethrow
             } catch(RuntimeException ex) {
+                
+                System.err.println("------------------------------------------");
+                System.err.println("rootOid: "+rootOid.enString());
+                
+                ex.printStackTrace();
+                System.err.println("------------------------------------------");
+
+                
                 throw new PojoRecreationException(rootOid, ex);
             }
         }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/persistence/adapter/PojoAdapter.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/persistence/adapter/PojoAdapter.java
@@ -108,15 +108,15 @@ public class PojoAdapter extends InstanceAbstract implements ObjectAdapter {
         return pojo;
     }
 
-    /**
-     * Sometimes it is necessary to manage the replacement of the underlying
-     * domain object (by another component such as an object store). This method
-     * allows the adapter to be kept while the domain object is replaced.
-     */
-    @Override
-    public void replacePojo(final Object pojo) {
-        this.pojo = pojo;
-    }
+//    /**
+//     * Sometimes it is necessary to manage the replacement of the underlying
+//     * domain object (by another component such as an object store). This method
+//     * allows the adapter to be kept while the domain object is replaced.
+//     */
+//    @Override
+//    public void replacePojo(final Object pojo) {
+//        this.pojo = pojo;
+//    }
 
     // -- getOid
     @Override
@@ -400,6 +400,22 @@ public class PojoAdapter extends InstanceAbstract implements ObjectAdapter {
     @Override
     public ObjectAdapter withOid(RootOid newOid) {
         return new PojoAdapter(pojo, newOid, authenticationSession, specificationLoader, persistenceSession);
+    }
+    
+    @Override
+    public ObjectAdapter withPojo(Object newPojo) {
+        return new PojoAdapter(newPojo, oid, authenticationSession, specificationLoader, persistenceSession);
+    }
+
+
+    @Override
+    public Friend friend() {
+        return new Friend() {
+            @Override
+            public void replacePojo(Object pojo) {
+                PojoAdapter.this.pojo = pojo;
+            }
+        };
     }
 
 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/persistence/adapter/PojoAdapter.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/persistence/adapter/PojoAdapter.java
@@ -19,6 +19,8 @@
 
 package org.apache.isis.core.runtime.persistence.adapter;
 
+import java.util.function.Function;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +57,7 @@ public class PojoAdapter extends InstanceAbstract implements ObjectAdapter {
     /**
      * can be {@link #replacePojo(Object) replace}d.
      */
-    private Object pojo;
+    private final Object pojo;
     /**
      * can be {@link #replaceOid(Oid) replace}d.
      */
@@ -83,8 +85,7 @@ public class PojoAdapter extends InstanceAbstract implements ObjectAdapter {
         this.pojo = pojo;
         this.oid = oid;
     }
-
-
+    
     // -- getSpecification
 
     /**

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/persistence/adapter/PojoAdapter.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/persistence/adapter/PojoAdapter.java
@@ -407,15 +407,4 @@ public class PojoAdapter extends InstanceAbstract implements ObjectAdapter {
         return new PojoAdapter(newPojo, oid, authenticationSession, specificationLoader, persistenceSession);
     }
 
-
-    @Override
-    public Friend friend() {
-        return new Friend() {
-            @Override
-            public void replacePojo(Object pojo) {
-                PojoAdapter.this.pojo = pojo;
-            }
-        };
-    }
-
 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/PersistenceSession.java
@@ -29,6 +29,7 @@ import org.apache.isis.core.commons.config.IsisConfiguration;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapterProvider;
 import org.apache.isis.core.metamodel.adapter.concurrency.ConcurrencyChecking;
+import org.apache.isis.core.metamodel.adapter.oid.Oid.State;
 import org.apache.isis.core.metamodel.adapter.oid.ParentedCollectionOid;
 import org.apache.isis.core.metamodel.adapter.oid.RootOid;
 import org.apache.isis.core.metamodel.services.ServicesInjector;
@@ -89,9 +90,6 @@ public interface PersistenceSession extends ObjectAdapterProvider.Delegating, Tr
 
     void close();
 
-    RootOid createTransientOrViewModelOid(Object pojo);
-    RootOid createPersistentOrViewModelOid(Object pojo);
-
     ObjectAdapter createTransientInstance(ObjectSpecification spec);
 
     ObjectAdapter createViewModelInstance(ObjectSpecification spec, String memento);
@@ -108,6 +106,14 @@ public interface PersistenceSession extends ObjectAdapterProvider.Delegating, Tr
     IsisConfiguration getConfiguration();
 
     PersistenceManager getPersistenceManager();
+    
+    /**
+     * @param pojo
+     * @param type
+     * @return String representing an object's id.
+     * @since 2.0.0-M2
+     */
+    String identifierFor(Object pojo, State type);
 
     /**
      * Convenient equivalent to {@code getPersistenceManager()}.
@@ -167,6 +173,8 @@ public interface PersistenceSession extends ObjectAdapterProvider.Delegating, Tr
     boolean isTransient(Object pojo);
     boolean isRepresentingPersistent(Object pojo);
     boolean isDestroyed(Object pojo);
+
+
 
 
 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -245,7 +245,7 @@ public class ObjectAdapterContext {
     // -- SERVICE LOOKUP
     
     public ObjectAdapter lookupServiceAdapterFor(RootOid rootOid) {
-        return serviceLookupMixin.serviceAdapterFor(rootOid);
+        return serviceLookupMixin.lookupServiceAdapterFor(rootOid);
     }
     
     // -- FACTORIES

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -41,6 +41,7 @@ import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.runtime.memento.Data;
+import org.apache.isis.core.runtime.persistence.adapter.PojoAdapter;
 import org.apache.isis.core.runtime.system.persistence.PersistenceSession;
 
 /**
@@ -468,14 +469,24 @@ public class ObjectAdapterContext {
      * @deprecated https://issues.apache.org/jira/browse/ISIS-1976
      */
     @Deprecated
-    public void remapRecreatedPojo(ObjectAdapter adapter, final Object pojo) {
-        removeAdapterFromCache(adapter);
+    public ObjectAdapter remapRecreatedPojo(ObjectAdapter adapter, final Object pojo) {
+        final ObjectAdapter newAdapter = adapter.withPojo(pojo);
+        pojoAdapterMap.remove(adapter);
+        pojoAdapterMap.remove(newAdapter);
         
-        adapter.friend().replacePojo(pojo);
-        mapAndInjectServices(adapter);
+        oidAdapterMap.remove(adapter.getOid());
+        oidAdapterMap.remove(newAdapter.getOid());
+
+        //FIXME[ISIS-1976] can't remove yet, does have strange side-effects 
+        if(true){
+            adapter.friend().replacePojo(pojo);
+            mapAndInjectServices(adapter);
+            return adapter;
+        }
+        //---
         
-        //final ObjectAdapter newAdapter = adapter.withPojo(pojo);
-        //mapAndInjectServices(newAdapter);
+        mapAndInjectServices(newAdapter);
+        return newAdapter;
     }
 
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -135,7 +135,6 @@ public class ObjectAdapterContext {
     
     private final Cache cache = new Cache();
     
-    @SuppressWarnings("unused")
     private final PersistenceSession persistenceSession; 
     private final ServicesInjector servicesInjector;
     private final SpecificationLoader specificationLoader;
@@ -171,7 +170,7 @@ public class ObjectAdapterContext {
 
     // -- DEBUG
     
-    private void printContextInfo(String msg) {
+    void printContextInfo(String msg) {
         String id = Integer.toHexString(this.hashCode());
         String session = ""+persistenceSession;
         System.out.println("!!!!!!!!!!!!!!!!!!!!!!! "+String.format("%s id=%s session='%s'", 
@@ -359,21 +358,6 @@ public class ObjectAdapterContext {
     }
     
     // ------------------------------------------------------------------------------------------------
-    
-//    /**
-//     * Creates {@link ObjectAdapter adapters} for the service list, ensuring that these are mapped correctly,
-//     * and have the same OIDs as in any previous sessions.
-//     * 
-//     * @deprecated https://issues.apache.org/jira/browse/ISIS-1976
-//     */
-//    @Deprecated
-//    private void initServices() {
-//        final List<Object> registeredServices = servicesInjector.getRegisteredServices();
-//        for (final Object service : registeredServices) {
-//            final ObjectAdapter serviceAdapter = objectAdapterProviderMixin.adapterFor(service);
-//            Assert.assertFalse("expected to not be 'transient'", serviceAdapter.getOid().isTransient());
-//        }
-//    }
     
     public ObjectAdapter disposableAdapterForViewModel(Object viewModelPojo) {
             final ObjectSpecification objectSpecification = 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -427,8 +427,8 @@ public class ObjectAdapterContext {
 
             if (collectionPojoActuallyOnPojo != collectionPojoWrappedByAdapter) {
                 pojoAdapterMap.remove(collectionAdapter);
-                collectionAdapter.friend().replacePojo(collectionPojoActuallyOnPojo);
-                pojoAdapterMap.add(collectionPojoActuallyOnPojo, collectionAdapter);
+                final ObjectAdapter newCollectionAdapter = collectionAdapter.withPojo(collectionPojoActuallyOnPojo);
+                pojoAdapterMap.add(collectionPojoActuallyOnPojo, newCollectionAdapter);
             }
         }
         
@@ -470,8 +470,12 @@ public class ObjectAdapterContext {
     @Deprecated
     public void remapRecreatedPojo(ObjectAdapter adapter, final Object pojo) {
         removeAdapterFromCache(adapter);
+        
         adapter.friend().replacePojo(pojo);
         mapAndInjectServices(adapter);
+        
+        //final ObjectAdapter newAdapter = adapter.withPojo(pojo);
+        //mapAndInjectServices(newAdapter);
     }
 
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -171,10 +171,12 @@ public class ObjectAdapterContext {
     // -- DEBUG
     
     void printContextInfo(String msg) {
-        String id = Integer.toHexString(this.hashCode());
-        String session = ""+persistenceSession;
-        System.out.println("!!!!!!!!!!!!!!!!!!!!!!! "+String.format("%s id=%s session='%s'", 
-                msg, id, session));
+        if(LOG.isDebugEnabled()) {
+            String id = Integer.toHexString(this.hashCode());
+            String session = ""+persistenceSession;
+            System.out.println("!!!!!!!!!!!!!!!!!!!!!!! "+String.format("%s id=%s session='%s'", 
+                    msg, id, session));
+        }
     }
     
     // -- LIFE-CYCLING

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.functions._Predicates;
 import org.apache.isis.core.commons.authentication.AuthenticationSession;
+import org.apache.isis.core.commons.ensure.Assert;
 import org.apache.isis.core.commons.ensure.Ensure;
 import org.apache.isis.core.commons.ensure.IsisAssertException;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
@@ -348,18 +349,6 @@ public class ObjectAdapterContext {
                 //remapAsPersistent(serviceAdapter, null, persistenceSession);
             }
         }
-    }
-    
-    @Deprecated // don't expose caching
-    public void addAdapterHonoringSpecImmutability(Object pojo, ObjectAdapter adapter) {
-        // add all aggregated collections
-        final ObjectSpecification objSpec = adapter.getSpecification();
-        if (!adapter.isParentedCollection() || adapter.isParentedCollection() && !objSpec.isImmutable()) {
-            cache.putPojo(pojo, adapter);
-        }
-
-        // order is important - add to pojo map first, then identity map
-        oidAdapterMap().add(adapter.getOid(), adapter);
     }
     
     public ObjectAdapter disposableAdapterForViewModel(Object viewModelPojo) {

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -502,23 +502,11 @@ public class ObjectAdapterContext {
         return accessor.getProperty(ownerAdapter, InteractionInitiatedBy.FRAMEWORK);
     }
 
-    /**
-     * @deprecated https://issues.apache.org/jira/browse/ISIS-1976
-     */
     @Deprecated
     public ObjectAdapter remapRecreatedPojo(ObjectAdapter adapter, final Object pojo) {
         final ObjectAdapter newAdapter = adapter.withPojo(pojo);
         cache.removeAdapter(adapter);
         cache.removeAdapter(newAdapter);
-
-        //FIXME[ISIS-1976] can't remove yet, does have strange side-effects 
-        if(true){
-            adapter.friend().replacePojo(pojo);
-            mapAndInjectServices(adapter);
-            return adapter;
-        }
-        //---
-        
         mapAndInjectServices(newAdapter);
         return newAdapter;
     }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext.java
@@ -427,7 +427,7 @@ public class ObjectAdapterContext {
 
             if (collectionPojoActuallyOnPojo != collectionPojoWrappedByAdapter) {
                 pojoAdapterMap.remove(collectionAdapter);
-                collectionAdapter.replacePojo(collectionPojoActuallyOnPojo);
+                collectionAdapter.friend().replacePojo(collectionPojoActuallyOnPojo);
                 pojoAdapterMap.add(collectionPojoActuallyOnPojo, collectionAdapter);
             }
         }
@@ -470,7 +470,7 @@ public class ObjectAdapterContext {
     @Deprecated
     public void remapRecreatedPojo(ObjectAdapter adapter, final Object pojo) {
         removeAdapterFromCache(adapter);
-        adapter.replacePojo(pojo);
+        adapter.friend().replacePojo(pojo);
         mapAndInjectServices(adapter);
     }
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.core.commons.ensure.Assert;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.oid.Oid;
@@ -43,6 +44,7 @@ class ObjectAdapterContext_AdapterManager {
     
     private static final Logger LOG = LoggerFactory.getLogger(ObjectAdapterContext_AdapterManager.class);
     private final ObjectAdapterContext objectAdapterContext;
+    @SuppressWarnings("unused")
     private final PersistenceSession persistenceSession;
     private final ServicesInjector servicesInjector; 
     
@@ -68,10 +70,8 @@ class ObjectAdapterContext_AdapterManager {
      * @param recreatedPojo - already known to the object store impl, or a service
      */
     //@Override
-    public ObjectAdapter addRecreatedPojoToCache(Oid oid, Object recreatedPojo) {
+    ObjectAdapter addRecreatedPojoToCache(Oid oid, Object recreatedPojo) {
         // attempt to locate adapter for the pojo
-        // REVIEW: this check is possibly redundant because the pojo will most likely
-        // have just been instantiated, so won't yet be in any maps
         final ObjectAdapter adapterLookedUpByPojo = lookupAdapterFor(recreatedPojo);
         if (adapterLookedUpByPojo != null) {
             return adapterLookedUpByPojo;
@@ -80,6 +80,7 @@ class ObjectAdapterContext_AdapterManager {
         // attempt to locate adapter for the Oid
         final ObjectAdapter adapterLookedUpByOid = lookupAdapterFor(oid);
         if (adapterLookedUpByOid != null) {
+            _Exceptions.throwUnexpectedCodeReach();
             return adapterLookedUpByOid;
         }
 
@@ -128,23 +129,6 @@ class ObjectAdapterContext_AdapterManager {
         return objectAdapterContext.lookupAdapterByPojo(pojo);  
     }
 
-    /**
-     * Gets the {@link ObjectAdapter adapter} for the {@link Oid} if it exists
-     * in the identity map.
-     *
-     * @param oid
-     *            - must not be <tt>null</tt>
-     * @return adapter, or <tt>null</tt> if doesn't exist.
-     * @deprecated don't expose caching
-     */
-    //@Override
-    ObjectAdapter lookupAdapterFor(final Oid oid) {
-        Objects.requireNonNull(oid);
-        objectAdapterContext.ensureMapsConsistent(oid);
-
-        return objectAdapterContext.lookupAdapterById(oid);
-    }
- 
     ObjectAdapter mapAndInjectServices(final ObjectAdapter adapter) {
         // since the whole point of this method is to map an adapter that's just been created.
         // so we *don't* call ensureMapsConsistent(adapter);

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
@@ -23,7 +23,9 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.isis.commons.internal.functions._Predicates;
 import org.apache.isis.core.commons.ensure.Assert;
+import org.apache.isis.core.commons.ensure.Ensure;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.ParentedCollectionOid;
@@ -149,7 +151,6 @@ class ObjectAdapterContext_AdapterManager {
         // since the whole point of this method is to map an adapter that's just been created.
         // so we *don't* call ensureMapsConsistent(adapter);
 
-        Assert.assertNotNull(adapter);
         final Object pojo = adapter.getObject();
         Assert.assertFalse("POJO Map already contains object", pojo, objectAdapterContext.containsAdapterForPojo(pojo));
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
@@ -23,9 +23,7 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.isis.commons.internal.functions._Predicates;
 import org.apache.isis.core.commons.ensure.Assert;
-import org.apache.isis.core.commons.ensure.Ensure;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.ParentedCollectionOid;
@@ -171,7 +169,8 @@ class ObjectAdapterContext_AdapterManager {
             return adapter;
         }
 
-        objectAdapterContext.addAdapterHonoringSpecImmutability(pojo, adapter);
+        Assert.assertTrue("expected same", Objects.equals(adapter.getObject(), pojo));
+        objectAdapterContext.addAdapter(adapter);
 
         // must inject after mapping, otherwise infinite loop
         servicesInjector.injectServicesInto(pojo);

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_AdapterManager.java
@@ -178,6 +178,36 @@ class ObjectAdapterContext_AdapterManager {
         return adapter;
     }
     
+    ObjectAdapter injectServices(final ObjectAdapter adapter) {
+        // since the whole point of this method is to map an adapter that's just been created.
+        // so we *don't* call ensureMapsConsistent(adapter);
+
+        Assert.assertNotNull(adapter);
+        final Object pojo = adapter.getObject();
+
+        if (LOG.isDebugEnabled()) {
+            // don't interact with the underlying object because may be a ghost
+            // and would trigger a resolve
+            // don't call toString() on adapter because calls hashCode on
+            // underlying object, may also trigger a resolve.
+            LOG.debug("adding identity for adapter with oid={}", adapter.getOid());
+        }
+
+        // value adapters are not mapped (but all others - root and aggregated adapters - are)
+        if (adapter.isValue()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("not mapping value adapter");
+            }
+            servicesInjector.injectServicesInto(pojo);
+            return adapter;
+        }
+
+        // must inject after mapping, otherwise infinite loop
+        servicesInjector.injectServicesInto(pojo);
+
+        return adapter;
+    }
+    
     ObjectAdapter createRootOrAggregatedAdapter(final Oid oid, final Object pojo) {
         final ObjectAdapter createdAdapter;
         if(oid instanceof RootOid) {

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_Consistency.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_Consistency.java
@@ -118,5 +118,26 @@ class ObjectAdapterContext_Consistency {
                         + mapName
                         + ": provided adapter's OID: " + adapterOid + ", \n"
                         + "but map's adapter's OID was: " + adapterAccordingToMap.getOid());
+        
+        ensureThatArg(
+                adapter.getObject(), equalTo(adapterAccordingToMap.getObject()),
+                ()->String.format("mismatch in %s (oid='%s')"
+                        + ": provided adapter's hash: %s (pojo='%s'), \n"
+                        + "but map's adapter's hash was: %s (pojo='%s')",
+                        mapName, adapterOid,
+                        Integer.toHexString(adapter.hashCode()), ""+adapter.getObject(),
+                        Integer.toHexString(adapterAccordingToMap.hashCode()), ""+adapterAccordingToMap.getObject()
+                        ));
+
+//      TODO[ISIS-1976] too strict, remove        
+//        ensureThatArg(
+//                adapter, equalTo(adapterAccordingToMap),
+//                ()->String.format("mismatch in %s (oid='%s')"
+//                        + ": provided adapter's hash: %s (pojo='%s'), \n"
+//                        + "but map's adapter's hash was: %s (pojo='%s')",
+//                        mapName, adapterOid,
+//                        Integer.toHexString(adapter.hashCode()), ""+adapter.getObject(),
+//                        Integer.toHexString(adapterAccordingToMap.hashCode()), ""+adapterAccordingToMap.getObject()
+//                        ));
     }
 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_Consistency.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_Consistency.java
@@ -113,7 +113,7 @@ class ObjectAdapterContext_Consistency {
         }
 
         ensureThatArg(
-                adapter, equalTo(adapterAccordingToMap),
+                adapterOid, equalTo(adapterAccordingToMap.getOid()),
                 ()->"mismatch in "
                         + mapName
                         + ": provided adapter's OID: " + adapterOid + ", \n"

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_Consistency.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_Consistency.java
@@ -35,9 +35,11 @@ import org.apache.isis.core.metamodel.adapter.oid.Oid;
  * Responsibility: ObjectAdapter Cache/Map consistency
  * </p> 
  * @since 2.0.0-M2
+ * @deprecated expected to be made obsolete
  */
 class ObjectAdapterContext_Consistency {
     
+    @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(ObjectAdapterContext_Consistency.class);
     private final ObjectAdapterContext objectAdapterContext;
     
@@ -47,9 +49,8 @@ class ObjectAdapterContext_Consistency {
 
     /**
      * Fail early if any problems.
-     * @deprecated https://issues.apache.org/jira/browse/ISIS-1976
      */
-    protected void ensureMapsConsistent(final ObjectAdapter adapter) {
+    void ensureMapsConsistent(final ObjectAdapter adapter) {
         if (adapter.isValue()) {
             return;
         }
@@ -62,9 +63,8 @@ class ObjectAdapterContext_Consistency {
 
     /**
      * Fail early if any problems.
-     * @deprecated https://issues.apache.org/jira/browse/ISIS-1976
      */
-    protected void ensureMapsConsistent(final Oid oid) {
+    void ensureMapsConsistent(final Oid oid) {
         Objects.requireNonNull(oid);
 
         final ObjectAdapter adapter = objectAdapterContext.lookupAdapterById(oid);

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_MementoSupport.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_MementoSupport.java
@@ -74,7 +74,7 @@ class ObjectAdapterContext_MementoSupport implements MementoRecreateObjectSuppor
 
             final Object recreatedPojo = persistenceSession.instantiateAndInjectServices(spec);
             adapter = objectAdapterContext.addRecreatedPojoToCache(oid, recreatedPojo);
-            populateCollection(adapter, (CollectionData) data);
+            adapter = populateCollection(adapter, (CollectionData) data);
 
         } else {
             Assert.assertTrue("oid must be a RootOid representing an object because spec is not a collection and cannot be a value", oid instanceof RootOid);
@@ -138,14 +138,14 @@ class ObjectAdapterContext_MementoSupport implements MementoRecreateObjectSuppor
         }
     }
     
-    private void populateCollection(final ObjectAdapter collectionAdapter, final CollectionData state) {
+    private ObjectAdapter populateCollection(final ObjectAdapter collectionAdapter, final CollectionData state) {
         final ObjectAdapter[] initData = new ObjectAdapter[state.getElements().length];
         int i = 0;
         for (final Data elementData : state.getElements()) {
             initData[i++] = recreateReference(elementData);
         }
         final CollectionFacet facet = collectionAdapter.getSpecification().getFacet(CollectionFacet.class);
-        facet.init(collectionAdapter, initData);
+        return facet.init(collectionAdapter, initData);
     }
     
     private void updateFieldsAndResolveState(final ObjectAdapter objectAdapter, final Data data) {

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_NewIdentifier.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_NewIdentifier.java
@@ -1,0 +1,129 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.isis.core.runtime.system.persistence.adaptermanager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.isis.core.metamodel.adapter.oid.Oid;
+import org.apache.isis.core.metamodel.adapter.oid.RootOid;
+import org.apache.isis.core.metamodel.facets.object.viewmodel.ViewModelFacet;
+import org.apache.isis.core.metamodel.services.ServicesInjector;
+import org.apache.isis.core.metamodel.spec.ObjectSpecId;
+import org.apache.isis.core.metamodel.spec.ObjectSpecification;
+import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
+import org.apache.isis.core.runtime.system.persistence.PersistenceSession;
+
+/**
+ * package private mixin for ObjectAdapterContext
+ * <p>
+ * Responsibility: creates RootOids 
+ * </p> 
+ * @since 2.0.0-M2
+ */
+@SuppressWarnings("unused")
+class ObjectAdapterContext_NewIdentifier {
+    
+    
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectAdapterContext_NewIdentifier.class);
+    private final ObjectAdapterContext objectAdapterContext;
+    private final PersistenceSession persistenceSession;
+    private final ServicesInjector servicesInjector;
+    private final SpecificationLoader specificationLoader;
+    
+    
+    ObjectAdapterContext_NewIdentifier(ObjectAdapterContext objectAdapterContext,
+            PersistenceSession persistenceSession) {
+        this.objectAdapterContext = objectAdapterContext;
+        this.persistenceSession = persistenceSession;
+        this.servicesInjector = persistenceSession.getServicesInjector();
+        this.specificationLoader = servicesInjector.getSpecificationLoader();
+    }
+    
+//    RootOid rootOidFor(Object pojo) {
+//        final RootOid rootOid = servicesInjector.isRegisteredServiceInstance(pojo) 
+//                ? createPersistentOrViewModelOid(pojo) 
+//                        : createTransientOrViewModelOid(pojo);
+//        
+//                
+//        return rootOid;
+//    }
+    
+    
+    // -- create...Oid (main API)
+    /**
+     * Create a new {@link Oid#isTransient() transient} {@link Oid} for the
+     * supplied pojo, uniquely distinguishable from any other {@link Oid}.
+     */
+    final RootOid createTransientOrViewModelOid(final Object pojo) {
+        return newIdentifier(pojo, Oid.State.TRANSIENT);
+    }
+
+    /**
+     * Return an equivalent {@link RootOid}, but being persistent.
+     *
+     * <p>
+     * It is the responsibility of the implementation to determine the new unique identifier.
+     * For example, the generator may simply assign a new value from a sequence, or a GUID;
+     * or, the generator may use the oid to look up the object and inspect the object in order
+     * to obtain an application-defined value.
+     *
+     * @param pojo - being persisted
+     */
+    final RootOid createPersistentOrViewModelOid(Object pojo) {
+        return newIdentifier(pojo, Oid.State.PERSISTENT);
+    }
+
+    RootOid newIdentifier(final Object pojo, final Oid.State type) {
+        final ObjectSpecification spec = objectSpecFor(pojo);
+        if(spec.isService()) {
+            return newRootId(spec, PersistenceSession.SERVICE_IDENTIFIER, Oid.State.PERSISTENT); // services are always persistent
+        }
+
+        final ViewModelFacet recreatableObjectFacet = spec.getFacet(ViewModelFacet.class);
+        final String identifier =
+                recreatableObjectFacet != null
+                ? recreatableObjectFacet.memento(pojo)
+                        : persistenceSession.identifierFor(pojo, type);
+
+                return newRootId(spec, identifier, type);
+    }
+    
+    
+    private RootOid newRootId(final ObjectSpecification spec, final String identifier, final Oid.State type) {
+        final Oid.State state =
+                spec.containsDoOpFacet(ViewModelFacet.class)
+                ? Oid.State.VIEWMODEL
+                        : type == Oid.State.TRANSIENT
+                        ? Oid.State.TRANSIENT
+                                : Oid.State.PERSISTENT;
+        final ObjectSpecId objectSpecId = spec.getSpecId();
+        return new RootOid(objectSpecId, identifier, state);
+    }
+    
+    // -- HELPER
+    
+    private ObjectSpecification objectSpecFor(final Object pojo) {
+        final Class<?> pojoClass = pojo.getClass();
+        return specificationLoader.loadSpecification(pojoClass);
+    }
+
+
+    
+}

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
@@ -30,7 +30,6 @@ import org.apache.isis.core.commons.ensure.Assert;
 import org.apache.isis.core.metamodel.IsisJdoMetamodelPlugin;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapterProvider;
-import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.RootOid;
 import org.apache.isis.core.metamodel.facets.object.value.ValueFacet;
 import org.apache.isis.core.metamodel.services.ServicesInjector;

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
@@ -72,8 +72,9 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
         if(persistentOrValueOid != null) {
             return persistentOrValueOid;
         }
-        // Creates a new transient root for the supplied domain object
-        final RootOid rootOid = persistenceSession.createTransientOrViewModelOid(pojo);
+        final RootOid rootOid = servicesInjector.isRegisteredServiceInstance(pojo) 
+                ? persistenceSession.createPersistentOrViewModelOid(pojo) 
+                        : persistenceSession.createTransientOrViewModelOid(pojo);
         return rootOid;
     }
     
@@ -88,8 +89,11 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
             return existingOrValueAdapter;
         }
 
-        // Creates a new transient root {@link ObjectAdapter adapter} for the supplied domain
-        final RootOid rootOid = persistenceSession.createTransientOrViewModelOid(pojo);
+        final RootOid rootOid = servicesInjector.isRegisteredServiceInstance(pojo) 
+                ? persistenceSession.createPersistentOrViewModelOid(pojo) 
+                        : persistenceSession.createTransientOrViewModelOid(pojo);
+        
+//        final RootOid rootOid = persistenceSession.createTransientOrViewModelOid(pojo);
         final ObjectAdapter newAdapter = objectAdapterContext.getFactories().createRootAdapter(pojo, rootOid);
 
         return objectAdapterContext.mapAndInjectServices(newAdapter);

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
@@ -116,8 +116,15 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
     }
 
     @Override
-    public ObjectAdapter specificationForViewModel(Object viewModelPojo) {
-        return objectAdapterContext.specificationForViewModel(viewModelPojo);
+    public ObjectSpecification specificationForViewModel(Object viewModelPojo) {
+        final ObjectSpecification objectSpecification = 
+                specificationLoader.loadSpecification(viewModelPojo.getClass());
+        return objectSpecification;
+    }
+    
+    @Override
+    public ObjectAdapter disposableAdapterForViewModel(Object viewModelPojo) {
+        return objectAdapterContext.disposableAdapterForViewModel(viewModelPojo);
     }
 
     @Override

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
@@ -145,6 +145,15 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
         return adapter;
     }
     
+    @Override
+    public List<ObjectAdapter> getServices() {
+        return serviceAdapters.get();
+    }
+    
+    // -- HELPER
+    
+    private _Lazy<List<ObjectAdapter>> serviceAdapters = _Lazy.of(this::initServiceAdapters);
+    
     private List<ObjectAdapter> initServiceAdapters() {
         return servicesInjector.streamRegisteredServiceInstances()
         .map(this::adapterFor)
@@ -153,15 +162,6 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
         })
         .collect(Collectors.toList());
     }
-    
-    private _Lazy<List<ObjectAdapter>> serviceAdapters = _Lazy.of(this::initServiceAdapters);
-    
-    @Override
-    public List<ObjectAdapter> getServices() {
-        return serviceAdapters.get();
-    }
-    
-    // -- HELPER
     
 //    private Oid persistentOrValueOid(Object pojo) {
 //        
@@ -197,13 +197,13 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
 //        return null;
 //    }
     
-    protected Oid persistentOid(final Object pojo) {
-        if (persistenceSession.getPersistenceManager().getObjectId(pojo) == null) {
-            return null;
-        }
-        final RootOid oid = objectAdapterContext.createPersistentOrViewModelOid(pojo);
-        return oid;
-    }
+//    private Oid persistentOid(final Object pojo) {
+//        if (persistenceSession.getPersistenceManager().getObjectId(pojo) == null) {
+//            return null;
+//        }
+//        final RootOid oid = objectAdapterContext.createPersistentOrViewModelOid(pojo);
+//        return oid;
+//    }
     
     private ObjectAdapter existingOrValueAdapter(Object pojo) {
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ObjectAdapterProvider.java
@@ -20,11 +20,13 @@ package org.apache.isis.core.runtime.system.persistence.adaptermanager;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.isis.commons.internal.collections._Lists;
+import org.apache.isis.commons.internal.base._Lazy;
+import org.apache.isis.core.commons.ensure.Assert;
 import org.apache.isis.core.metamodel.IsisJdoMetamodelPlugin;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapterProvider;
@@ -47,6 +49,7 @@ import org.apache.isis.core.runtime.system.persistence.PersistenceSession;
  */
 class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvider {
     
+    @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(ObjectAdapterContext_ObjectAdapterProvider.class);
     private final ObjectAdapterContext objectAdapterContext;
     private final PersistenceSession persistenceSession;
@@ -63,20 +66,19 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
         this.isisJdoMetamodelPlugin = IsisJdoMetamodelPlugin.get();
     }
 
-    @Override
-    public Oid oidFor(Object pojo) {
-        if(pojo == null) {
-            return null;
-        }
-        final Oid persistentOrValueOid = persistentOrValueOid(pojo);
-        if(persistentOrValueOid != null) {
-            return persistentOrValueOid;
-        }
-        final RootOid rootOid = servicesInjector.isRegisteredServiceInstance(pojo) 
-                ? persistenceSession.createPersistentOrViewModelOid(pojo) 
-                        : persistenceSession.createTransientOrViewModelOid(pojo);
-        return rootOid;
-    }
+//    @Override
+//    public Oid oidFor(Object pojo) {
+//        if(pojo == null) {
+//            return null;
+//        }
+//        final Oid persistentOrValueOid = persistentOrValueOid(pojo);
+//        if(persistentOrValueOid != null) {
+//            return persistentOrValueOid;
+//        }
+//        final RootOid rootOid = objectAdapterContext.rootOidFor(pojo);
+//        
+//        return rootOid;
+//    }
     
     @Override
     public ObjectAdapter adapterFor(Object pojo) {
@@ -89,16 +91,14 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
             return existingOrValueAdapter;
         }
 
-        final RootOid rootOid = servicesInjector.isRegisteredServiceInstance(pojo) 
-                ? persistenceSession.createPersistentOrViewModelOid(pojo) 
-                        : persistenceSession.createTransientOrViewModelOid(pojo);
+        final RootOid rootOid = objectAdapterContext.createTransientOrViewModelOid(pojo);
         
-//        final RootOid rootOid = persistenceSession.createTransientOrViewModelOid(pojo);
         final ObjectAdapter newAdapter = objectAdapterContext.getFactories().createRootAdapter(pojo, rootOid);
 
         return objectAdapterContext.mapAndInjectServices(newAdapter);
     }
-
+    
+    
     @Override
     public ObjectAdapter adapterFor(Object pojo, ObjectAdapter parentAdapter, OneToManyAssociation collection) {
 
@@ -140,66 +140,68 @@ class ObjectAdapterContext_ObjectAdapterProvider implements ObjectAdapterProvide
         if (persistenceSession.getPersistenceManager().getObjectId(pojo) == null) {
             return null;
         }
-        final RootOid oid = persistenceSession.createPersistentOrViewModelOid(pojo);
+        final RootOid oid = objectAdapterContext.createPersistentOrViewModelOid(pojo);
         final ObjectAdapter adapter = objectAdapterContext.addRecreatedPojoToCache(oid, pojo);
         return adapter;
     }
     
+    private List<ObjectAdapter> initServiceAdapters() {
+        return servicesInjector.streamRegisteredServiceInstances()
+        .map(this::adapterFor)
+        .peek(serviceAdapter->{
+            Assert.assertFalse("expected to not be 'transient'", serviceAdapter.getOid().isTransient());
+        })
+        .collect(Collectors.toList());
+    }
+    
+    private _Lazy<List<ObjectAdapter>> serviceAdapters = _Lazy.of(this::initServiceAdapters);
+    
     @Override
     public List<ObjectAdapter> getServices() {
-        final List<Object> services = servicesInjector.getRegisteredServices();
-        final List<ObjectAdapter> serviceAdapters = _Lists.newArrayList();
-        for (final Object servicePojo : services) {
-            ObjectAdapter serviceAdapter = objectAdapterContext.lookupAdapterFor(servicePojo);
-            if(serviceAdapter == null) {
-                throw new IllegalStateException("ObjectAdapter for service " + servicePojo + " does not exist?!?");
-            }
-            serviceAdapters.add(serviceAdapter);
-        }
-        return serviceAdapters;
+        return serviceAdapters.get();
     }
     
     // -- HELPER
     
-    private Oid persistentOrValueOid(Object pojo) {
-        
-        Oid oid;
-
-        // equivalent to  isInstanceOfPersistable = pojo instanceof Persistable;
-        final boolean isInstanceOfPersistable = isisJdoMetamodelPlugin.isPersistenceEnhanced(pojo.getClass());
-        
-        // pojo may have been lazily loaded by object store, but we haven't yet seen it
-        if (isInstanceOfPersistable) {
-            oid = persistentOid(pojo);
-
-            // TODO: could return null if the pojo passed in !dnIsPersistent() || !dnIsDetached()
-            // in which case, we would ought to map as a transient object, rather than fall through and treat as a value?
-        } else {
-            oid = null;
-        }
-
-        if(oid != null) {
-            return oid;
-        }
-        
-        // need to create (and possibly map) the adapter.
-        final ObjectSpecification objSpec = specificationLoader.loadSpecification(pojo.getClass());
-
-        // we create value facets as standalone (so not added to maps)
-        if (objSpec.containsFacet(ValueFacet.class)) {
-            //TODO[ISIS-1976] don't need an adapter, just its oid
-            oid = objectAdapterContext.getFactories().createStandaloneAdapter(pojo).getOid(); 
-            return oid;
-        }
-
-        return null;
-    }
+//    private Oid persistentOrValueOid(Object pojo) {
+//        
+//        Oid oid;
+//
+//        // equivalent to  isInstanceOfPersistable = pojo instanceof Persistable;
+//        final boolean isInstanceOfPersistable = isisJdoMetamodelPlugin.isPersistenceEnhanced(pojo.getClass());
+//        
+//        // pojo may have been lazily loaded by object store, but we haven't yet seen it
+//        if (isInstanceOfPersistable) {
+//            oid = persistentOid(pojo);
+//
+//            // TODO: could return null if the pojo passed in !dnIsPersistent() || !dnIsDetached()
+//            // in which case, we would ought to map as a transient object, rather than fall through and treat as a value?
+//        } else {
+//            oid = null;
+//        }
+//
+//        if(oid != null) {
+//            return oid;
+//        }
+//        
+//        // need to create (and possibly map) the adapter.
+//        final ObjectSpecification objSpec = specificationLoader.loadSpecification(pojo.getClass());
+//
+//        // we create value facets as standalone (so not added to maps)
+//        if (objSpec.containsFacet(ValueFacet.class)) {
+//            //TODO[ISIS-1976] don't need an adapter, just its oid
+//            oid = objectAdapterContext.getFactories().createStandaloneAdapter(pojo).getOid(); 
+//            return oid;
+//        }
+//
+//        return null;
+//    }
     
     protected Oid persistentOid(final Object pojo) {
         if (persistenceSession.getPersistenceManager().getObjectId(pojo) == null) {
             return null;
         }
-        final RootOid oid = persistenceSession.createPersistentOrViewModelOid(pojo);
+        final RootOid oid = objectAdapterContext.createPersistentOrViewModelOid(pojo);
         return oid;
     }
     

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ServiceLookup.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ServiceLookup.java
@@ -1,0 +1,109 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.isis.core.runtime.system.persistence.adaptermanager;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.isis.commons.internal.collections._Maps;
+import org.apache.isis.commons.internal.context._Context;
+import org.apache.isis.core.commons.ensure.Assert;
+import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
+import org.apache.isis.core.metamodel.adapter.oid.RootOid;
+import org.apache.isis.core.metamodel.services.ServicesInjector;
+
+/**
+ * package private mixin for ObjectAdapterContext
+ * <p>
+ * Responsibility: provides ObjectAdapters for registered services 
+ * </p> 
+ * @since 2.0.0-M2
+ */
+@SuppressWarnings("unused")
+class ObjectAdapterContext_ServiceLookup {
+    
+    
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectAdapterContext_ServiceLookup.class);
+    private final ObjectAdapterContext objectAdapterContext;
+    private final ServicesInjector servicesInjector;
+    
+    ObjectAdapterContext_ServiceLookup(ObjectAdapterContext objectAdapterContext,
+            ServicesInjector servicesInjector) {
+        this.objectAdapterContext = objectAdapterContext;
+        this.servicesInjector = servicesInjector;
+    }
+
+    ObjectAdapter serviceAdapterFor(RootOid rootOid) {
+        
+        final ServicesByIdResource servicesByIdResource =
+                _Context.computeIfAbsent(ServicesByIdResource.class, cls->initLookupResource());
+        
+        try {
+            final Object serviceInstance = servicesByIdResource.lookupServiceInstance(rootOid);
+            if(serviceInstance==null) {
+                return null;
+            }
+            return objectAdapterContext.getFactories().createRootAdapter(serviceInstance, rootOid);
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+            throw new IllegalStateException("Could not resolve service for id '" + rootOid.enStringNoVersion() + "'");
+        }
+        
+    }
+    
+    // -- HELPER
+    
+    /**
+     *  Application scoped resource to hold a map for looking up services by id.
+     */
+    private static class ServicesByIdResource implements AutoCloseable {
+        private final Map<RootOid, Object> servicesById = _Maps.newHashMap();
+
+        @Override
+        public void close() {
+            servicesById.clear();
+        }
+
+        public Object lookupServiceInstance(RootOid serviceRootOid) {
+            return servicesById.get(serviceRootOid);
+        }
+    }
+    
+    private ServicesByIdResource initLookupResource() {
+        
+        System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! INIT SERVICE ID LOOKUP RESOURCE");
+        
+        final ServicesByIdResource lookupResource = new ServicesByIdResource();
+        
+        servicesInjector.streamRegisteredServiceInstances()
+        .map(objectAdapterContext.getObjectAdapterProvider()::adapterFor)
+        .forEach(serviceAdapter->{
+            Assert.assertFalse("expected to not be 'transient'", serviceAdapter.getOid().isTransient());
+            lookupResource.servicesById.put((RootOid)serviceAdapter.getOid() , serviceAdapter.getObject());
+        });
+        
+        return lookupResource;
+    }
+    
+
+}

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ServiceLookup.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/ObjectAdapterContext_ServiceLookup.java
@@ -91,7 +91,7 @@ class ObjectAdapterContext_ServiceLookup {
     
     private ServicesByIdResource initLookupResource() {
         
-        System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! INIT SERVICE ID LOOKUP RESOURCE");
+        objectAdapterContext.printContextInfo("INIT SERVICE ID LOOKUP RESOURCE");
         
         final ServicesByIdResource lookupResource = new ServicesByIdResource();
         

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/RootAndCollectionAdapters.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/RootAndCollectionAdapters.java
@@ -22,7 +22,6 @@ package org.apache.isis.core.runtime.system.persistence.adaptermanager;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.Maps;
@@ -32,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.isis.core.commons.ensure.Assert;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
-import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.ParentedCollectionOid;
 import org.apache.isis.core.metamodel.adapter.oid.RootOid;
 import org.apache.isis.core.metamodel.spec.feature.Contributed;
@@ -49,8 +47,10 @@ import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
  */
 class RootAndCollectionAdapters implements Iterable<ObjectAdapter> {
     
+    @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(RootAndCollectionAdapters.class);
 
+    private final ObjectAdapterContext context;
     private final ObjectAdapter parentAdapter;
     private final RootOid rootAdapterOid;
 
@@ -58,11 +58,12 @@ class RootAndCollectionAdapters implements Iterable<ObjectAdapter> {
 
     public RootAndCollectionAdapters(
             final ObjectAdapter parentAdapter,
-            final ObjectAdapterContext_AdapterManager adapterManagerMixin) {
+            final ObjectAdapterContext context) {
         Assert.assertNotNull(parentAdapter);
         this.rootAdapterOid = (RootOid) parentAdapter.getOid();
         this.parentAdapter = parentAdapter;
-        addCollectionAdapters(adapterManagerMixin);
+        this.context = context;
+        addCollectionAdapters();
     }
 
     public ObjectAdapter getRootAdapter() {
@@ -102,10 +103,10 @@ class RootAndCollectionAdapters implements Iterable<ObjectAdapter> {
     // Helpers
     ////////////////////////////////////////////////////////////////////////
 
-    private void addCollectionAdapters(ObjectAdapterContext_AdapterManager adapterManagerMixin) {
+    private void addCollectionAdapters() {
         for (final OneToManyAssociation otma : parentAdapter.getSpecification().getCollections(Contributed.EXCLUDED)) {
             final ParentedCollectionOid collectionOid = new ParentedCollectionOid((RootOid) rootAdapterOid, otma);
-            final ObjectAdapter collectionAdapter = adapterManagerMixin.lookupAdapterFor(collectionOid);
+            final ObjectAdapter collectionAdapter = context.lookupParentedCollectionAdapter(collectionOid);
             if (collectionAdapter != null) {
                 // collection adapters are lazily created and so there may not be one.
                 addCollectionAdapter(otma, collectionAdapter);

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/RootAndCollectionAdapters.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/system/persistence/adaptermanager/RootAndCollectionAdapters.java
@@ -22,12 +22,17 @@ package org.apache.isis.core.runtime.system.persistence.adaptermanager;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.Maps;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.isis.core.commons.ensure.Assert;
 import org.apache.isis.core.metamodel.adapter.ObjectAdapter;
+import org.apache.isis.core.metamodel.adapter.oid.Oid;
 import org.apache.isis.core.metamodel.adapter.oid.ParentedCollectionOid;
 import org.apache.isis.core.metamodel.adapter.oid.RootOid;
 import org.apache.isis.core.metamodel.spec.feature.Contributed;
@@ -43,6 +48,8 @@ import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
  * must also be persisted.
  */
 class RootAndCollectionAdapters implements Iterable<ObjectAdapter> {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(RootAndCollectionAdapters.class);
 
     private final ObjectAdapter parentAdapter;
     private final RootOid rootAdapterOid;

--- a/core/viewer-wicket-model/src/main/java/org/apache/isis/viewer/wicket/model/mementos/ObjectAdapterMemento.java
+++ b/core/viewer-wicket-model/src/main/java/org/apache/isis/viewer/wicket/model/mementos/ObjectAdapterMemento.java
@@ -134,7 +134,7 @@ public class ObjectAdapterMemento implements Serializable {
                 final List<Object> listOfPojos =
                         _Lists.transform(oam.list, Functions.toPojo(persistenceSession, specificationLoader));
 
-                return ObjectAdapter.Functions.adapterForUsing(persistenceSession).apply(listOfPojos);
+                return persistenceSession.adapterFor(listOfPojos);
             }
 
             @Override

--- a/core/viewer-wicket-model/src/main/java/org/apache/isis/viewer/wicket/model/models/EntityCollectionModel.java
+++ b/core/viewer-wicket-model/src/main/java/org/apache/isis/viewer/wicket/model/models/EntityCollectionModel.java
@@ -176,7 +176,7 @@ UiHintContainer {
 
                 final List<ObjectAdapter> adapterList =
                         _Lists.transform(objectList,
-                                ObjectAdapter.Functions.adapterForUsing( entityCollectionModel.getPersistenceSession() ));
+                                entityCollectionModel.getPersistenceSession()::adapterFor);
 
                 return adapterList;
             }


### PR DESCRIPTION
A http web request might trigger multiple `PersistenceSession` life-cycles (at least one).

Previously each PersistenceSession created its own ObjectAdapter list for any registered domain-service eagerly, even if not required. We do this now lazy:

1) `ObjectAdapterProvider` provides a `List<ObjectAdapter> getServices()` which provides this list on demand, chached in the context of the current PersistenceSession.
2) `ObjectAdapterContext` provides a lookup `ObjectAdapter lookupServiceAdapterFor(RootOid rootOid)` while an underlying lookup map is created lazy and cached application scoped.

Other than that ObjectAdapters are immutable now. (field for the pojo is final)

I'd like to merge at this state, because it appears stable.
