### PR TITLE
chore: fix case of JavaScript and TypeScript

### DIFF
--- a/antora/components/docs/modules/ROOT/pages/what-is-apache-isis/powered-by/gesconsultor-grc.adoc
+++ b/antora/components/docs/modules/ROOT/pages/what-is-apache-isis/powered-by/gesconsultor-grc.adoc
@@ -44,7 +44,7 @@ Alternatively, a custom drag-n-drop visual interface can be used:
 
 image::what-is-apache-isis/powered-by/gesconsultor-grc/fig-2-custom-drag-n-drop-interface.png[width="800px"]
 
-This is implemented with the Dojo javascript library, interfacing to Apache Isis-managed domain objects.
+This is implemented with the Dojo JavaScript library, interfacing to Apache Isis-managed domain objects.
 
 
 

--- a/antora/components/refguide-index/modules/_overview/pages/about.adoc
+++ b/antora/components/refguide-index/modules/_overview/pages/about.adoc
@@ -33,7 +33,7 @@ package "App\n[Software System]" {
 .Projects/Modules (App)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Starter Parent
 [source,yaml]
@@ -126,7 +126,7 @@ package "Mavendeps\n[Software System]" {
 .Projects/Modules (Mavendeps)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Maven Deps
 [source,yaml]
@@ -408,7 +408,7 @@ package "Testing\n[Software System]" {
 .Projects/Modules (Testing)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Testing
 [source,yaml]
@@ -767,7 +767,7 @@ package "Examples\n[Software System]" {
 .Projects/Modules (Examples)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Demo - Parent
 [source,yaml]
@@ -1134,7 +1134,7 @@ package "Root\n[Software System]" {
 .Projects/Modules (Root)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis (Aggregator)
 [source,yaml]
@@ -1213,7 +1213,7 @@ package "Commons\n[Software System]" {
 .Projects/Modules (Commons)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Commons
 [source,yaml]
@@ -1369,7 +1369,7 @@ package "Core\n[Software System]" {
 .Projects/Modules (Core)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Core
 [source,yaml]
@@ -1891,7 +1891,7 @@ package "JDO\n[Software System]" {
 .Projects/Modules (JDO)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Persistence - JDO
 [source,yaml]
@@ -2115,7 +2115,7 @@ package "JPA\n[Software System]" {
 .Projects/Modules (JPA)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Persistence - JPA
 [source,yaml]
@@ -2248,7 +2248,7 @@ package "Security\n[Software System]" {
 .Projects/Modules (Security)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Security - Spring
 [source,yaml]
@@ -2309,7 +2309,7 @@ package "Bypass\n[Software System]" {
 .Projects/Modules (Bypass)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Security - Bypass
 [source,yaml]
@@ -2366,7 +2366,7 @@ package "Keycloak\n[Software System]" {
 .Projects/Modules (Keycloak)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Security - Keycloak
 [source,yaml]
@@ -2429,7 +2429,7 @@ package "Shiro\n[Software System]" {
 .Projects/Modules (Shiro)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Security - Shiro
 [source,yaml]
@@ -2494,7 +2494,7 @@ package "Viewer\n[Software System]" {
 .Projects/Modules (Viewer)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Viewer - Common Model
 [source,yaml]
@@ -2585,7 +2585,7 @@ package "Restful Objects\n[Software System]" {
 .Projects/Modules (Restful Objects)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Viewer - RO
 [source,yaml]
@@ -2793,7 +2793,7 @@ package "Wicket\n[Software System]" {
 .Projects/Modules (Wicket)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Viewer - Wicket
 [source,yaml]
@@ -2978,7 +2978,7 @@ package "Valuetypes\n[Software System]" {
 .Projects/Modules (Valuetypes)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Value types
 [source,yaml]
@@ -3164,7 +3164,7 @@ package "Asciidoc\n[Software System]" {
 .Projects/Modules (Asciidoc)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Val - Asciidoctor (parent)
 [source,yaml]
@@ -3392,7 +3392,7 @@ package "Markdown\n[Software System]" {
 .Projects/Modules (Markdown)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Val - Markdown (parent)
 [source,yaml]
@@ -3549,7 +3549,7 @@ package "Mappings\n[Software System]" {
 .Projects/Modules (Mappings)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Mappings
 [source,yaml]
@@ -3612,7 +3612,7 @@ package "JAX-RS Client Library\n[Software System]" {
 .Projects/Modules (JAX-RS Client Library)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Map - JaxRS Client (parent)
 [source,yaml]
@@ -3694,7 +3694,7 @@ package "REST Client\n[Software System]" {
 .Projects/Modules (REST Client)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Ext - REST Client (parent)
 [source,yaml]
@@ -3912,7 +3912,7 @@ package "Extensions\n[Software System]" {
 .Projects/Modules (Extensions)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Extensions
 [source,yaml]
@@ -4031,7 +4031,7 @@ Artifact: isis-extensions-fullcalendar
 Type: pom
 Directory: /extensions/vw/fullcalendar
 ----
-|A component for Apache Isis' Wicket viewer, displaying collections of objects that have a date on a fullcalendar.io (javascript widget).
+|A component for Apache Isis' Wicket viewer, displaying collections of objects that have a date on a fullcalendar.io (JavaScript widget).
 
 |Apache Isis Ext - Wicket Viewer - fullcalendar (applib)
 [source,yaml]
@@ -4381,7 +4381,7 @@ package "Core: Command Log\n[Software System]" {
 .Projects/Modules (Core: Command Log)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Ext - Command Log
 [source,yaml]
@@ -4471,7 +4471,7 @@ package "Core: Command Replay\n[Software System]" {
 .Projects/Modules (Core: Command Replay)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Ext - Command Replay
 [source,yaml]
@@ -4585,7 +4585,7 @@ package "Core: Model Annotation\n[Software System]" {
 .Projects/Modules (Core: Model Annotation)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Ext - @Model
 [source,yaml]
@@ -4652,7 +4652,7 @@ package "Core: Quartz\n[Software System]" {
 .Projects/Modules (Core: Quartz)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Ext - Quartz
 [source,yaml]
@@ -4798,7 +4798,7 @@ package "Subdomains\n[Software System]" {
 .Projects/Modules (Subdomains)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Subdomains
 [source,yaml]
@@ -4978,7 +4978,7 @@ package "Base\n[Software System]" {
 .Projects/Modules (Base)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Sub - Base (parent)
 [source,yaml]
@@ -5076,7 +5076,7 @@ package "Excel\n[Software System]" {
 .Projects/Modules (Excel)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Sub - Excel (parent)
 [source,yaml]
@@ -5212,7 +5212,7 @@ package "Spring\n[Software System]" {
 .Projects/Modules (Spring)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Sub - Spring (parent)
 [source,yaml]
@@ -5286,7 +5286,7 @@ package "XDocReport\n[Software System]" {
 .Projects/Modules (XDocReport)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Sub - XdocReport (parent)
 [source,yaml]
@@ -5401,7 +5401,7 @@ package "Tooling\n[Software System]" {
 .Projects/Modules (Tooling)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis - Tooling
 [source,yaml]
@@ -5580,7 +5580,7 @@ package "Regression Tests\n[Software System]" {
 .Projects/Modules (Regression Tests)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis - Regression Tests
 [source,yaml]
@@ -5682,7 +5682,7 @@ package "Incubator\n[Software System]" {
 .Projects/Modules (Incubator)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Incubator
 [source,yaml]
@@ -5730,7 +5730,7 @@ package "Kroviz Client\n[Software System]" {
 .Projects/Modules (Kroviz Client)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Inc - Client kroViz
 [source,yaml]
@@ -5794,7 +5794,7 @@ package "JavaFX Viewer\n[Software System]" {
 .Projects/Modules (JavaFX Viewer)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Inc - Viewer JavaFX
 [source,yaml]
@@ -5927,7 +5927,7 @@ package "Vaadin Viewer\n[Software System]" {
 .Projects/Modules (Vaadin Viewer)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Inc - Viewer Vaadin
 [source,yaml]
@@ -6067,7 +6067,7 @@ package "Legacy\n[Software System]" {
 .Projects/Modules (Legacy)
 [cols="3a,5a", options="header"]
 |===
-|Coordinates |Description 
+|Coordinates |Description
 
 |Apache Isis Legacy
 [source,yaml]

--- a/examples/demo/wicket/e2e-notes.adoc
+++ b/examples/demo/wicket/e2e-notes.adoc
@@ -37,7 +37,7 @@ npm run cypress:open
 
 * moved the scaffolding to `cypress-scaffolding` for reference
 +
-NOTE: it uses javascript rather than typescript.
+NOTE: it uses JavaScript rather than TypeScript.
 
 == Tab support (plugin)
 

--- a/examples/demo/wicket/src/test/e2e/cypress-scaffolding/integration/typescript/basic.ts
+++ b/examples/demo/wicket/src/test/e2e/cypress-scaffolding/integration/typescript/basic.ts
@@ -1,4 +1,4 @@
-describe('learning typescript', () => {
+describe('learning TypeScript', () => {
 
     it('should perform basic google search', () => {
         cy.visit('https://google.com');

--- a/examples/demo/wicket/src/test/e2e/tsconfig.json
+++ b/examples/demo/wicket/src/test/e2e/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["dom","es6"],                     /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "allowJs": true,                       /* Allow JavaScript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */

--- a/extensions/vw/fullcalendar/pom.xml
+++ b/extensions/vw/fullcalendar/pom.xml
@@ -32,7 +32,7 @@
     <packaging>pom</packaging>
 
     <description>
-        A component for Apache Isis' Wicket viewer, displaying collections of objects that have a date on a fullcalendar.io (javascript widget).
+        A component for Apache Isis' Wicket viewer, displaying collections of objects that have a date on a fullcalendar.io (JavaScript widget).
     </description>
 
     <modules>

--- a/extensions/vw/pdfjs/ui/src/main/java/org/wicketstuff/pdfjs/res/pdf.js
+++ b/extensions/vw/pdfjs/ui/src/main/java/org/wicketstuff/pdfjs/res/pdf.js
@@ -2380,7 +2380,7 @@
             if (this._isInvalid || !this._scheme) {
               return '';
             }
-            // javascript: Gecko returns String(""), WebKit/Blink String("null")
+            // JavaScript: Gecko returns String(""), WebKit/Blink String("null")
             // Gecko throws error for "data://"
             // data: Gecko returns "", Blink returns "data://", WebKit returns "null"
             // Gecko returns String("") for file: mailto:

--- a/viewers/wicket/adoc/modules/ROOT/pages/customisation/auto-refresh.adoc
+++ b/viewers/wicket/adoc/modules/ROOT/pages/customisation/auto-refresh.adoc
@@ -22,7 +22,7 @@ public class MyDomainObject {
 }
 ----
 
-* Then, use javascript in `scripts/application.js` (under `src/main/webapp/`) to reload:
+* Then, use JavaScript in `scripts/application.js` (under `src/main/webapp/`) to reload:
 +
 [source,javascript]
 ----

--- a/viewers/wicket/adoc/modules/ROOT/pages/customisation/custom-javascript.adoc
+++ b/viewers/wicket/adoc/modules/ROOT/pages/customisation/custom-javascript.adoc
@@ -23,7 +23,7 @@ Currently only one such `.js` file can be registered.
 [WARNING]
 ====
 Just because something is possible, it doesn't necessarily mean we encourage it.
-Please be aware that there is no formal API for any custom javascript that you might implement to target; future versions of Apache Isis might break your code.
+Please be aware that there is no formal API for any custom JavaScript that you might implement to target; future versions of Apache Isis might break your code.
 
 As an alternative, consider using the `ComponentFactory` API described in the xref:vw:ROOT:extending.adoc[Extending] chapter.
 ====


### PR DESCRIPTION
Changes are:

- `javascript` -> `JavaScript`
- `typescript` -> `TypeScript`