### PR TITLE
ISIS-2346 - Tab Layout isn't using 100% Width

### DIFF
--- a/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/DropdownSearch.kt
+++ b/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/DropdownSearch.kt
@@ -26,7 +26,7 @@ import pl.treksoft.kvision.form.select.Select
 import pl.treksoft.kvision.utils.obj
 import pl.treksoft.kvision.utils.px
 import pl.treksoft.kvision.panel.SimplePanel
-import pl.treksoft.kvision.utils.px
+import pl.treksoft.kvision.utils.pc
 import kotlin.js.Date
 
 @Serializable
@@ -40,6 +40,7 @@ class DropdownSearch() : SimplePanel() {
     init {
         this.marginTop = 10.px
         this.marginLeft = 40.px
+        this.width = 100.pc
         val formPanel = formPanel<Form> {
             add(
                     Form::select, Select(

--- a/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/EventChart.kt
+++ b/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/EventChart.kt
@@ -22,6 +22,7 @@ import pl.treksoft.kvision.chart.*
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.obj
 import pl.treksoft.kvision.utils.px
+import pl.treksoft.kvision.utils.pc
 
 //IMPROVE https://github.com/datavisyn/chartjs-chart-box-and-violin-plot
 class EventChart(model: ChartModel) : SimplePanel() {
@@ -63,6 +64,7 @@ class EventChart(model: ChartModel) : SimplePanel() {
 
     init {
         this.marginTop = 10.px
+        this.width = 100.pc
         chart(
                 configuration = Configuration(
                         type = ChartType.BAR,

--- a/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/RoApp.kt
+++ b/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/RoApp.kt
@@ -20,14 +20,14 @@ package org.apache.isis.client.kroviz.ui.kv
 
 import pl.treksoft.kvision.panel.HPanel
 import pl.treksoft.kvision.panel.SimplePanel
-import pl.treksoft.kvision.utils.pc
+import pl.treksoft.kvision.utils.perc
 
 object RoApp : SimplePanel() {
     init {
         this.add(RoMenuBar.navbar)
 
         val view = HPanel(classes = setOf("main")) {
-            width = 100.pc
+            width = 100.perc
         }
         view.add(RoIconBar.panel)
         view.add(RoView.tabPanel)

--- a/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/RoTabPanel.kt
+++ b/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/ui/kv/RoTabPanel.kt
@@ -23,12 +23,12 @@ import pl.treksoft.kvision.core.UNIT
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.panel.TabPanel
 import pl.treksoft.kvision.panel.VPanel
-import pl.treksoft.kvision.utils.pc
+import pl.treksoft.kvision.utils.perc
 
 class RoTabPanel : TabPanel() {
 
     init {
-        width = 100.pc
+        width = 100.perc
         marginTop = CssSize(40, UNIT.px)
     }
 


### PR DESCRIPTION
The root width was previously set to 100pc, this caused the TabPanel to not be 100% width even if set to 100%. By setting both the root (RoApp) and TabPanel widths to 100% the Tab-layout now is in fact, 100% width.