### PR TITLE
ISIS-2356: fix broken links and anchors in docs

### DIFF
--- a/antora/components/comguide/modules/ROOT/pages/antora-publish-procedure.adoc
+++ b/antora/components/comguide/modules/ROOT/pages/antora-publish-procedure.adoc
@@ -12,7 +12,7 @@ There is relevant material in xref:post-release-successful.adoc[Post Release (Su
 
 
 
-Apache Isis' documentation (meaning the website and the users' guide, the reference guide and this contributors' guide) is written using link:https://asciidoctor.org/[Asciidoctor] syntax, and organized to be published as an link:https:antora.org[Antora] website.
+Apache Isis' documentation (meaning the website and the users' guide, the reference guide and this contributors' guide) is written using link:https://asciidoctor.org/[Asciidoctor] syntax, and organized to be published as an link:https://antora.org[Antora] website.
 
 The website and guides are created by running build tools (documented below) which create the HTML version of the site and guides.
 You can therefore easily check the documentation before raising a pull request (as a contributor) or publishing the site (if a committer).

--- a/antora/components/comguide/modules/ROOT/pages/verifying-releases.adoc
+++ b/antora/components/comguide/modules/ROOT/pages/verifying-releases.adoc
@@ -10,7 +10,7 @@ The release process consists of:
 
 * the release manager xref:comguide:ROOT:cutting-a-release.adoc[cutting the release]
 * members of the Apache Isis PMC verifying and voting on the release (documented below)
-* the release manager performing post-release tasks, for either a xref:comguide:ROOT:post-release-successful.adoc.adoc[successful] or an xref:comguide:ROOT:post-release-unsuccessful[unsuccessful] vote.
+* the release manager performing post-release tasks, for either a xref:comguide:ROOT:post-release-successful.adoc[successful] or an xref:comguide:ROOT:post-release-unsuccessful.adoc[unsuccessful] vote.
 
 This section describes some guidance on what a voter (members of the Apache Isis PMC and anyone else who wishes) is expected to do before casting their vote in order to verify a release.
 

--- a/antora/components/docs/modules/ROOT/pages/going-deeper/articles-and-presentations.adoc
+++ b/antora/components/docs/modules/ROOT/pages/going-deeper/articles-and-presentations.adoc
@@ -74,7 +74,7 @@ Slides available *link:http://www.danhaywood.com/spa2016/#/[here]*
 * *Article, Methods and Tools: link:http://www.methodsandtools.com/archive/archive.php?id=97[An Introduction to Domain Driven Design]*
 * Presentation, Skillsmatter: link:http://skillsmatter.com/podcast/design-architecture/exploring-domains-and-collaborating-with-domain-experts[Exploring Domains and Collaborating with Domain Experts] (1 hr video)
 * Article, PragPub: link:http://pragprog.com/magazines/2009-12[Going Naked]
-* *Book: xref:docs:ROOT:books/books.adoc#__books_DDD-using-NO[Domain Driven Design using Naked Objects], Dan Haywood*
+* *Book: xref:docs:ROOT:going-deeper/books.adoc#domain-driven-design-using-naked-objects[Domain Driven Design using Naked Objects], Dan Haywood*
 
 
 == 2008:
@@ -95,4 +95,4 @@ Slides available *link:http://www.danhaywood.com/spa2016/#/[here]*
 
 == 2002:
 
-* *Book: xref:docs:ROOT:books/books.adoc#__books_Naked-Objects[Naked Objects], Richard Pawson and Robert Matthews.*
+* *Book: xref:docs:ROOT:going-deeper/books.adoc#naked-objects[Naked Objects], Richard Pawson and Robert Matthews.*

--- a/antora/components/docs/modules/ROOT/pages/going-deeper/books.adoc
+++ b/antora/components/docs/modules/ROOT/pages/going-deeper/books.adoc
@@ -10,6 +10,7 @@ Indeed, the generic user interfaces provided by Apache Isis xref:vw:ROOT:about.a
 
 If the idea of naked objects is of interest, then there are a couple of books on the topic that you might want to read.
 
+[#naked-objects]
 == Naked Objects
 
 Richard Pawson and Robert Matthews, Wiley 2002
@@ -32,6 +33,7 @@ The book is freely available online http://www.nakedobjects.org/book/[here]. Or,
 
 
 
+[#domain-driven-design-using-naked-objects]
 == Domain Driven Design using Naked Objects
 
 Dan Haywood, Pragmatic Bookshelf 2009

--- a/api/adoc/userguide/modules/fun/pages/concepts-patterns/architecture.adoc
+++ b/api/adoc/userguide/modules/fun/pages/concepts-patterns/architecture.adoc
@@ -87,7 +87,7 @@ Mixins can also contribute read-only properties or collections: effectively the 
 In other words, we can dissociate behaviour from data.
 
 That's not always the right thing to do of course.
-In Richard Pawson's description of the xref:userguide:fun:concepts-patterns.adoc#naked-objects-pattern.adoc[naked objects pattern] he talks about "behaviourally rich" objects, in other words where the business functionality encapsulates the data.
+In Richard Pawson's description of the xref:userguide:fun:concepts-patterns.adoc#naked-objects-pattern[naked objects pattern] he talks about "behaviourally rich" objects, in other words where the business functionality encapsulates the data.
 But on the other hand sometimes the behaviour and data structures change at different rates.
 The link:http://en.wikipedia.org/wiki/Single_responsibility_principle[single responsibility principle] says we should only lump code together that changes at the same rate.
 Apache Isis' support for contributions (not only contributed actions, but also contributed properties and contributed collections) enables this.

--- a/api/applib/src/main/adoc/modules/applib-svc/pages/RoutingService.adoc
+++ b/api/applib/src/main/adoc/modules/applib-svc/pages/RoutingService.adoc
@@ -51,7 +51,7 @@ The framework provides a default implementation - `o.a.i.runtimeservices.routing
 Under the covers it uses the xref:refguide:applib-svc:HomePageResolverService.adoc[`HomePageResolverService`].
 
 There can be multiple implementations of `RoutingService` registered.
-These are checked in turn (chain of responsibility pattern), ordered according to the Spring link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation or equivalent (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services.adoc[introduction] to this guide).
+These are checked in turn (chain of responsibility pattern), ordered according to the Spring link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation or equivalent (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services[introduction] to this guide).
 The route from the first service that returns `true` from its `canRoute(...)` method will be used.
 
 

--- a/api/applib/src/main/adoc/modules/applib-svc/pages/SudoService.adoc
+++ b/api/applib/src/main/adoc/modules/applib-svc/pages/SudoService.adoc
@@ -31,7 +31,7 @@ The current user/role reported by the internal xref:core:runtime-services:Authen
 [IMPORTANT]
 ====
 Note that this the "effective user" does not propagate through to the xref:security:ROOT:about.adoc[Shiro security mechanism], which will continue to be evaluated according to the permissions of the current user.
-See the xref:refguide:applib-svc:SudoService.adoc#ACCESS-ALL-ROLE[`ACCESS-ALL-ROLE`] below for details of how to circumvent this.
+See the xref:refguide:applib-svc:SudoService.adoc#access_all_role[`ACCESS-ALL-ROLE`] below for details of how to circumvent this.
 ====
 
 
@@ -61,6 +61,7 @@ protected void execute(final ExecutionContext ec) {
 ----
 
 
+[#access_all_role]
 === ACCESS_ALL_ROLE
 
 When `sudo(...)` is called the "effective user" is reported by both xref:refguide:applib-svc:UserService.adoc[`UserService`] and by xref:core:runtime-services:AuthenticationSessionProvider.adoc[`AuthenticationSessionProvider`], but does not propagate through to the xref:security:ROOT:about.adoc[Shiro security mechanism].

--- a/api/applib/src/main/adoc/modules/applib-svc/pages/TableColumnOrderService.adoc
+++ b/api/applib/src/main/adoc/modules/applib-svc/pages/TableColumnOrderService.adoc
@@ -30,7 +30,7 @@ If all provided implementations return `null`, then the framework will fallback 
 The framework provides a fallback implementation of this service, namely `TableColumnOrderService.Default`.
 
 There can be multiple implementations of `TableColumnOrderService registered.
-These are checked in turn (chain of responsibility pattern), ordered according to the Spring link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`Order`] annotation, or equivalent (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services.adoc[introduction] to this guide).
+These are checked in turn (chain of responsibility pattern), ordered according to the Spring link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`Order`] annotation, or equivalent (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services[introduction] to this guide).
 The order from the first service that returns a non null value will be used.
 
 

--- a/api/applib/src/main/adoc/modules/applib-svc/pages/_BackgroundService.adoc
+++ b/api/applib/src/main/adoc/modules/applib-svc/pages/_BackgroundService.adoc
@@ -37,7 +37,7 @@ public interface BackgroundService {
 
 The default implementation is provided by core (`o.a.i.core.runtime.services.background.BackgroundServiceDefault`).
 
-To provide an alternative implementation, subclass and link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] or equivalent (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services.adoc[introduction] to this guide).
+To provide an alternative implementation, subclass and link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] or equivalent (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services[introduction] to this guide).
 
 
 == Usage

--- a/api/applib/src/main/adoc/modules/applib-svc/pages/about.adoc
+++ b/api/applib/src/main/adoc/modules/applib-svc/pages/about.adoc
@@ -91,6 +91,7 @@ For transient objects (instantiated programmatically), the xref:refguide:applib-
 
 Alternatively the object can be instantiated simply using `new`, then services injected using xref:refguide:applib-svc:ServiceRegistry.adoc[`ServiceRegistry`]'s ``injectServicesInto(...)`` method.
 
+[#overriding-the-services]
 == Overriding the services
 
 The framework provides default implementations for many of the domain services.
@@ -163,7 +164,7 @@ In the majority of cases there is likely to be just a single top-level node of t
 * before and after each action invocation/property edit, a xref:applib-classes:classes/domainevent.adoc[domain event] is may be broadcast to all subscribers.
 Whether this occurs depends on whether the action/property has been annotated (using xref:refguide:applib-ant:Action.adoc#domainEvent[`@Action#domainEvent()`] or xref:refguide:applib-ant:Property.adoc#domainEvent[`@Property#domainEvent()`]).
 +
-(Note that susbcribers will also receive events for vetoing the action/property; this is not shown on the diagram).
+(Note that subscribers will also receive events for vetoing the action/property; this is not shown on the diagram).
 
 * As each execution progresses, and objects that are modified are "enlisted" into the (internal) xref:core:runtime-services:ChangedObjectsServiceInternal.adoc[`ChangedObjectsServiceInternal`] domain service.
 Metrics as to which objects are merely loaded into memory are also captured using the xref:refguide:applib-svc:MetricsService.adoc[`MetricsService`] (not shown on the diagram).

--- a/api/schema/src/main/adoc/modules/schema/pages/chg.adoc
+++ b/api/schema/src/main/adoc/modules/schema/pages/chg.adoc
@@ -53,7 +53,7 @@ Although URIs are not the same as URLs, you will find that the schemas are also 
 The corresponding XML will use this as its top-level element.
 <4> each instance of this schema indicates the version of the schema it is compatible with (following semantic versioning)
 <5> unique identifier for the transaction in which this interaction is being executed.
-The transaction Id is used to correlate back to the xref:refguide:schema:command[command] that represented the intention to perform this execution, as well as to the xref:refguide:schema:about.adoc#interaction.adoc[interaction] that executes said command.
+The transaction Id is used to correlate back to the xref:refguide:schema:cmd.adoc[command] that represented the intention to perform this execution, as well as to the xref:refguide:schema:ixn.adoc[interaction] that executes said command.
 <6> uniquely identifies this set of changes within the interaction.
 Can be combined with `transactionId` to create a unique identifier (across all other changed object events and also any interaction executions) of this particular set of changed objects.
 <7> the date/time that the transaction that dirtied this objects completed

--- a/api/schema/src/main/adoc/modules/schema/pages/cmd.adoc
+++ b/api/schema/src/main/adoc/modules/schema/pages/cmd.adoc
@@ -67,7 +67,7 @@ Although URIs are not the same as URLs, you will find that the schemas are also 
 The corresponding XML will use this as its top-level element.
 <4> each instance of this schema indicates the version of the schema it is compatible with (following semantic versioning)
 <5> unique identifier for the transaction in which this command is created.
-The transaction Id is used to correlate to the xref:refguide:schema:interaction[interaction] that executes the command, and to any xref:refguide:schema:about.adoc#changes.adoc[changes] to domain objects occurring as a side-effect of that interaction.
+The transaction Id is used to correlate to the xref:refguide:schema:ixn.adoc[interaction] that executes the command, and to any xref:refguide:schema:chg.adoc[changes] to domain objects occurring as a side-effect of that interaction.
 <6> the name of the user who created the command (whose intention it is to invoke the action/edit the property).
 <7> the target object (or objects) to be invoked.
 A bulk action will create multiple commands, each with only a single target.

--- a/core/runtimeservices/src/main/adoc/modules/runtime-services/pages/ContentNegotiationService.adoc
+++ b/core/runtimeservices/src/main/adoc/modules/runtime-services/pages/ContentNegotiationService.adoc
@@ -195,7 +195,7 @@ If the property is not set, then the default depends on the xref:refguide:config
 
 Apache Isis' default implementations of `ContentNegotiationService` service are automatically registered and injected (it is annotated with `@DomainService`) so no further configuration is required.
 
-To use an alternative implementation, use Spring's link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services.adoc[introduction] to this guide).
+To use an alternative implementation, use Spring's link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services[introduction] to this guide).
 
 
 

--- a/core/runtimeservices/src/main/adoc/modules/runtime-services/pages/PublisherDispatchService.adoc
+++ b/core/runtimeservices/src/main/adoc/modules/runtime-services/pages/PublisherDispatchService.adoc
@@ -40,7 +40,7 @@ The service implementation is `o.a.i.c.m.s.publishing.PublisherDispatchService`.
 
 Apache Isis' default implementation of `PublisherDispatchService` class is automatically registered (it is annotated with `@DomainService`) so no further configuration is required.
 
-To use an alternative implementation, use Spring's link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services.adoc[introduction] to this guide).
+To use an alternative implementation, use Spring's link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services[introduction] to this guide).
 
 
 == Related Classes

--- a/core/runtimeservices/src/main/adoc/modules/runtime-services/pages/RepresentationService.adoc
+++ b/core/runtimeservices/src/main/adoc/modules/runtime-services/pages/RepresentationService.adoc
@@ -79,7 +79,7 @@ ie `MemberReprMode`
 As discussed in the introduction, the framework provides a default implementation, `o.a.i.v.ro.rendering.service.RepresentationServiceContentNegotiator`.
 This delegates to xref:core:runtime-services:ContentNegotiationService.adoc[`ContentNegotiationService`] to generate an alternative representation; but if none is provided then it falls back on generating the representations as defined in the link:http://restfulobjects.org[Restful Objects spec] v1.0.
 
-To use an alternative implementation, use Spring's link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services.adoc[introduction] to this guide).
+To use an alternative implementation, use Spring's link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/Order.html[`@Order`] annotation (as explained in the xref:refguide:applib-svc:about.adoc#overriding-the-services[introduction] to this guide).
 
 
 == Registering the Services

--- a/testing/adoc/modules/ROOT/pages/about.adoc
+++ b/testing/adoc/modules/ROOT/pages/about.adoc
@@ -133,7 +133,7 @@ This defines a pattern (command pattern and composite pattern) with supporting c
 
 include::testing:fakedata:partial$intro.adoc[]
 
-Apache Isis provides the link:testing:fakedata:about.adoc[Fake Data] library to assist with this.
+Apache Isis provides the xref:testing:fakedata:about.adoc[Fake Data] library to assist with this.
 
 [TIP]
 ====

--- a/viewers/wicket/adoc/modules/ROOT/pages/extending/replacing-page-elements.adoc
+++ b/viewers/wicket/adoc/modules/ROOT/pages/extending/replacing-page-elements.adoc
@@ -35,7 +35,7 @@ There will typically be only one `ComponentFactory` capable of rendering a parti
 
 [NOTE]
 ====
-There is one refinement to the above algorithm where multiple component factories might be used to render an object; this is discussed in xref:vw:ROOT:extending/replacing-page-elements.adoc#collections[Additional Views of Collections], below.
+There is one refinement to the above algorithm where multiple component factories might be used to render an object; this is discussed in xref:vw:ROOT:extending/replacing-page-elements.adoc#additional-views-of-collections[Additional Views of Collections], below.
 ====
 
 
@@ -129,6 +129,7 @@ public class MyAppApplication extends IsisWicketApplication {
 
 
 
+[#additional-views-of-collections]
 == Additional Views of Collections
 
 As explained above, in most cases Apache Isis' Wicket viewer will search for the first `ComponentFactory` that can render an element, and use it.


### PR DESCRIPTION
For the AsciiDoc plugin for IntelliJ I'm currently implementing a link checker for xrefs and anchors and I used the Apache Isis project to "train" it.

This PR fixes some of the links I was able to fix from their respective contexts. Please double-check if I chose the correct target for each link.

To find more broken links, install the latest IntelliJ plugin for AsciiDoc (0.30.56+) and run "Analyze | Inspect code...". I found it helpful to setup an inspection profile for only AsciiDoc checks.

(cc: @danhaywood) 