### PR TITLE
[ISIS-2117] Replace instances of Math.random with Random.nextDouble

### DIFF
--- a/core/metamodel/src/main/java/org/apache/isis/core/runtime/authentication/standard/RandomCodeGenerator10Chars.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/runtime/authentication/standard/RandomCodeGenerator10Chars.java
@@ -19,6 +19,8 @@
 
 package org.apache.isis.core.runtime.authentication.standard;
 
+import java.util.Random;
+
 public class RandomCodeGenerator10Chars implements RandomCodeGenerator {
 
     private static final int NUMBER_CHARACTERS = 10;
@@ -27,8 +29,9 @@ public class RandomCodeGenerator10Chars implements RandomCodeGenerator {
     @Override
     public String generateRandomCode() {
         final StringBuilder buf = new StringBuilder(NUMBER_CHARACTERS);
+	Random rand = new Random();
         for (int i = 0; i < NUMBER_CHARACTERS; i++) {
-            final int pos = (int) ((Math.random() * CHARACTERS.length()));
+            final int pos = (int) ((rand.nextDouble() * CHARACTERS.length()));
             buf.append(CHARACTERS.charAt(pos));
         }
         return buf.toString();


### PR DESCRIPTION
[ISIS-2117](https://issues.apache.org/jira/browse/ISIS-2117) Replace Math.random with Random.nextDouble. There is a performance overhead cost when using Math.random over Random.nextDouble. Even moreso, the Random class can allow for easier random manipulation in the future if needed.

