### PR TITLE
ISIS-2063: Entering a string for a joda LocalTime causes an error

### DIFF
--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/jodatime/ConverterForJodaLocalTime.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/jodatime/ConverterForJodaLocalTime.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.isis.viewer.wicket.ui.components.scalars.jodatime;
+
+import org.apache.wicket.util.convert.ConversionException;
+import org.apache.wicket.util.convert.IConverter;
+import org.joda.time.LocalTime;
+
+import java.util.Locale;
+
+public class ConverterForJodaLocalTime implements IConverter<LocalTime> {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public LocalTime convertToObject(String value, Locale locale) throws ConversionException {
+        try {
+            return LocalTime.parse(value);
+        } catch (Exception e) {
+            throw new ConversionException("'" + value + "' is not a valid time.");
+        }
+    }
+    
+    public String convertToString(LocalTime value, Locale locale) {
+        return value.toString();
+    }
+}

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/jodatime/JodaLocalTimePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/jodatime/JodaLocalTimePanel.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.isis.viewer.wicket.ui.components.scalars.jodatime;
+
+import org.apache.isis.viewer.wicket.model.models.ScalarModel;
+import org.apache.isis.viewer.wicket.ui.components.scalars.ScalarPanelTextFieldAbstract;
+import org.apache.isis.viewer.wicket.ui.components.scalars.TextFieldValueModel;
+import org.apache.wicket.markup.html.form.AbstractTextComponent;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.util.convert.IConverter;
+import org.joda.time.LocalTime;
+
+/**
+ * Panel for rendering scalars of type {@link LocalTime}.
+ */
+public class JodaLocalTimePanel extends ScalarPanelTextFieldAbstract<LocalTime> {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public JodaLocalTimePanel(final String id, final ScalarModel scalarModel) {
+        super(id, scalarModel, LocalTime.class);
+    }
+    
+    @Override
+    protected AbstractTextComponent<LocalTime> createTextFieldForRegular(final String id) {
+        final TextFieldValueModel<LocalTime> textFieldValueModel = new TextFieldValueModel<>(this);
+        return new TextField<LocalTime>(id, textFieldValueModel, LocalTime.class) {
+            private static final long serialVersionUID = 1L;
+    
+            @SuppressWarnings("unchecked")
+            @Override
+            public <C> IConverter<C> getConverter(Class<C> type) {
+                return (IConverter<C>) (type == LocalTime.class ? new ConverterForJodaLocalTime() : super.getConverter(type));
+            }
+        };
+    }
+    
+    @Override
+    protected String getScalarPanelType() {
+        return "jodaLocalTimePanel";
+    }
+}

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/jodatime/JodaLocalTimePanelFactory.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/scalars/jodatime/JodaLocalTimePanelFactory.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.isis.viewer.wicket.ui.components.scalars.jodatime;
+
+import org.apache.isis.viewer.wicket.model.models.ScalarModel;
+import org.apache.isis.viewer.wicket.ui.ComponentFactory;
+import org.apache.isis.viewer.wicket.ui.components.scalars.ComponentFactoryScalarAbstract;
+import org.apache.wicket.Component;
+import org.joda.time.LocalTime;
+
+/**
+ * {@link ComponentFactory} for {@link JodaLocalTimePanel}.
+ */
+public class JodaLocalTimePanelFactory extends ComponentFactoryScalarAbstract {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public JodaLocalTimePanelFactory() {
+        super(JodaLocalTimePanel.class, LocalTime.class);
+    }
+    
+    @Override
+    public Component createComponent(final String id, final ScalarModel scalarModel) {
+        return new JodaLocalTimePanel(id, scalarModel);
+    }
+}

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/registries/components/ComponentFactoryRegistrarDefault.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/registries/components/ComponentFactoryRegistrarDefault.java
@@ -65,6 +65,7 @@ import org.apache.isis.viewer.wicket.ui.components.scalars.jdkmath.JavaMathBigIn
 import org.apache.isis.viewer.wicket.ui.components.scalars.jodatime.JodaDateTimePanelFactory;
 import org.apache.isis.viewer.wicket.ui.components.scalars.jodatime.JodaLocalDatePanelFactory;
 import org.apache.isis.viewer.wicket.ui.components.scalars.jodatime.JodaLocalDateTimePanelFactory;
+import org.apache.isis.viewer.wicket.ui.components.scalars.jodatime.JodaLocalTimePanelFactory;
 import org.apache.isis.viewer.wicket.ui.components.scalars.markup.MarkupPanelFactories;
 import org.apache.isis.viewer.wicket.ui.components.scalars.oiddto.OidDtoPanelFactory;
 import org.apache.isis.viewer.wicket.ui.components.scalars.passwd.IsisPasswordPanelFactory;
@@ -252,6 +253,7 @@ public class ComponentFactoryRegistrarDefault implements ComponentFactoryRegistr
 
         componentFactories.add(new JodaLocalDatePanelFactory());
         componentFactories.add(new JodaLocalDateTimePanelFactory());
+        componentFactories.add(new JodaLocalTimePanelFactory());
         componentFactories.add(new JodaDateTimePanelFactory());
 
         componentFactories.add(new Jdk8OffsetDateTimePanelFactory());


### PR DESCRIPTION
Without this patch applied, input to a joda LocalTime field causes an error.
This patch fixes the problem by adding a panel to be used by joda LocalTime.