### PR TITLE
JAXB Gradle plugin implementation

### DIFF
--- a/api/schema/build.gradle
+++ b/api/schema/build.gradle
@@ -1,11 +1,17 @@
+plugins {
+    id "org.openrepose.gradle.plugins.jaxb" version "2.5.0"
+}
 description = 'Apache Isis Core - Schemas'
-apply plugin: 'war'
+apply plugin: 'java-library'
 apply plugin: 'io.freefair.lombok'
+
+def episodesDir = "${project.buildDir}/generated-sources/xjc/META-INF"
+def javaVersion = JavaVersion.current()
 
 sourceSets {
     main {
         java {
-            srcDir 'target/generated-sources/xjc'
+            srcDirs += "${buildDir}/generated-sources/xjc"
         }
     }
 }
@@ -15,11 +21,20 @@ dependencies {
 
     compile(Libs.springContext)
     compile(Libs.jodaTime)
-
-    // These dependencies are required in order to build on jdk11
-    compile(Libs.jaxbApi)  // not set in POM`s ??
-    compile(Libs.jaxbCore)
-    compile(Libs.jaxbImpl)
+    
+    if (javaVersion > JavaVersion.VERSION_1_8) {
+    // These dependencies are required in order to build on jdk versions > 1.8
+    	api(Libs.jaxbApi)
+    	implementation(Libs.jaxbImpl)
+    	implementation(Libs.jaxbCore)
+    }
+    
+    // jaxb plugin dependencies
+    jaxb(Libs.jaxbApi)
+    jaxb(Libs.jaxbCore)
+    jaxb(Libs.jaxbImpl)
+    jaxb(Libs.jaxbXjc)
+    jaxb("org.jvnet.jaxb2_commons:jaxb2-namespace-prefix:1.3")
 }
 
 task packageTests(type: Jar) {
@@ -27,3 +42,34 @@ task packageTests(type: Jar) {
     classifier = 'tests'
 }
 artifacts.archives packageTests
+
+jaxb {
+	xsdDir = "${project.projectDir}/src/main/resources/org/apache/isis/schema"
+ 	xsdIncludes = ['**/*.xsd']
+ 	bindingsDir = "${project.projectDir}/src/main/resources/org/apache/isis/schema"
+ 	bindings = ['*.xml']
+ 	xjc {
+ 		accessExternalSchema = 'file'
+ 		args = ["-Xnamespace-prefix"]
+ 	}
+}
+
+xjc.configure {
+	doLast {
+	  	mkdir "${episodesDir}"
+	  	copy {
+		    from file("${project.buildDir}/generated-resources/episodes/isis.apache.org-schema-common.episode")
+		    into "${episodesDir}"
+		}
+	}
+}
+
+compileJava {
+	dependsOn xjc
+}
+
+// required due to bug 
+// https://github.com/rackerlabs/gradle-jaxb-plugin/issues/36
+tasks.named("xsd-dependency-tree").configure {
+    outputs.upToDateWhen { false }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,11 @@ buildscript {
 }
 
 apply from: './dependencies.gradle'
+def javaVersion = JavaVersion.current()
+
+task test {
+	println "Using JDK version: $javaVersion"
+}
 
 allprojects {
     apply plugin: "io.freefair.lombok"

--- a/core/metamodel/build.gradle
+++ b/core/metamodel/build.gradle
@@ -1,10 +1,18 @@
 description = 'Apache Isis Core - MetaModel'
 
 sourceSets {
+	main {
+        resources {
+            srcDirs += "src/main/java"
+            include "**/*"
+            exclude "**/*.java"
+        }
+    }
     test {
         resources {
             srcDirs += "src/test/java"
-            include "**/*.xml" 
+            include "**/*"
+            exclude "**/*.java"
         }
     }
 }

--- a/core/metamodel/build.gradle
+++ b/core/metamodel/build.gradle
@@ -1,4 +1,14 @@
 description = 'Apache Isis Core - MetaModel'
+
+sourceSets {
+    test {
+        resources {
+            srcDirs += "src/test/java"
+            include "**/*.xml" 
+        }
+    }
+}
+
 dependencies {
     compile project(':isis-parent:isis-applib')
     compile project(':isis-parent:isis:isis-core-config')

--- a/core/runtimeservices/build.gradle
+++ b/core/runtimeservices/build.gradle
@@ -1,4 +1,10 @@
 description = 'Apache Isis Core - Runtime Services'
+
+sourceSets.test.resources { 
+	srcDirs = ["src/test/java"]
+	include "**/*.*" 
+}
+
 dependencies {
     compile project(':isis-parent:isis:isis-core-runtime')
     compile project(':isis-parent:isis:isis-core-codegen-bytebuddy')

--- a/subdomains/xdocreport/applib/src/test/java/org/apache/isis/subdomains/xdocreport/applib/service/XDocReportServiceTest.java
+++ b/subdomains/xdocreport/applib/src/test/java/org/apache/isis/subdomains/xdocreport/applib/service/XDocReportServiceTest.java
@@ -69,6 +69,7 @@ public class XDocReportServiceTest {
         final byte[] docxBytes = service.render(templateBytes, dataModel, OutputType.DOCX);
 
         // then
+        new File("target").mkdir(); // create the target folder if needed [gradle]
         IOUtils.write(docxBytes,new FileOutputStream(new File("target/Project.docx")));
     }
 

--- a/testing/fakedata/applib/build.gradle
+++ b/testing/fakedata/applib/build.gradle
@@ -1,5 +1,11 @@
 group = 'org.apache.isis.testing'
 description = 'Apache Isis Tst - FakeData (applib)'
+
+sourceSets.main.resources { 
+	srcDirs = ["src/main/java"]
+	include "**/*.*" 
+}
+
 dependencies {
     compile project(':isis-parent:isis-applib')
     compile(Libs.javafaker) {


### PR DESCRIPTION
Adds XJC task for jaxb in shema project.
Also, in a few projects, adds non-java resources from `src/main/java` to build folder [gradle] as they are excluded by default.