### PR TITLE
Isis 2700 + 2705:  hides objects (and members of other objects that would navigate to said objects) if not visible per authorisation.  Also improvements to popups of wicket viewer

### DIFF
--- a/core/config/src/main/java/org/apache/isis/core/config/IsisConfiguration.java
+++ b/core/config/src/main/java/org/apache/isis/core/config/IsisConfiguration.java
@@ -21,6 +21,8 @@ package org.apache.isis.core.config;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,6 +50,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.validation.annotation.Validated;
 
@@ -2445,6 +2448,75 @@ public class IsisConfiguration {
                  */
                 private String text;
             }
+
+            private final MessagePopups messagePopups = new MessagePopups();
+            @Data
+            public static class MessagePopups {
+
+                /**
+                 * How long the info popup should display before disappearing.
+                 *
+                 * <p>
+                 *     A value of 0 means do not disappear automatically.
+                 * </p>
+                 */
+                Duration infoDelay = Duration.ofMillis(3500);
+
+                /**
+                 * How long the warning popup should display before disappearing.
+                 *
+                 * <p>
+                 *     A value of 0 (the default) means do not disappear automatically.
+                 * </p>
+                 */
+                Duration warningDelay = Duration.ofMillis(0);
+
+                /**
+                 * How long the error popup should display before disappearing.
+                 *
+                 * <p>
+                 *     A value of 0 (the default) means do not disappear automatically.
+                 * </p>
+                 */
+                Duration errorDelay = Duration.ofMillis(0);
+
+                /**
+                 * How far in from the edge the popup should display
+                 */
+                int offset = 100;
+
+                private final Placement placement = new Placement();
+                @Data
+                public static class Placement {
+
+                    public static enum Vertical {
+                        TOP, BOTTOM
+                    }
+
+                    public static enum Horizontal {
+                        LEFT, RIGHT
+                    }
+
+                    /**
+                     * Whether to display popups at the top or the bottom of the page.
+                     *
+                     * <p>
+                     * The default is to show them at the top.
+                     * </p>
+                     */
+                    Vertical vertical = Vertical.TOP;
+
+                    /**
+                     * Whether to display popups aligned ot the left or right of the page.
+                     *
+                     * <p>
+                     * The default is to show them aligned to the right
+                     * </p>
+                     */
+                    Horizontal horizontal = Horizontal.RIGHT;
+                }
+            }
+
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/members/hiddenmember/HiddenMemberFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/members/hiddenmember/HiddenMemberFacet.java
@@ -17,25 +17,24 @@
  *  under the License.
  */
 
-package org.apache.isis.core.metamodel.facets.object.hidden;
+package org.apache.isis.core.metamodel.facets.members.hiddenmember;
 
 import org.apache.isis.core.metamodel.facetapi.Facet;
-import org.apache.isis.core.metamodel.facetapi.FacetHolder;
-import org.apache.isis.core.metamodel.facets.all.hide.HiddenFacet;
+import org.apache.isis.core.metamodel.facets.object.hidden.HiddenTypeFacetDerivedFromAuthorization;
 import org.apache.isis.core.metamodel.interactions.HidingInteractionAdvisor;
-import org.apache.isis.core.metamodel.spec.ObjectSpecification;
-import org.apache.isis.core.metamodel.spec.feature.ObjectMember;
 
-public interface HiddenObjectFacet extends HiddenInstanceFacet {
+/**
+ * Hide a property, collection or action based <i>not</i> on the object
+ * instance itself, but at the &quot;type&quot; level, eg based on the
+ * permissions for the end-user accessing the object.
+ *
+ * <p>
+ * Used by {@link HiddenTypeFacetDerivedFromAuthorization}
+ * to determine if the type overall should be hidden from the end-user:
+ * if all members are hidden, then (all instanes of) the type should be also.
+ * </p>
+ */
+public interface HiddenMemberFacet extends Facet, HidingInteractionAdvisor {
 
-    /**
-     * Clone this facet onto another {@link FacetHolder}.
-     *
-     * <p>
-     * Introduced to allow this facet to be installed onto the
-     * {@link ObjectSpecification}, and then copied down onto each of the spec's
-     * {@link ObjectMember}s.
-     */
-    public void copyOnto(FacetHolder holder);
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/members/navigation/NavigationFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/members/navigation/NavigationFacet.java
@@ -17,24 +17,24 @@
  *  under the License.
  */
 
-package org.apache.isis.core.metamodel.facets.members.hiddenmember;
+package org.apache.isis.core.metamodel.facets.members.navigation;
 
 import org.apache.isis.core.metamodel.facetapi.Facet;
-import org.apache.isis.core.metamodel.facets.object.hidden.HiddenTypeFacetDerivedFromAuthorization;
+import org.apache.isis.core.metamodel.facetapi.FacetAbstract;
+import org.apache.isis.core.metamodel.facetapi.FacetHolder;
+import org.apache.isis.core.metamodel.facets.object.hidden.HiddenTypeFacet;
 import org.apache.isis.core.metamodel.interactions.HidingInteractionAdvisor;
+import org.apache.isis.core.metamodel.interactions.VisibilityContext;
+import org.apache.isis.core.metamodel.postprocessors.allbutparam.authorization.AuthorizationFacet;
+import org.apache.isis.core.metamodel.spec.feature.MixedIn;
+
+import lombok.val;
 
 /**
- * Hide a property, collection or action based <i>not</i> on the object
- * instance itself, but at the &quot;type&quot; level, eg based on the
- * permissions for the end-user accessing the object.
- *
- * <p>
- * Used by {@link HiddenTypeFacetDerivedFromAuthorization}
- * to determine if the type overall should be hidden from the end-user:
- * if all members are hidden, then (all instanes of) the type should be also.
- * </p>
+ * Hides object members that would allow navigation to a domain type that is
+ * {@link HiddenTypeFacet hidden} (typically due to security permissions).
  */
-public interface HiddenMemberFacet extends Facet, HidingInteractionAdvisor {
+public interface NavigationFacet extends Facet, HidingInteractionAdvisor {
 
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenInstanceFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenInstanceFacet.java
@@ -26,16 +26,21 @@ import org.apache.isis.core.metamodel.interactions.HidingInteractionAdvisor;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.spec.feature.ObjectMember;
 
-public interface HiddenObjectFacet extends HiddenInstanceFacet {
-
-    /**
-     * Clone this facet onto another {@link FacetHolder}.
-     *
-     * <p>
-     * Introduced to allow this facet to be installed onto the
-     * {@link ObjectSpecification}, and then copied down onto each of the spec's
-     * {@link ObjectMember}s.
-     */
-    public void copyOnto(FacetHolder holder);
+/**
+ * Mechanism for determining whether this object is should be hidden.
+ *
+ * <p>
+ * Even though all the properties of an object may themselves be visible, there
+ * could be reasons to hide the object.
+ * </p>
+ *
+ * <p>
+ * In the standard Apache Isis Programming Model, typically corresponds to the
+ * <tt>hidden</tt> method.
+ * </p>
+ *
+ * @see HiddenFacet
+ */
+public interface HiddenInstanceFacet extends Facet, HidingInteractionAdvisor {
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenTypeFacet.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenTypeFacet.java
@@ -19,23 +19,10 @@
 
 package org.apache.isis.core.metamodel.facets.object.hidden;
 
-import org.apache.isis.core.metamodel.facetapi.Facet;
 import org.apache.isis.core.metamodel.facetapi.FacetHolder;
-import org.apache.isis.core.metamodel.facets.all.hide.HiddenFacet;
-import org.apache.isis.core.metamodel.interactions.HidingInteractionAdvisor;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.spec.feature.ObjectMember;
 
-public interface HiddenObjectFacet extends HiddenInstanceFacet {
-
-    /**
-     * Clone this facet onto another {@link FacetHolder}.
-     *
-     * <p>
-     * Introduced to allow this facet to be installed onto the
-     * {@link ObjectSpecification}, and then copied down onto each of the spec's
-     * {@link ObjectMember}s.
-     */
-    public void copyOnto(FacetHolder holder);
+public interface HiddenTypeFacet extends HiddenInstanceFacet {
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenTypeFacetDerivedFromAuthorization.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenTypeFacetDerivedFromAuthorization.java
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.isis.core.metamodel.facets.object.hidden;
+
+import java.util.function.BinaryOperator;
+
+import org.apache.isis.applib.services.metamodel.BeanSort;
+import org.apache.isis.core.metamodel.facetapi.Facet;
+import org.apache.isis.core.metamodel.facetapi.FacetAbstract;
+import org.apache.isis.core.metamodel.facetapi.FacetHolder;
+import org.apache.isis.core.metamodel.facets.members.hiddenmember.HiddenMemberFacet;
+import org.apache.isis.core.metamodel.interactions.VisibilityContext;
+import org.apache.isis.core.metamodel.postprocessors.allbutparam.authorization.AuthorizationFacet;
+import org.apache.isis.core.metamodel.spec.ManagedObject;
+import org.apache.isis.core.metamodel.spec.ObjectSpecification;
+import org.apache.isis.core.metamodel.spec.feature.MixedIn;
+
+import lombok.val;
+
+public class HiddenTypeFacetDerivedFromAuthorization extends FacetAbstract implements HiddenTypeFacet {
+
+    public static Class<? extends Facet> type() {
+        return HiddenTypeFacet.class;
+    }
+
+    public HiddenTypeFacetDerivedFromAuthorization(final FacetHolder holder) {
+        super(type(), holder, Derivation.NOT_DERIVED);
+    }
+
+    @Override
+    public String hides(final VisibilityContext ic) {
+        val obj = ic.getTarget();
+        val specification = obj.getSpecification();
+        val beanSort = specification.getBeanSort();
+        switch (beanSort) {
+            case VIEW_MODEL:
+            case ENTITY:
+                final boolean allHidden = specification.streamAssociations(MixedIn.INCLUDED)
+                        .map(x -> {
+                            final AuthorizationFacet facet = x.getFacet(AuthorizationFacet.class);
+                            return facet != null && facet.hides(ic) != null;
+                        })
+                        .reduce(true, (prev, next) -> prev && next);
+                return allHidden ? "all members hidden" : null;
+            default:
+                return null;
+        }
+    }
+
+}

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenTypeFacetDerivedFromAuthorizationFactory.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/HiddenTypeFacetDerivedFromAuthorizationFactory.java
@@ -19,23 +19,26 @@
 
 package org.apache.isis.core.metamodel.facets.object.hidden;
 
-import org.apache.isis.core.metamodel.facetapi.Facet;
 import org.apache.isis.core.metamodel.facetapi.FacetHolder;
-import org.apache.isis.core.metamodel.facets.all.hide.HiddenFacet;
-import org.apache.isis.core.metamodel.interactions.HidingInteractionAdvisor;
+import org.apache.isis.core.metamodel.facetapi.FacetUtil;
+import org.apache.isis.core.metamodel.facetapi.FeatureType;
+import org.apache.isis.core.metamodel.facets.FacetFactoryAbstract;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
-import org.apache.isis.core.metamodel.spec.feature.ObjectMember;
 
-public interface HiddenObjectFacet extends HiddenInstanceFacet {
+/**
+ * Installs the {@link HiddenTypeFacetDerivedFromAuthorization} on the
+ * {@link ObjectSpecification}.
+ */
+public class HiddenTypeFacetDerivedFromAuthorizationFactory extends FacetFactoryAbstract {
 
-    /**
-     * Clone this facet onto another {@link FacetHolder}.
-     *
-     * <p>
-     * Introduced to allow this facet to be installed onto the
-     * {@link ObjectSpecification}, and then copied down onto each of the spec's
-     * {@link ObjectMember}s.
-     */
-    public void copyOnto(FacetHolder holder);
+    public HiddenTypeFacetDerivedFromAuthorizationFactory() {
+        super(FeatureType.OBJECTS_ONLY);
+    }
+
+    @Override
+    public void process(final ProcessClassContext processClassContext) {
+        final FacetHolder facetHolder = processClassContext.getFacetHolder();
+        FacetUtil.addFacet(new HiddenTypeFacetDerivedFromAuthorization(facetHolder));
+    }
 
 }

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/method/HiddenObjectFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/facets/object/hidden/method/HiddenObjectFacetViaMethod.java
@@ -51,7 +51,7 @@ extends HiddenObjectFacetAbstract {
             return null;
         }
         final Boolean isHidden = (Boolean) ManagedObjects.InvokeUtil.invoke(method, target);
-        return isHidden.booleanValue() ? "Hidden" : null;
+        return isHidden ? "Hidden" : null;
     }
 
     @Override

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/members/navigation/DeriveNavigationFacetFromHiddenTypePostProcessor.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/members/navigation/DeriveNavigationFacetFromHiddenTypePostProcessor.java
@@ -1,0 +1,63 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.isis.core.metamodel.postprocessors.members.navigation;
+
+import org.apache.isis.core.metamodel.facetapi.FacetHolder;
+import org.apache.isis.core.metamodel.facetapi.FacetUtil;
+import org.apache.isis.core.metamodel.facets.object.hidden.HiddenTypeFacet;
+import org.apache.isis.core.metamodel.postprocessors.ObjectSpecificationPostProcessorAbstract;
+import org.apache.isis.core.metamodel.spec.ObjectSpecification;
+import org.apache.isis.core.metamodel.spec.feature.ObjectAction;
+import org.apache.isis.core.metamodel.spec.feature.ObjectActionParameter;
+import org.apache.isis.core.metamodel.spec.feature.ObjectMember;
+import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
+import org.apache.isis.core.metamodel.spec.feature.OneToOneAssociation;
+
+/**
+ * Installs the {@link NavigationFacetDerivedFromHiddenType} on all of the
+ * {@link ObjectMember}s of the {@link ObjectSpecification}.
+ */
+public class DeriveNavigationFacetFromHiddenTypePostProcessor extends ObjectSpecificationPostProcessorAbstract {
+
+    @Override protected void doPostProcess(ObjectSpecification objectSpecification) {
+    }
+
+    @Override protected void doPostProcess(ObjectSpecification objectSpecification, ObjectAction act) {
+        addFacetIfRequired(act, act.getReturnType());
+    }
+
+    @Override protected void doPostProcess(ObjectSpecification objectSpecification, ObjectAction objectAction, ObjectActionParameter param) {
+    }
+
+    @Override protected void doPostProcess(ObjectSpecification objectSpecification, OneToOneAssociation prop) {
+        addFacetIfRequired(prop, prop.getSpecification());
+    }
+
+    @Override protected void doPostProcess(ObjectSpecification objectSpecification, OneToManyAssociation coll) {
+        addFacetIfRequired(coll, coll.getSpecification());
+    }
+
+    private static void addFacetIfRequired(FacetHolder facetHolder, ObjectSpecification navigatedType) {
+        if(navigatedType.containsNonFallbackFacet(HiddenTypeFacet.class)) {
+            FacetUtil.addFacet(new NavigationFacetDerivedFromHiddenType(facetHolder, navigatedType));
+        }
+    }
+
+}

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/members/navigation/NavigationFacetDerivedFromHiddenType.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/members/navigation/NavigationFacetDerivedFromHiddenType.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.isis.core.metamodel.postprocessors.members.navigation;
+
+import org.apache.isis.applib.Identifier;
+import org.apache.isis.applib.id.LogicalType;
+import org.apache.isis.core.metamodel.facetapi.Facet;
+import org.apache.isis.core.metamodel.facetapi.FacetAbstract;
+import org.apache.isis.core.metamodel.facetapi.FacetHolder;
+import org.apache.isis.core.metamodel.facets.members.navigation.NavigationFacet;
+import org.apache.isis.core.metamodel.facets.object.hidden.HiddenTypeFacet;
+import org.apache.isis.core.metamodel.interactions.HidingInteractionAdvisor;
+import org.apache.isis.core.metamodel.interactions.ObjectVisibilityContext;
+import org.apache.isis.core.metamodel.interactions.VisibilityContext;
+import org.apache.isis.core.metamodel.postprocessors.allbutparam.authorization.AuthorizationFacet;
+import org.apache.isis.core.metamodel.spec.ObjectSpecification;
+import org.apache.isis.core.metamodel.spec.feature.MixedIn;
+
+import lombok.val;
+
+public class NavigationFacetDerivedFromHiddenType extends FacetAbstract implements NavigationFacet {
+
+    private final ObjectSpecification navigatedType;
+
+    public static Class<? extends Facet> type() {
+        return NavigationFacet.class;
+    }
+
+    public NavigationFacetDerivedFromHiddenType(final FacetHolder holder, final ObjectSpecification navigatedType) {
+        super(type(), holder, Derivation.DERIVED);
+        this.navigatedType = navigatedType;
+    }
+
+    @Override
+    public String hides(final VisibilityContext ic) {
+        val facet = navigatedType.getFacet(HiddenTypeFacet.class);
+        if(facet == null) {
+            // not expected to happen; this facet should only be installed for object members
+            // that navigate to a class that has the HiddenTypeFacet
+            return null;
+        }
+        val ovc = new ObjectVisibilityContext(ic.getHead().getOwner(), Identifier.classIdentifier(navigatedType.getLogicalType()), ic.getInitiatedBy(), ic.getWhere());
+        final String hides = facet.hides(ovc);
+        return hides;
+    }
+
+}

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/progmodels/dflt/ProgrammingModelFacetsJava8.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/progmodels/dflt/ProgrammingModelFacetsJava8.java
@@ -59,6 +59,7 @@ import org.apache.isis.core.metamodel.facets.object.domainservice.annotation.Dom
 import org.apache.isis.core.metamodel.facets.object.domainservicelayout.DomainServiceLayoutFacetFactory;
 import org.apache.isis.core.metamodel.facets.object.facets.annotation.FacetsFacetAnnotationFactory;
 import org.apache.isis.core.metamodel.facets.object.grid.GridFacetFactory;
+import org.apache.isis.core.metamodel.facets.object.hidden.HiddenTypeFacetDerivedFromAuthorizationFactory;
 import org.apache.isis.core.metamodel.facets.object.hidden.method.HiddenObjectFacetViaMethodFactory;
 import org.apache.isis.core.metamodel.facets.object.icon.method.IconFacetMethodFactory;
 import org.apache.isis.core.metamodel.facets.object.ignore.annotation.RemoveAnnotatedMethodsFacetFactory;
@@ -346,6 +347,8 @@ public final class ProgrammingModelFacetsJava8 extends ProgrammingModelAbstract 
         addFactory(FacetProcessingOrder.G1_VALUE_TYPES, LocalDateTimeValueFacetUsingSemanticsProviderFactory.class);
         addFactory(FacetProcessingOrder.G1_VALUE_TYPES, OffsetDateTimeValueFacetUsingSemanticsProviderFactory.class);
         addFactory(FacetProcessingOrder.G1_VALUE_TYPES, ZonedDateTimeValueFacetUsingSemanticsProviderFactory.class);
+
+        addFactory(FacetProcessingOrder.Z0_BEFORE_FINALLY, HiddenTypeFacetDerivedFromAuthorizationFactory.class);
 
         // written to not trample over TypeOf if already installed
         addFactory(FacetProcessingOrder.Z1_FINALLY, CollectionFacetFactory.class);

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/progmodels/dflt/ProgrammingModelFacetsJava8.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/progmodels/dflt/ProgrammingModelFacetsJava8.java
@@ -146,6 +146,7 @@ import org.apache.isis.core.metamodel.postprocessors.all.DeriveDescribedAsFromTy
 import org.apache.isis.core.metamodel.postprocessors.all.i18n.TranslationPostProcessor;
 import org.apache.isis.core.metamodel.postprocessors.allbutparam.authorization.AuthorizationFacetPostProcessor;
 import org.apache.isis.core.metamodel.postprocessors.collparam.DeriveCollectionParamDefaultsAndChoicesPostProcessor;
+import org.apache.isis.core.metamodel.postprocessors.members.navigation.DeriveNavigationFacetFromHiddenTypePostProcessor;
 import org.apache.isis.core.metamodel.postprocessors.members.TweakDomainEventsForMixinPostProcessor;
 import org.apache.isis.core.metamodel.postprocessors.object.DeriveProjectionFacetsPostProcessor;
 import org.apache.isis.core.metamodel.postprocessors.properties.DeriveDisabledFromImmutablePostProcessor;
@@ -278,6 +279,7 @@ public final class ProgrammingModelFacetsJava8 extends ProgrammingModelAbstract 
         // must come after DomainObjectAnnotationFacetFactory & MixinFacetFactory
         addFactory(FacetProcessingOrder.E1_MEMBER_MODELLING, ContributingFacetDerivedFromMixinFacetFactory.class);
 
+        addFactory(FacetProcessingOrder.E1_MEMBER_MODELLING, HiddenTypeFacetDerivedFromAuthorizationFactory.class);
 
         addFactory(FacetProcessingOrder.F1_LAYOUT, GridFacetFactory.class);
 
@@ -348,8 +350,6 @@ public final class ProgrammingModelFacetsJava8 extends ProgrammingModelAbstract 
         addFactory(FacetProcessingOrder.G1_VALUE_TYPES, OffsetDateTimeValueFacetUsingSemanticsProviderFactory.class);
         addFactory(FacetProcessingOrder.G1_VALUE_TYPES, ZonedDateTimeValueFacetUsingSemanticsProviderFactory.class);
 
-        addFactory(FacetProcessingOrder.Z0_BEFORE_FINALLY, HiddenTypeFacetDerivedFromAuthorizationFactory.class);
-
         // written to not trample over TypeOf if already installed
         addFactory(FacetProcessingOrder.Z1_FINALLY, CollectionFacetFactory.class);
         // must come after CollectionFacetFactory
@@ -383,6 +383,7 @@ public final class ProgrammingModelFacetsJava8 extends ProgrammingModelAbstract 
         addPostProcessor(PostProcessingOrder.A1_BUILTIN, DeriveCollectionParamDefaultsAndChoicesPostProcessor.class);
         addPostProcessor(PostProcessingOrder.A1_BUILTIN, TweakDomainEventsForMixinPostProcessor.class);
         addPostProcessor(PostProcessingOrder.A1_BUILTIN, DeriveProjectionFacetsPostProcessor.class);
+        addPostProcessor(PostProcessingOrder.A1_BUILTIN, DeriveNavigationFacetFromHiddenTypePostProcessor.class);
 
         // must be after all named facets and description facets have been installed
         addPostProcessor(PostProcessingOrder.A1_BUILTIN, TranslationPostProcessor.class);

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/executor/MemberExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/executor/MemberExecutorServiceDefault.java
@@ -260,7 +260,7 @@ implements MemberExecutorService {
         }
 
         val entityState = ManagedObjects.EntityUtil.getEntityState(resultAdapter);
-        if(entityState.isDetached()) {
+        if(entityState.isDetached())   {
             // ensure that any still-to-be-persisted adapters get persisted to DB.
             getTransactionService().flushTransaction();
         }

--- a/extensions/security/secman/applib/src/main/java/org/apache/isis/extensions/secman/applib/permission/app/ApplicationOrphanedPermissionManager.layout.fallback.xml
+++ b/extensions/security/secman/applib/src/main/java/org/apache/isis/extensions/secman/applib/permission/app/ApplicationOrphanedPermissionManager.layout.fallback.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<bs3:grid
+        xsi:schemaLocation="http://isis.apache.org/applib/layout/component http://isis.apache.org/applib/layout/component/component.xsd   http://isis.apache.org/applib/layout/grid/bootstrap3 http://isis.apache.org/applib/layout/grid/bootstrap3/bootstrap3.xsd"
+        xmlns:bs3="http://isis.apache.org/applib/layout/grid/bootstrap3"
+        xmlns:cpt="http://isis.apache.org/applib/layout/component"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <bs3:row>
+        <bs3:col span="12" unreferencedActions="true">
+            <cpt:domainObject/>
+        </bs3:col>
+    </bs3:row>
+    <bs3:row>
+        <bs3:col span="12">
+            <cpt:collection id="orphanedCollections"/>
+        </bs3:col>
+    </bs3:row>
+    <bs3:row>
+        <bs3:col span="12">
+            <bs3:tabGroup unreferencedCollections="true"/>
+        </bs3:col>
+    </bs3:row>
+    <bs3:row>
+        <bs3:col span="12">
+            <cpt:fieldSet name="Metadata" id="metadata"/>
+            <cpt:fieldSet name="Other" id="other" unreferencedProperties="true"/>
+        </bs3:col>
+    </bs3:row>
+</bs3:grid>

--- a/extensions/security/secman/applib/src/main/java/org/apache/isis/extensions/secman/applib/role/seed/IsisExtSecmanRegularUserRoleAndPermissions.java
+++ b/extensions/security/secman/applib/src/main/java/org/apache/isis/extensions/secman/applib/role/seed/IsisExtSecmanRegularUserRoleAndPermissions.java
@@ -104,8 +104,8 @@ public class IsisExtSecmanRegularUserRoleAndPermissions extends AbstractRoleAndP
         val vetoViewing = Can.of(
                 // we explicitly ensure that the user cannot grant themselves
                 // additional privileges or see stuff that they shouldn't
-                ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "permissions"),
-                ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "filterPermissions"),
+                ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "effectiveMemberPermissions"),
+                ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "filterEffectiveMemberPermissions"),
                 ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "resetPassword"),
                 ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "lock"),
                 ApplicationFeatureId.newMember(ApplicationUser.LOGICAL_TYPE_NAME, "unlock"),

--- a/extensions/security/secman/integration/src/main/java/org/apache/isis/extensions/secman/integration/IsisModuleExtSecmanIntegration.java
+++ b/extensions/security/secman/integration/src/main/java/org/apache/isis/extensions/secman/integration/IsisModuleExtSecmanIntegration.java
@@ -24,7 +24,6 @@ import org.springframework.context.annotation.Import;
 import org.apache.isis.extensions.secman.applib.IsisModuleExtSecmanApplib;
 import org.apache.isis.extensions.secman.integration.authorizor.AuthorizorSecman;
 import org.apache.isis.extensions.secman.integration.facets.TenantedAuthorizationPostProcessor;
-import org.apache.isis.extensions.secman.applib.seed.SeedSecurityModuleService;
 import org.apache.isis.extensions.secman.integration.spiimpl.ImpersonateMenuAdvisorForSecman;
 import org.apache.isis.extensions.secman.integration.spiimpl.TableColumnVisibilityServiceForSecman;
 import org.apache.isis.extensions.secman.integration.userreg.UserRegistrationServiceForSecman;

--- a/extensions/security/secman/integration/src/main/java/org/apache/isis/extensions/secman/integration/facets/TenantedAuthorizationPostProcessor.java
+++ b/extensions/security/secman/integration/src/main/java/org/apache/isis/extensions/secman/integration/facets/TenantedAuthorizationPostProcessor.java
@@ -26,7 +26,6 @@ import javax.inject.Provider;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
-import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.applib.services.queryresultscache.QueryResultsCache;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.user.UserService;
@@ -107,7 +106,6 @@ public class TenantedAuthorizationPostProcessor
     }
 
     @Inject ServiceRegistry serviceRegistry;
-    @Inject ServiceInjector serviceInjector;
     @Inject UserService userService;
     @Inject @Lazy ApplicationUserRepository userRepository;
     @Inject Provider<QueryResultsCache> queryResultsCacheProvider;

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/breadcrumbs/BreadcrumbPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/breadcrumbs/BreadcrumbPanel.java
@@ -42,6 +42,8 @@ import org.apache.isis.viewer.wicket.ui.errors.JGrowlUtil;
 import org.apache.isis.viewer.wicket.ui.pages.entity.EntityPage;
 import org.apache.isis.viewer.wicket.ui.panels.PanelAbstract;
 
+import lombok.val;
+
 public class BreadcrumbPanel
 extends PanelAbstract<Void, IModel<Void>> {
 
@@ -129,10 +131,11 @@ extends PanelAbstract<Void, IModel<Void>> {
                         final String oidStr = breadcrumbChoice.getInput();
                         final EntityModel selectedModel = breadcrumbModel.lookup(oidStr);
                         if(selectedModel == null) {
+                            val configuration = getCommonContext().getConfiguration();
                             getCommonContext().getMessageBroker()
                             .ifPresent(messageBroker->{
                                 messageBroker.addWarning("Cannot find object");
-                                String feedbackMsg = JGrowlUtil.asJGrowlCalls(messageBroker);
+                                String feedbackMsg = JGrowlUtil.asJGrowlCalls(messageBroker, configuration);
                                 target.appendJavaScript(feedbackMsg);
                             });
                             breadcrumbModel.remove(oidStr);

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/errors/JGrowlBehaviour.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/errors/JGrowlBehaviour.java
@@ -32,6 +32,8 @@ import org.apache.isis.core.interaction.session.MessageBroker;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.viewer.wicket.model.common.CommonContextUtils;
 
+import lombok.val;
+
 /**
  * Attach to any Ajax button that might trigger a notification (ie calls
  * {@link MessageBroker#addMessage(String)}, {@link MessageBroker#addWarning(String)},
@@ -56,8 +58,9 @@ public class JGrowlBehaviour extends AbstractDefaultAjaxBehavior {
     @Override
     protected void respond(AjaxRequestTarget target) {
 
+        val configuration = getCommonContext().getConfiguration();
         getCommonContext().getMessageBroker().ifPresent(messageBroker->{
-            String feedbackMsg = JGrowlUtil.asJGrowlCalls(messageBroker);
+            String feedbackMsg = JGrowlUtil.asJGrowlCalls(messageBroker, configuration);
             if(!_Strings.isNullOrEmpty(feedbackMsg)) {
                 target.appendJavaScript(feedbackMsg);
             }
@@ -76,9 +79,10 @@ public class JGrowlBehaviour extends AbstractDefaultAjaxBehavior {
                 JavaScriptHeaderItem
                 .forReference(new JavaScriptResourceReference(JGrowlBehaviour.class, "js/bootstrap-growl.js")));
 
+        val configuration = getCommonContext().getConfiguration();
         getCommonContext().getMessageBroker().ifPresent(messageBroker->{
 
-            String feedbackMsg = JGrowlUtil.asJGrowlCalls(messageBroker);
+            String feedbackMsg = JGrowlUtil.asJGrowlCalls(messageBroker, configuration);
             if(_Strings.isNotEmpty(feedbackMsg)) {
                 response.render(OnDomReadyHeaderItem.forScript(feedbackMsg));
             }

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/errors/JGrowlUtil.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/errors/JGrowlUtil.java
@@ -20,6 +20,7 @@ package org.apache.isis.viewer.wicket.ui.errors;
 
 import org.apache.wicket.util.string.Strings;
 
+import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.interaction.session.MessageBroker;
 
 import lombok.Getter;
@@ -32,9 +33,21 @@ public class JGrowlUtil {
 
     @RequiredArgsConstructor @Getter
     static enum MessageSeverity {
-        INFO(3500),
-        WARNING(0), // sticky
-        DANGER(0) // sticky
+        INFO(3500) {
+            @Override long delay(IsisConfiguration.Viewer.Wicket.MessagePopups messagePopups) {
+                return messagePopups.getInfoDelay().toMillis();
+            }
+        },
+        WARNING(0) {
+            @Override long delay(IsisConfiguration.Viewer.Wicket.MessagePopups messagePopups) {
+                return messagePopups.getWarningDelay().toMillis();
+            }
+        }, // sticky
+        DANGER(0){
+            @Override long delay(IsisConfiguration.Viewer.Wicket.MessagePopups messagePopups) {
+                return messagePopups.getErrorDelay().toMillis();
+            }
+        } // sticky
         ;
 
         private final int delayMillis;
@@ -42,29 +55,33 @@ public class JGrowlUtil {
         public String cssClassSuffix() {
             return name().toLowerCase();
         }
+
+        abstract long delay(IsisConfiguration.Viewer.Wicket.MessagePopups messagePopups);
     }
 
-    public static String asJGrowlCalls(final MessageBroker messageBroker) {
+    public static String asJGrowlCalls(final MessageBroker messageBroker, IsisConfiguration configuration) {
         val buf = new StringBuilder();
 
+        val messagePopups = configuration.getViewer().getWicket().getMessagePopups();
         for (String info : messageBroker.drainMessages()) {
-            addJGrowlCall(info, JGrowlUtil.MessageSeverity.INFO, buf);
+            addJGrowlCall(info, JGrowlUtil.MessageSeverity.INFO, messagePopups, buf);
         }
 
         for (String warning : messageBroker.drainWarnings()) {
-            addJGrowlCall(warning, JGrowlUtil.MessageSeverity.WARNING, buf);
+            addJGrowlCall(warning, JGrowlUtil.MessageSeverity.WARNING, messagePopups, buf);
         }
 
         messageBroker.drainApplicationError()
         .ifPresent(error->
-            addJGrowlCall(error, MessageSeverity.DANGER, buf));
+            addJGrowlCall(error, MessageSeverity.DANGER, messagePopups, buf));
 
         return buf.toString();
     }
 
-    public static void addJGrowlCall(
+    private static void addJGrowlCall(
             final String origMsg,
             final MessageSeverity severity,
+            final IsisConfiguration.Viewer.Wicket.MessagePopups messagePopups,
             final StringBuilder buf) {
 
         final CharSequence escapedMsg = escape(origMsg);
@@ -74,9 +91,9 @@ public class JGrowlUtil {
         .append('"');
         buf.append(", {");
         buf.append("type: \"").append(severity.cssClassSuffix()).append('"');
-        buf.append(", delay: " + severity.delayMillis);
-        buf.append(", placement: { from: 'top', align: 'right' }");
-        buf.append(", offset: 50");
+        buf.append(String.format(", delay: %d", severity.delay(messagePopups)));
+        buf.append(String.format(", placement: { from: '%s', align: '%s' }", messagePopups.getPlacement().getVertical().name().toLowerCase(), messagePopups.getPlacement().getHorizontal().name().toLowerCase()));
+        buf.append(String.format(", offset: %d", messagePopups.getOffset()));
         buf.append('}');
         buf.append(");\n");
     }

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
@@ -174,8 +174,9 @@ implements FormExecutor {
                 // also in this branch we also know that there *is* an ajax target to use
                 addComponentsToRedraw(targetIfAny);
 
+                val configuration = getCommonContext().getConfiguration();
                 currentMessageBroker().ifPresent(messageBorker->{
-                    final String jGrowlCalls = JGrowlUtil.asJGrowlCalls(messageBorker);
+                    final String jGrowlCalls = JGrowlUtil.asJGrowlCalls(messageBorker, configuration);
                     targetIfAny.appendJavaScript(jGrowlCalls);
                 });
 


### PR DESCRIPTION
* installs a new HiddenTypeFacet on every objectspec, that infers that all instances of the domain type should be hidden if authorisation says that all properties and collections are hidden for current user (we don't bother checking actions)

* installs a new NavigationFacet on every object member that will hide said member if the type it navigates to (ie return type of action, reference type of property, element type of collection) is one that is hidden to the end user.