### PR TITLE
ISIS-1979: Refactor logging in headless runtime and prevent configuri…

### DIFF
--- a/core/log4j/src/main/java/org/apache/isis/core/runtime/logging/IsisLoggingConfigurer.java
+++ b/core/log4j/src/main/java/org/apache/isis/core/runtime/logging/IsisLoggingConfigurer.java
@@ -51,11 +51,15 @@ public class IsisLoggingConfigurer {
      * The root logging level can also be adjusted using command line arguments.
      */
     public void configureLogging(final String configDirectory, final String[] args) {
+        configureLoggingWithFile(configDirectory + "/" + LoggingConstants.LOGGING_CONFIG_FILE, args);
+    }
+
+    public void configureLoggingWithFile(final String configFile, final String[] args) {
         if (loggingSetup) {
             return;
         }
         loggingSetup = true;
-        configureLogging(configDirectory);
+        configureLogging(configFile);
         applyLoggingLevelFromCommandLine(args);
     }
 
@@ -77,12 +81,11 @@ public class IsisLoggingConfigurer {
      * {@link Level#WARN warning}, a typical {@link PatternLayout} and logging
      * to the {@link ConsoleAppender console}.
      */
-    private void configureLogging(final String configDirectory) {
+    private void configureLogging(final String configFile) {
         final Properties properties = new Properties();
-        final String path = configDirectory + "/" + LoggingConstants.LOGGING_CONFIG_FILE;
         FileInputStream inStream = null;
         try {
-            inStream = new FileInputStream(path);
+            inStream = new FileInputStream(configFile);
             properties.load(inStream);
         } catch (final IOException ignore) {
             // ignore
@@ -94,7 +97,7 @@ public class IsisLoggingConfigurer {
             InputStream inStream2 = null;
             try {
                 final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-                inStream2 = classLoader.getResourceAsStream(path);
+                inStream2 = classLoader.getResourceAsStream(configFile);
                 if (inStream2 != null) {
                     properties.load(inStream2);
                 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/HeadlessWithBootstrappingAbstract.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/HeadlessWithBootstrappingAbstract.java
@@ -18,22 +18,21 @@
  */
 package org.apache.isis.core.runtime.headless;
 
-import java.io.PrintStream;
-
 import com.google.common.base.Strings;
-
-import org.apache.log4j.PropertyConfigurator;
+import org.apache.isis.applib.Module;
+import org.apache.isis.applib.clock.Clock;
+import org.apache.isis.applib.services.xactn.TransactionService;
+import org.apache.isis.core.commons.factory.InstanceUtil;
+import org.apache.isis.core.runtime.headless.logging.LeveledLogger;
+import org.apache.isis.core.runtime.headless.logging.LogConfig;
+import org.apache.isis.core.runtime.headless.logging.LogStream;
+import org.apache.isis.core.runtime.logging.IsisLoggingConfigurer;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import org.apache.isis.applib.Module;
-import org.apache.isis.applib.clock.Clock;
-import org.apache.isis.applib.services.xactn.TransactionService;
-import org.apache.isis.core.commons.factory.InstanceUtil;
-import org.apache.isis.core.runtime.headless.logging.LogConfig;
-import org.apache.isis.core.runtime.headless.logging.LogStream;
+import java.io.PrintStream;
 
 /**
  * Provides headless access to the system, first bootstrapping the system if required.
@@ -53,6 +52,8 @@ public abstract class HeadlessWithBootstrappingAbstract extends HeadlessAbstract
         return LogStream.logPrintStream(LOG, level);
     }
 
+    private final LeveledLogger logger;
+
     private final static ThreadLocal<Boolean> setupLogging = new ThreadLocal<Boolean>() {{
         set(false);
     }};
@@ -70,10 +71,12 @@ public abstract class HeadlessWithBootstrappingAbstract extends HeadlessAbstract
             final Module module) {
 
         this.logConfig = logConfig;
+        this.logger = new LeveledLogger(LOG, logConfig.getTestLoggingLevel());
 
         final boolean firstTime = !setupLogging.get();
         if(firstTime) {
-            PropertyConfigurator.configure(logConfig.getLoggingPropertyFile());
+            IsisLoggingConfigurer loggingConfigurer = new IsisLoggingConfigurer(org.apache.log4j.Level.INFO);
+            loggingConfigurer.configureLoggingWithFile(logConfig.getLoggingPropertyFile(), new String[0]);
             setupLogging.set(true);
         }
 
@@ -136,22 +139,6 @@ public abstract class HeadlessWithBootstrappingAbstract extends HeadlessAbstract
     }
 
     protected void log(final String message) {
-        switch (logConfig.getTestLoggingLevel()) {
-        case ERROR:
-            LOG.error(message);
-            break;
-        case WARN:
-            LOG.warn(message);
-            break;
-        case INFO:
-            LOG.info(message);
-            break;
-        case DEBUG:
-            LOG.debug(message);
-            break;
-        case TRACE:
-            LOG.trace(message);
-            break;
-        }
+        logger.log(message);
     }
 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/IsisSystem.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/IsisSystem.java
@@ -19,10 +19,7 @@
 
 package org.apache.isis.core.runtime.headless;
 
-import static org.apache.isis.commons.internal.base._Casts.uncheckedCast;
-
-import java.util.Set;
-
+import com.google.common.base.Joiner;
 import org.apache.isis.applib.AppManifest;
 import org.apache.isis.applib.fixtures.FixtureClock;
 import org.apache.isis.core.commons.authentication.AuthenticationSession;
@@ -34,13 +31,14 @@ import org.apache.isis.core.metamodel.specloader.validator.MetaModelInvalidExcep
 import org.apache.isis.core.runtime.authentication.AuthenticationManager;
 import org.apache.isis.core.runtime.authentication.AuthenticationRequest;
 import org.apache.isis.core.runtime.headless.auth.AuthenticationRequestNameOnly;
-import org.apache.isis.core.runtime.logging.IsisLoggingConfigurer;
 import org.apache.isis.core.runtime.system.context.IsisContext;
 import org.apache.isis.core.runtime.system.session.IsisSessionFactory;
 import org.apache.isis.core.runtime.system.session.IsisSessionFactoryBuilder;
 import org.apache.isis.core.runtime.systemusinginstallers.IsisComponentProvider;
 
-import com.google.common.base.Joiner;
+import java.util.Set;
+
+import static org.apache.isis.commons.internal.base._Casts.uncheckedCast;
 
 
 /**
@@ -83,8 +81,6 @@ public class IsisSystem {
 
         protected AppManifest appManifestIfAny;
 
-        protected org.apache.log4j.Level level;
-
         public T with(IsisConfiguration configuration) {
             this.configuration = (IsisConfigurationDefault) configuration;
             return uncheckedCast(this);
@@ -100,11 +96,6 @@ public class IsisSystem {
             return uncheckedCast(this);
         }
 
-        public T withLoggingAt(org.apache.log4j.Level level) {
-            this.level = level;
-            return uncheckedCast(this);
-        }
-
         public S build() {
             final IsisSystem isisSystem =
                     new IsisSystem(
@@ -115,10 +106,6 @@ public class IsisSystem {
         }
 
         protected S configure(final S isisSystem) {
-            if(level != null) {
-                isisSystem.setLevel(level);
-            }
-
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
                 public synchronized void run() {
@@ -166,24 +153,6 @@ public class IsisSystem {
         this.authenticationRequestIfAny = authenticationRequestIfAny;
     }
 
-
-
-    // -- level
-    private org.apache.log4j.Level level = org.apache.log4j.Level.INFO;
-
-    /**
-     * The level to use for the root logger if fallback (ie a <tt>logging.properties</tt> file cannot be found).
-     */
-    public org.apache.log4j.Level getLevel() {
-        return level;
-    }
-
-    public void setLevel(org.apache.log4j.Level level) {
-        this.level = level;
-    }
-
-
-
     // -- setup (also componentProvider)
 
     // populated at #setupSystem
@@ -210,9 +179,6 @@ public class IsisSystem {
 
         boolean firstTime = isisSessionFactory == null;
         if(firstTime) {
-            IsisLoggingConfigurer isisLoggingConfigurer = new IsisLoggingConfigurer(getLevel());
-            isisLoggingConfigurer.configureLogging(".", new String[] {});
-
             componentProvider = new IsisComponentProviderDefault(
                     appManifestIfAny,
                     configurationOverride

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/IsisSystemBootstrapper.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/IsisSystemBootstrapper.java
@@ -18,10 +18,6 @@
  */
 package org.apache.isis.core.runtime.headless;
 
-import java.util.List;
-
-import javax.jdo.PersistenceManagerFactory;
-
 import org.apache.isis.applib.AppManifest;
 import org.apache.isis.applib.AppManifest2;
 import org.apache.isis.applib.AppManifestAbstract2;
@@ -33,10 +29,14 @@ import org.apache.isis.applib.services.jdosupport.IsisJdoSupport;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.core.runtime.headless.logging.LogConfig;
+import org.apache.isis.core.runtime.headless.logging.LeveledLogger;
 import org.apache.isis.core.runtime.system.context.IsisContext;
 import org.apache.isis.core.runtime.system.session.IsisSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jdo.PersistenceManagerFactory;
+import java.util.List;
 
 public class IsisSystemBootstrapper {
 
@@ -48,8 +48,8 @@ public class IsisSystemBootstrapper {
     private static ThreadLocal<AppManifest2> isftAppManifest = new ThreadLocal<>();
 
 
-    private final LogConfig logConfig;
     private final AppManifest2 appManifest2;
+    private final LeveledLogger logger;
 
     public IsisSystemBootstrapper(
             final LogConfig logConfig,
@@ -61,8 +61,8 @@ public class IsisSystemBootstrapper {
             final LogConfig logConfig,
             final AppManifest2 appManifest2) {
 
-        this.logConfig = logConfig;
         this.appManifest2 = appManifest2;
+        this.logger = new LeveledLogger(LOG, logConfig.getTestLoggingLevel());
     }
 
     public AppManifest2 getAppManifest2() {
@@ -148,9 +148,8 @@ public class IsisSystemBootstrapper {
 
         final IsisSystem isft =
                 IsisSystem.builder()
-                .withLoggingAt(org.apache.log4j.Level.INFO)
-                .with(appManifest2)
-                .build();
+                    .with(appManifest2)
+                    .build();
 
         isft.setUpSystem();
 
@@ -207,23 +206,7 @@ public class IsisSystemBootstrapper {
     }
 
     private void log(final String message) {
-        switch (logConfig.getTestLoggingLevel()) {
-        case ERROR:
-            LOG.error(message);
-            break;
-        case WARN:
-            LOG.warn(message);
-            break;
-        case INFO:
-            LOG.info(message);
-            break;
-        case DEBUG:
-            LOG.debug(message);
-            break;
-        case TRACE:
-            LOG.trace(message);
-            break;
-        }
+        logger.log(message);
     }
 
 }

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/logging/LeveledLogger.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/logging/LeveledLogger.java
@@ -1,0 +1,36 @@
+package org.apache.isis.core.runtime.headless.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+public class LeveledLogger {
+
+    private Logger logger;
+    private Level level;
+
+    public LeveledLogger(final Logger logger, final Level level) {
+        this.logger = logger;
+        this.level = level;
+    }
+
+    public void log(final String message) {
+        switch (level) {
+            case ERROR:
+                logger.error(message);
+                break;
+            case WARN:
+                logger.warn(message);
+                break;
+            case INFO:
+                logger.info(message);
+                break;
+            case DEBUG:
+                logger.debug(message);
+                break;
+            case TRACE:
+                logger.trace(message);
+                break;
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/logging/LogStream.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/headless/logging/LogStream.java
@@ -18,16 +18,15 @@
  */
 package org.apache.isis.core.runtime.headless.logging;
 
-import java.io.OutputStream;
-import java.io.PrintStream;
-
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 public class LogStream extends OutputStream {
 
-    private final Logger logger;
-    private final Level level;
+    private final LeveledLogger logger;
 
     private final StringBuilder buf = new StringBuilder();
 
@@ -36,8 +35,7 @@ public class LogStream extends OutputStream {
     }
 
     public LogStream(final Logger logger, final Level level) {
-        this.logger = logger;
-        this.level = level;
+        this.logger = new LeveledLogger(logger, level);
     }
 
     @Override
@@ -45,24 +43,7 @@ public class LogStream extends OutputStream {
 
     @Override
     public void flush() {
-        final String message = toString();
-        switch (level) {
-        case ERROR:
-            logger.error(message);
-            break;
-        case WARN:
-            logger.warn(message);
-            break;
-        case INFO:
-            logger.info(message);
-            break;
-        case DEBUG:
-            logger.debug(message);
-            break;
-        case TRACE:
-            logger.trace(message);
-            break;
-        }
+        logger.log(toString());
 
         // Clear the buffer
         buf.delete(0, buf.length());


### PR DESCRIPTION
…g log4j twice

Without these changes, IsisSystem is setting up log4j which is too late since other classes which
bootstrap Isis require logging to work. Currently, HeadlessWithBootstrappingAbstract configures log4j in
addition to IsisSystem. IsisSystem sets up logging either through logging.properties or a fallback. But
logging.properties does not always exist (integration tests). Without logging.properties the fallback
adds a console appender to the root logger in addition to any configuration in logging-integtest.properties,
resulting in duplicated logs in integration tests.

This commit removes any logging setup from IsisSystem. HeadlessWithBootstrappingAbstract now uses the
IsisLoggingConfigurer which is normally used to set up logging. This requires IsisLoggingConfigurer to
be flexible as to the basename of the configuration file.

Also, some code duplication is refactored into LeveledLogger.