### PR TITLE
ISIS-2082: spikes the use of type-safe config properties, for two cases.

### DIFF
--- a/core/applib/src/main/java/org/apache/isis/applib/services/repository/RepositoryService.java
+++ b/core/applib/src/main/java/org/apache/isis/applib/services/repository/RepositoryService.java
@@ -27,24 +27,6 @@ import org.apache.isis.applib.query.Query;
 public interface RepositoryService {
 
     /**
-     * Normally any queries are automatically preceded by flushing pending executions.
-     *
-     * <p>
-     * This key allows this behaviour to be disabled.
-     *
-     * <p>
-     *     Originally introduced as part of ISIS-1134 (fixing memory leaks in the objectstore)
-     *     where it was found that the autoflush behaviour was causing a (now unrepeatable)
-     *     data integrity error (see <a href="https://issues.apache.org/jira/browse/ISIS-1134?focusedCommentId=14500638&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14500638">ISIS-1134 comment</a>, in the isis-module-security.
-     *     However, that this could be circumvented by removing the call to flush().
-     *     We don't want to break existing apps that might rely on this behaviour, on the
-     *     other hand we want to fix the memory leak.  Adding this configuration property
-     *     seems the most prudent way forward.
-     * </p>
-     */
-    String KEY_DISABLE_AUTOFLUSH = "isis.services.container.disableAutoFlush";
-
-    /**
      * Same as {@link org.apache.isis.applib.services.factory.FactoryService#instantiate(Class)}; provided as a
      * convenience because instantiating and {@link #persist(Object) persisting} are often done together.
      */

--- a/core/config/src/main/java/org/apache/isis/config/ConfigurationConstants.java
+++ b/core/config/src/main/java/org/apache/isis/config/ConfigurationConstants.java
@@ -28,10 +28,11 @@ import org.apache.isis.commons.internal.collections._Lists;
 
 public final class ConfigurationConstants {
 
-    public static final String ROOT = "isis.";
-
     public static final String LIST_SEPARATOR = ",";
     public static final String DELIMITER = ".";
+    public static final String ROOT_PREFIX = "isis";
+    public static final String ROOT = ROOT_PREFIX + DELIMITER;
+
     public static final String DEFAULT_CONFIG_DIRECTORY = "config";
     public static final String WEBINF_DIRECTORY = "WEB-INF";
     public static final String WEBINF_FULL_DIRECTORY = "src/main/webapp/" + WEBINF_DIRECTORY;
@@ -43,8 +44,6 @@ public final class ConfigurationConstants {
 
         public static final class Reflector {
 
-            public static final String explicitAnnotationsForActions = 
-                    ROOT + "reflector.explicitAnnotations.action";
 
             public static final String viewModelSemanticCheckingFacetFactoryEnable = 
                     ROOT + "reflector.facets.ViewModelSemanticCheckingFacetFactory.enable";

--- a/core/config/src/main/java/org/apache/isis/config/IsisConfigModule.java
+++ b/core/config/src/main/java/org/apache/isis/config/IsisConfigModule.java
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.isis.config;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "module")
+public class IsisConfigModule {
+
+}

--- a/core/config/src/main/java/org/apache/isis/config/IsisConfigProperties.java
+++ b/core/config/src/main/java/org/apache/isis/config/IsisConfigProperties.java
@@ -1,0 +1,62 @@
+package org.apache.isis.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(ConfigurationConstants.ROOT_PREFIX)
+public class IsisConfigProperties {
+
+    @Getter
+    private final Reflector reflector = new Reflector();
+    public static class Reflector {
+
+        @Getter
+        private final ExplicitAnnotations explicitAnnotations = new ExplicitAnnotations();
+        public static class ExplicitAnnotations {
+
+            /**
+             * Whether or not a public method needs to be annotated with
+             * @{@link org.apache.isis.applib.annotation.Action} in order to be picked up as an action in the metamodel.
+             */
+            @Getter @Setter
+            private boolean action = false;
+        }
+    }
+
+    @Getter
+    private final Services services = new Services();
+    public static class Services {
+
+        @Getter
+        private final Services.Container container = new Services.Container();
+
+        public static class Container {
+
+            /**
+             * Normally any queries are automatically preceded by flushing pending executions.
+             *
+             * <p>
+             * This key allows this behaviour to be disabled.
+             *
+             * <p>
+             *     Originally introduced as part of ISIS-1134 (fixing memory leaks in the objectstore)
+             *     where it was found that the autoflush behaviour was causing a (now unrepeatable)
+             *     data integrity error (see <a href="https://issues.apache.org/jira/browse/ISIS-1134?focusedCommentId=14500638&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14500638">ISIS-1134 comment</a>, in the isis-module-security.
+             *     However, that this could be circumvented by removing the call to flush().
+             *     We don't want to break existing apps that might rely on this behaviour, on the
+             *     other hand we want to fix the memory leak.  Adding this configuration property
+             *     seems the most prudent way forward.
+             * </p>
+             */
+            @Getter @Setter
+            private boolean disableAutoFlush = false;
+
+        }
+    }
+
+    
+}

--- a/core/metamodel/src/main/java/org/apache/isis/metamodel/services/repository/RepositoryServiceJdo.java
+++ b/core/metamodel/src/main/java/org/apache/isis/metamodel/services/repository/RepositoryServiceJdo.java
@@ -33,6 +33,7 @@ import org.apache.isis.applib.RepositoryException;
 import org.apache.isis.applib.query.Query;
 import org.apache.isis.applib.query.QueryFindAllInstances;
 import org.apache.isis.applib.services.factory.FactoryService;
+import org.apache.isis.config.IsisConfigProperties;
 import org.apache.isis.applib.services.repository.RepositoryService;
 import org.apache.isis.applib.services.wrapper.WrapperFactory;
 import org.apache.isis.applib.services.xactn.TransactionService;
@@ -41,17 +42,17 @@ import org.apache.isis.metamodel.adapter.ObjectAdapter;
 import org.apache.isis.metamodel.adapter.ObjectAdapterProvider;
 import org.apache.isis.metamodel.services.persistsession.PersistenceSessionServiceInternal;
 
-import static org.apache.isis.config.internal._Config.getConfiguration;
-
 @Singleton
 public class RepositoryServiceJdo implements RepositoryService {
 
     private boolean autoFlush;
 
+    @Inject
+    IsisConfigProperties isisConfigProperties;
 
     @PostConstruct
     public void init() {
-        final boolean disableAutoFlush = getConfiguration().getBoolean(KEY_DISABLE_AUTOFLUSH, false);
+        final boolean disableAutoFlush = isisConfigProperties.getServices().getContainer().isDisableAutoFlush();
         this.autoFlush = !disableAutoFlush;
     }
 

--- a/core/metamodel/src/main/java/org/apache/isis/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
+++ b/core/metamodel/src/main/java/org/apache/isis/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
@@ -20,18 +20,15 @@
 package org.apache.isis.metamodel.specloader.specimpl;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.commons.exceptions.IsisException;
 import org.apache.isis.commons.internal.collections._Lists;
 import org.apache.isis.commons.internal.collections._Sets;
-import org.apache.isis.config.ConfigurationConstants;
-import org.apache.isis.config.internal._Config;
+import org.apache.isis.commons.internal.context._Context;
+import org.apache.isis.commons.internal.ioc.spring._Spring;
+import org.apache.isis.config.IsisConfigProperties;
 import org.apache.isis.metamodel.commons.ListExtensions;
 import org.apache.isis.metamodel.commons.MethodUtil;
 import org.apache.isis.metamodel.commons.ToString;
@@ -159,8 +156,8 @@ public class FacetedMethodsBuilder {
         this.facetProcessor = facetedMethodsBuilderContext.facetProcessor;
         this.specificationLoader = facetedMethodsBuilderContext.specificationLoader;
 
-        this.explicitAnnotationsForActions = _Config.getConfiguration()
-                .getBoolean(ConfigurationConstants.Keys.Reflector.explicitAnnotationsForActions);
+        final IsisConfigProperties isisConfigProperties = _Spring.getSingletonElseFail(IsisConfigProperties.class);
+        this.explicitAnnotationsForActions = isisConfigProperties.getReflector().getExplicitAnnotations().isAction();
 
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2101,6 +2101,18 @@
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- OPTIONAL -->
+
+		<!-- IDE support -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<version>${spring-boot.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+
 	</dependencies>
 
 	<profiles>

--- a/core/runtime-extensions/src/main/java/org/apache/isis/runtime/spring/IsisBoot.java
+++ b/core/runtime-extensions/src/main/java/org/apache/isis/runtime/spring/IsisBoot.java
@@ -18,6 +18,7 @@
  */
 package org.apache.isis.runtime.spring;
 
+import org.apache.isis.config.IsisConfigModule;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -37,6 +38,7 @@ import org.apache.isis.wrapper.IsisWrapperModule;
 @ComponentScan(
         basePackageClasses= {
                 IsisApplibModule.class,
+                IsisConfigModule.class,
                 IsisMetamodelModule.class,
                 IsisRuntimeModule.class,
                 IsisRuntimeServicesModule.class,

--- a/examples/apps/helloworld/src/main/java/domainapp/application/isis-non-changing.properties
+++ b/examples/apps/helloworld/src/main/java/domainapp/application/isis-non-changing.properties
@@ -33,7 +33,6 @@ isis.reflector.facet.cssClassFa.patterns=\
 isis.reflector.facet.cssClass.patterns=\
                         delete.*:btn-danger
 
-isis.reflector.explicitAnnotations.action=true
 
 isis.objects.editing=false
 

--- a/examples/apps/helloworld/src/main/resources/application.properties
+++ b/examples/apps/helloworld/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+
+#
+# moved from isis-non-changing.properties for demo purposes only
+# renamed to kebab-case, but the old camelCase is also recognised and supported.
+#
+# to test, try commenting out the @Action annotation on HelloWorld#updateName(...)
+# with this property set to either false or true.
+#
+
+isis.reflector.explicit-annotations.action=true


### PR DESCRIPTION
- First is "isis.services.container.disableAutoflush", which is used by RepositoryServiceJdo.  Here the config bean can be injected and consumed directly.
- Second is "isis.reflector.explicitAnnotations.action", which is used by FacetedMethodBuilder.  Here we use the _Spring.getSingleton service locator to read.

Note: just the start of a hole bunch of similar config conversion steps