### PR TITLE
ISIS-2713: adds logicalTypeName to all framework-defined features

### DIFF
--- a/api/applib/src/main/java/org/apache/isis/applib/annotation/SemanticsOf.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/annotation/SemanticsOf.java
@@ -18,12 +18,14 @@
  */
 package org.apache.isis.applib.annotation;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.util.Enums;
 
 /**
  * @since 1.x {@index}
  * @see <a href="https://isis.apache.org/guides/rgant/rgant.html#_rgant-Action_semantics">Reference Guide</a>
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".annotation.SemanticsOf")
 public enum SemanticsOf {
 
     /**

--- a/api/applib/src/main/java/org/apache/isis/applib/graph/SimpleEdge.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/graph/SimpleEdge.java
@@ -18,16 +18,20 @@
  */
 package org.apache.isis.applib.graph;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
+
 import lombok.Value;
 
 /**
- * Fundamental building block for graph structures. 
- * 
+ * Fundamental building block for graph structures.
+ *
  * @since 2.0 {@index}
  *
  * @param <T> type constraint for values contained by this edge's vertices
  */
 @Value(staticConstructor = "of")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".graph.SimpleEdge")
 public class SimpleEdge<T> implements Edge<T> {
 
     Vertex<T> from;

--- a/api/applib/src/main/java/org/apache/isis/applib/graph/tree/TreeNode.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/graph/tree/TreeNode.java
@@ -29,6 +29,8 @@ import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Value;
 import org.apache.isis.applib.graph.Edge;
@@ -46,6 +48,7 @@ import org.apache.isis.commons.internal.exceptions._Exceptions;
  * @param <T> type constraint for values contained by this node
  */
 @Value(semanticsProviderName="org.apache.isis.core.metamodel.facets.value.treenode.TreeNodeValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".graph.tree.TreeNode")
 public class TreeNode<T> implements Vertex<T> {
 
     private final TreeState sharedState;

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/dto/Dto_downloadXml.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/dto/Dto_downloadXml.java
@@ -20,8 +20,10 @@ package org.apache.isis.applib.mixins.dto;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -52,6 +54,7 @@ import lombok.val;
 @ActionLayout(
         cssClassFa = "fa-download",
         sequence = "500.1")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.dto.Dto_downloadXml")
 @RequiredArgsConstructor
 public class Dto_downloadXml {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/dto/Dto_downloadXsd.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/dto/Dto_downloadXsd.java
@@ -22,8 +22,11 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
+import org.apache.isis.applib.annotation.Nature;
 import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -64,6 +67,7 @@ import lombok.val;
 @ActionLayout(
         cssClassFa = "fa-download",
         sequence = "500.2")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.dto.Dto_downloadXsd")
 @RequiredArgsConstructor
 public class Dto_downloadXsd {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/layout/Object_downloadLayoutXml.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/layout/Object_downloadLayoutXml.java
@@ -20,8 +20,10 @@ package org.apache.isis.applib.mixins.layout;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Publishing;
@@ -55,6 +57,7 @@ import lombok.val;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "700.1"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.layout.Object_downloadLayoutXml")
 @RequiredArgsConstructor
 public class Object_downloadLayoutXml {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_downloadMetamodelXml.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_downloadMetamodelXml.java
@@ -23,8 +23,10 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Publishing;
@@ -63,6 +65,7 @@ import lombok.val;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "700.2"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.metamodel.Object_downloadMetamodelXml")
 @RequiredArgsConstructor
 public class Object_downloadMetamodelXml {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_logicalTypeName.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_logicalTypeName.java
@@ -20,6 +20,7 @@ package org.apache.isis.applib.mixins.metamodel;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
@@ -56,6 +57,7 @@ import lombok.val;
         fieldSetId = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "700.1"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.metamodel.Object_logicalTypeName")
 @RequiredArgsConstructor
 public class Object_logicalTypeName {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_objectIdentifier.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_objectIdentifier.java
@@ -20,6 +20,7 @@ package org.apache.isis.applib.mixins.metamodel;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
@@ -56,6 +57,7 @@ import lombok.val;
         fieldSetId = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "700.2"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.metamodel.Object_objectIdentifier")
 @RequiredArgsConstructor
 public class Object_objectIdentifier {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_rebuildMetamodel.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/metamodel/Object_rebuildMetamodel.java
@@ -20,8 +20,10 @@ package org.apache.isis.applib.mixins.metamodel;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.RestrictTo;
@@ -51,6 +53,7 @@ import lombok.RequiredArgsConstructor;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "800.1"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.metamodel.Object_rebuildMetamodel")
 @RequiredArgsConstructor
 public class Object_rebuildMetamodel {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/mixins/rest/Object_openRestApi.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/mixins/rest/Object_openRestApi.java
@@ -22,8 +22,10 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.RestrictTo;
@@ -54,6 +56,7 @@ import lombok.val;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "750.1"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".mixins.rest.Object_openRestApi")
 @RequiredArgsConstructor
 public class Object_openRestApi {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/services/appfeat/ApplicationFeature.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/appfeat/ApplicationFeature.java
@@ -23,26 +23,29 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.SortedSet;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
 /**
- * 
+ *
  * @since 1.x revised for 2.0 {@index}
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE_SUDO + ".ApplicationFeature")
 public interface ApplicationFeature {
 
     ApplicationFeatureId getFeatureId();
-    
+
     default String getFullyQualifiedName() {
         return getFeatureId().getFullyQualifiedName();
     }
 
     /**
-     * Returns optionally the member sort, based on whether this feature is of sort 
+     * Returns optionally the member sort, based on whether this feature is of sort
      * {@link ApplicationFeatureSort#MEMBER}.
      */
     Optional<ApplicationMemberSort> getMemberSort();
-    
+
     default SortedSet<ApplicationFeatureId> getMembersOfSort(final ApplicationMemberSort memberSort) {
         switch (memberSort) {
         case PROPERTY:
@@ -55,33 +58,33 @@ public interface ApplicationFeature {
             return Collections.emptySortedSet();
         }
     }
-    
+
     /**
      * Returns optionally the action's return type, based on
      * whether this feature is of sorts
-     * {@link ApplicationFeatureSort#MEMBER member} and 
+     * {@link ApplicationFeatureSort#MEMBER member} and
      * {@link ApplicationMemberSort#ACTION action}.
      */
     Optional<Class<?>> getActionReturnType();
-    
+
     /**
      * Returns optionally the action's semantics, based on
      * whether this feature is of sorts
-     * {@link ApplicationFeatureSort#MEMBER member} and 
+     * {@link ApplicationFeatureSort#MEMBER member} and
      * {@link ApplicationMemberSort#ACTION action}.
      */
     Optional<SemanticsOf> getActionSemantics();
 
-    /** 
-     * Returns whether the property or collection feature is derived.  
-     * @return always {@code false} when not a property or collection 
+    /**
+     * Returns whether the property or collection feature is derived.
+     * @return always {@code false} when not a property or collection
      */
     boolean isPropertyOrCollectionDerived();
 
     /**
      * Returns optionally the property's semantics, based on
      * whether this feature is of sorts
-     * {@link ApplicationFeatureSort#MEMBER member} and 
+     * {@link ApplicationFeatureSort#MEMBER member} and
      * {@link ApplicationMemberSort#PROPERTY property}.
      */
     OptionalInt getPropertyTypicalLength();
@@ -89,11 +92,11 @@ public interface ApplicationFeature {
     /**
      * Returns optionally the property's max-length constraint, based on
      * whether this feature is of sorts
-     * {@link ApplicationFeatureSort#MEMBER member} and 
+     * {@link ApplicationFeatureSort#MEMBER member} and
      * {@link ApplicationMemberSort#PROPERTY property}.
      */
     OptionalInt getPropertyMaxLength();
-    
+
     SortedSet<ApplicationFeatureId> getContents();
 
     SortedSet<ApplicationFeatureId> getProperties();
@@ -101,5 +104,5 @@ public interface ApplicationFeature {
     SortedSet<ApplicationFeatureId> getCollections();
 
     SortedSet<ApplicationFeatureId> getActions();
-    
+
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/appfeat/ApplicationFeatureSort.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/appfeat/ApplicationFeatureSort.java
@@ -18,25 +18,29 @@
  */
 package org.apache.isis.applib.services.appfeat;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
+
 /**
- * 
+ *
  * @since 1.x revised for 2.0 {@index}
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE_FEAT + ".ApplicationFeatureSort")
 public enum ApplicationFeatureSort {
-    
-    /** 
+
+    /**
      * logical namespace
      */
     NAMESPACE,
-    
-    /** 
-     * {@code namespace + "." + typeSimpleName} 
+
+    /**
+     * {@code namespace + "." + typeSimpleName}
      * makes up the fully qualified logical type
      */
     TYPE,
-    
-    /** 
-     * {@code namespace + "." + typeSimpleName + "." + memberName} 
+
+    /**
+     * {@code namespace + "." + typeSimpleName + "." + memberName}
      * makes up the fully qualified logical member
      */
     MEMBER;
@@ -44,11 +48,11 @@ public enum ApplicationFeatureSort {
     public boolean isNamespace() {
         return this == ApplicationFeatureSort.NAMESPACE;
     }
-    
+
     public boolean isType() {
         return this == ApplicationFeatureSort.TYPE;
     }
-    
+
     public boolean isMember() {
         return this == ApplicationFeatureSort.MEMBER;
     }
@@ -57,6 +61,6 @@ public enum ApplicationFeatureSort {
     public String toString() {
         return name();
     }
-    
+
 
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/bookmark/Bookmark.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/bookmark/Bookmark.java
@@ -24,6 +24,8 @@ import java.util.StringTokenizer;
 
 import javax.annotation.Nullable;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.id.LogicalType;
 import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.codec._UrlDecoderUtil;
@@ -37,10 +39,11 @@ import lombok.val;
 
 /**
  * String representation of any persistable or re-creatable object managed by the framework.
- * 
+ *
  * @since 1.x revised for 2.0 {@index}
  */
 @org.apache.isis.applib.annotation.Value
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".Bookmark")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Bookmark implements Oid {
 
@@ -50,40 +53,40 @@ public final class Bookmark implements Oid {
     @Getter(onMethod_ = {@Override}) private final String identifier;
     @Getter private final @Nullable String hintId;
     private final int hashCode;
-    
+
     // -- FACTORIES
 
     public static Bookmark forLogicalTypeNameAndIdentifier(
             final @NonNull String logicalTypeName,
             final @NonNull String identifier) {
         return new Bookmark(
-                logicalTypeName, 
-                identifier, 
+                logicalTypeName,
+                identifier,
                 /*hintId*/null);
     }
-    
+
     public static Bookmark forLogicalTypeAndIdentifier(
-            final @NonNull LogicalType logicalType, 
+            final @NonNull LogicalType logicalType,
             final @NonNull String identifier) {
         return Bookmark.forLogicalTypeNameAndIdentifier(
-                logicalType.getLogicalTypeName(), 
+                logicalType.getLogicalTypeName(),
                 identifier);
     }
-    
+
     public static Bookmark forOidDto(final @NonNull OidDto oidDto) {
         return Bookmark.forLogicalTypeNameAndIdentifier(
-                oidDto.getType(), 
+                oidDto.getType(),
                 oidDto.getId());
     }
 
     public Bookmark withHintId(final @Nullable String hintId) {
-        return new Bookmark(this.getLogicalTypeName(), this.getIdentifier(), hintId); 
+        return new Bookmark(this.getLogicalTypeName(), this.getIdentifier(), hintId);
     }
-    
+
     // -- CONSTRUCTOR
-    
+
     private Bookmark(
-            final String logicalTypeName, 
+            final String logicalTypeName,
             final String identifier,
             final String hintId) {
 
@@ -92,9 +95,9 @@ public final class Bookmark implements Oid {
         this.hintId = hintId;
         this.hashCode = Objects.hash(logicalTypeName, identifier);
     }
-    
+
     // -- PARSE
-    
+
     /**
      * Round-trip with {@link #stringify()} representation.
      */
@@ -107,23 +110,23 @@ public final class Bookmark implements Oid {
         int tokenCount = tokenizer.countTokens();
         if(tokenCount==2) {
             return Optional.of(Bookmark.forLogicalTypeNameAndIdentifier(
-                    tokenizer.nextToken(), 
+                    tokenizer.nextToken(),
                     tokenizer.nextToken()));
         }
         if(tokenCount>2) {
             return Optional.of(Bookmark.forLogicalTypeNameAndIdentifier(
-                    tokenizer.nextToken(), 
+                    tokenizer.nextToken(),
                     tokenizer.nextToken("").substring(1)));
         }
         return Optional.empty();
     }
-    
+
     public static Optional<Bookmark> parseUrlEncoded(@Nullable String urlEncodedStr) {
         return _Strings.isEmpty(urlEncodedStr)
                 ? Optional.empty()
                 : parse(_UrlDecoderUtil.urlDecode(urlEncodedStr));
     }
-    
+
     // -- TO DTO
 
     public OidDto toOidDto() {
@@ -134,14 +137,14 @@ public final class Bookmark implements Oid {
     }
 
     // -- STRINGIFY
-    
+
     @Override
     public String stringify() {
         return stringify(identifier);
     }
-    
+
     // -- OBJECT CONTRACT // not considering any hintId
-    
+
     @Override
     public boolean equals(final Object other) {
         if (other == null) {
@@ -157,7 +160,7 @@ public final class Bookmark implements Oid {
     }
 
     public boolean equals(final Bookmark other) {
-        return Objects.equals(logicalTypeName, other.getLogicalTypeName()) 
+        return Objects.equals(logicalTypeName, other.getLogicalTypeName())
                 && Objects.equals(identifier, other.getIdentifier());
     }
 
@@ -165,15 +168,15 @@ public final class Bookmark implements Oid {
     public int hashCode() {
         return hashCode;
     }
-    
+
     @Override
     public String toString() {
         return stringify();
     }
-    
+
     /**
-     * Analogous to {@link #stringify()}, but replaces the {@code identifier} string with 
-     * the {@code hintId} if present and not empty. 
+     * Analogous to {@link #stringify()}, but replaces the {@code identifier} string with
+     * the {@code hintId} if present and not empty.
      */
     public String stringifyHonoringHintIfAny() {
         return _Strings.isNotEmpty(hintId)
@@ -182,11 +185,11 @@ public final class Bookmark implements Oid {
     }
 
     // -- HELPER
-    
+
     private String stringify(String id) {
         return logicalTypeName + SEPARATOR + id;
     }
 
-    
+
 
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/bookmark/BookmarkHolder_lookup.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/bookmark/BookmarkHolder_lookup.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 @ActionLayout(
         cssClassFa = "fa-bookmark"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.bookmark.BookmarkHolder_lookup")
 @RequiredArgsConstructor
 public class BookmarkHolder_lookup {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/services/bookmark/BookmarkHolder_object.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/bookmark/BookmarkHolder_object.java
@@ -21,6 +21,7 @@ package org.apache.isis.applib.services.bookmark;
 import javax.inject.Inject;
 
 import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Property;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
         domainEvent = BookmarkHolder_object.PropertyDomainEvent.class
 )
 @RequiredArgsConstructor
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.bookmark.BookmarkHolder_object")
 public class BookmarkHolder_object {
 
     private final BookmarkHolder bookmarkHolder;

--- a/api/applib/src/main/java/org/apache/isis/applib/services/jaxb/IsisSchemas.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/jaxb/IsisSchemas.java
@@ -18,6 +18,8 @@
  */
 package org.apache.isis.applib.services.jaxb;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.mixins.dto.Dto_downloadXsd;
 
 /**
@@ -33,6 +35,7 @@ import org.apache.isis.applib.mixins.dto.Dto_downloadXsd;
  * <a href="http://isis.apache.org/schema">downloaded</a> from the Isis website.
  * </p>
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.jaxb.IsisSchemas")
 public enum IsisSchemas {
     INCLUDE,
     IGNORE;

--- a/api/applib/src/main/java/org/apache/isis/applib/services/layout/Style.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/layout/Style.java
@@ -18,6 +18,8 @@
  */
 package org.apache.isis.applib.services.layout;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.layout.grid.Grid;
 
 /**
@@ -28,13 +30,14 @@ import org.apache.isis.applib.layout.grid.Grid;
  * content is assembled. Once a layout file is in place, its layout data takes precedence over any
  * conflicting layout data from annotations.
  * </p>
- * 
+ *
  * TODO update for v2 - @MemberGroupLayout and @MemberOrder have been removed
  *
  * @since 1.x {@index}
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.layout.Style")
 public enum Style {
-    
+
     /**
      * The current layout for the domain class.
      * <p>
@@ -45,7 +48,7 @@ public enum Style {
      * also {@link org.apache.isis.applib.services.grid.GridService#normalize(Grid) normalized}.
      */
     CURRENT,
-    
+
     /**
      * As per {@link #NORMALIZED}, but also with all (non-null) facets for all
      * properties/collections/actions also included included in the grid.
@@ -58,7 +61,7 @@ public enum Style {
      * </ul>
      */
     COMPLETE,
-    
+
     /**
      * Default, whereby missing properties/collections/actions are added to regions,
      * and unused/empty regions are removed/trimmed.
@@ -72,7 +75,7 @@ public enum Style {
      * </ul>
      */
     NORMALIZED,
-    
+
     /**
      * As per {@link #NORMALIZED}, but with no properties/collections/actions.
      * <p>

--- a/api/applib/src/main/java/org/apache/isis/applib/services/menu/MenuBarsService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/menu/MenuBarsService.java
@@ -18,6 +18,8 @@
  */
 package org.apache.isis.applib.services.menu;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.layout.menubars.MenuBars;
 
 /**
@@ -34,6 +36,7 @@ import org.apache.isis.applib.layout.menubars.MenuBars;
  */
 public interface MenuBarsService {
 
+    @DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.menu.MenuBarsService.Type")
     enum Type {
 
         /**

--- a/api/applib/src/main/java/org/apache/isis/applib/services/swagger/Format.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/swagger/Format.java
@@ -18,11 +18,15 @@
  */
 package org.apache.isis.applib.services.swagger;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
+
 /**
  * The format to generate the representation of the swagger spec.
  *
  * @since 1.x {@index}
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.swagger.Format")
 public enum Format {
     /**
      * Generate a format in JSON (<code>text/json</code> media type).

--- a/api/applib/src/main/java/org/apache/isis/applib/services/swagger/Visibility.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/swagger/Visibility.java
@@ -18,6 +18,7 @@
  */
 package org.apache.isis.applib.services.swagger;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.DomainService;
@@ -30,6 +31,7 @@ import org.apache.isis.applib.annotation.RestrictTo;
  *
  * @since 1.x {@index}
  */
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".services.swagger.Visibility")
 public enum Visibility {
 
     /**

--- a/api/applib/src/main/java/org/apache/isis/applib/value/Blob.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/value/Blob.java
@@ -31,6 +31,8 @@ import javax.activation.MimeTypeParseException;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Value;
 import org.apache.isis.applib.jaxb.PrimitiveJaxbAdapters;
 import org.apache.isis.commons.internal.base._Strings;
@@ -63,6 +65,7 @@ import lombok.extern.log4j.Log4j2;
  */
 @Value(semanticsProviderName =
         "org.apache.isis.core.metamodel.facets.value.blobs.BlobValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.Blob")
 @XmlJavaTypeAdapter(Blob.JaxbToStringAdapter.class)   // for JAXB view model support
 @Log4j2
 public final class Blob implements NamedWithMimeType {

--- a/api/applib/src/main/java/org/apache/isis/applib/value/Clob.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/value/Clob.java
@@ -29,6 +29,8 @@ import javax.activation.MimeTypeParseException;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Value;
 import org.apache.isis.applib.jaxb.PrimitiveJaxbAdapters;
 import org.apache.isis.commons.internal.base._Strings;
@@ -60,6 +62,7 @@ import lombok.extern.log4j.Log4j2;
  */
 @Value(semanticsProviderName =
         "org.apache.isis.core.metamodel.facets.value.clobs.ClobValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.Clob")
 @XmlJavaTypeAdapter(Clob.JaxbToStringAdapter.class)   // for JAXB view model support
 @Log4j2
 public final class Clob implements NamedWithMimeType {

--- a/api/applib/src/main/java/org/apache/isis/applib/value/LocalResourcePath.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/value/LocalResourcePath.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Value;
 
 import lombok.Getter;
@@ -51,6 +53,7 @@ import lombok.NonNull;
  */
 @Value(semanticsProviderName =
         "org.apache.isis.core.metamodel.facets.value.localrespath.LocalResourcePathValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.LocalResourcePath")
 @XmlJavaTypeAdapter(LocalResourcePath.JaxbToStringAdapter.class)   // for JAXB view model support
 public final class LocalResourcePath implements Serializable {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/value/Markup.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/value/Markup.java
@@ -26,6 +26,8 @@ import java.util.Base64;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Value;
 import org.apache.isis.commons.internal.base._Strings;
 
@@ -37,6 +39,7 @@ import org.apache.isis.commons.internal.base._Strings;
  */
 @Value(semanticsProviderName =
         "org.apache.isis.core.metamodel.facets.value.markup.MarkupValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.Markup")
 @XmlJavaTypeAdapter(Markup.JaxbToStringAdapter.class)   // for JAXB view model support
 public final class Markup implements HasHtml, Serializable {
 

--- a/api/applib/src/main/java/org/apache/isis/applib/value/Password.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/value/Password.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Value;
 
 /**
@@ -34,6 +36,7 @@ import org.apache.isis.applib.annotation.Value;
  */
 @Value(semanticsProviderName = "org.apache.isis.core.metamodel.facets.value.password.PasswordValueSemanticsProvider")
 @XmlAccessorType(XmlAccessType.FIELD)
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.Password")
 // @XmlJavaTypeAdapter(Password.JaxbToStringAdapter.class) // TODO: not automatically registered because not secure enough.  Instead we should set up some sort of mechanism to encrypt.
 @lombok.Value
 public class Password implements Serializable {

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/inspect/Object_inspectMetamodel.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/inspect/Object_inspectMetamodel.java
@@ -23,8 +23,10 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -56,6 +58,7 @@ import lombok.val;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "700.2.1"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + "mixins.metamodel.Object_inspectMetamodel")
 @RequiredArgsConstructor
 public class Object_inspectMetamodel {
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/appfeat/ApplicationFeatureDefault.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/appfeat/ApplicationFeatureDefault.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.SortedSet;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.SemanticsOf;
 import org.apache.isis.applib.annotation.Value;
 import org.apache.isis.applib.services.appfeat.ApplicationFeature;
@@ -50,6 +52,7 @@ import lombok.Setter;
  * </p>
  */
 @Value
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + "services.appfeat.ApplicationFeature")
 public class ApplicationFeatureDefault
 implements
 ApplicationFeature,

--- a/valuetypes/asciidoc/applib/src/main/java/org/apache/isis/valuetypes/asciidoc/applib/value/AsciiDoc.java
+++ b/valuetypes/asciidoc/applib/src/main/java/org/apache/isis/valuetypes/asciidoc/applib/value/AsciiDoc.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.value.HasHtml;
 import org.apache.isis.valuetypes.asciidoc.applib.jaxb.AsciiDocJaxbAdapter;
 
@@ -31,6 +33,7 @@ import org.apache.isis.valuetypes.asciidoc.applib.jaxb.AsciiDocJaxbAdapter;
  * @since 2.0 {@index}
  */
 @org.apache.isis.applib.annotation.Value(semanticsProviderName = "org.apache.isis.valuetypes.asciidoc.metamodel.facets.AsciiDocValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.AsciiDoc")
 @XmlJavaTypeAdapter(AsciiDocJaxbAdapter.class)  // for JAXB view model support
 public class AsciiDoc implements HasHtml, Serializable {
 

--- a/valuetypes/markdown/applib/src/main/java/org/apache/isis/valuetypes/markdown/applib/value/Markdown.java
+++ b/valuetypes/markdown/applib/src/main/java/org/apache/isis/valuetypes/markdown/applib/value/Markdown.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.isis.applib.IsisModuleApplib;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.value.HasHtml;
 import org.apache.isis.valuetypes.markdown.applib.jaxb.MarkdownJaxbAdapter;
 
@@ -31,6 +33,7 @@ import org.apache.isis.valuetypes.markdown.applib.jaxb.MarkdownJaxbAdapter;
  */
 @org.apache.isis.applib.annotation.Value(
         semanticsProviderName = "org.apache.isis.valuetypes.markdown.metamodel.facets.MarkdownValueSemanticsProvider")
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE + ".value.Markdown")
 @XmlJavaTypeAdapter(MarkdownJaxbAdapter.class)  // for JAXB view model support
 public class Markdown implements HasHtml, Serializable {
 

--- a/viewers/common/src/main/java/org/apache/isis/viewer/common/applib/mixins/Object_impersonate.java
+++ b/viewers/common/src/main/java/org/apache/isis/viewer/common/applib/mixins/Object_impersonate.java
@@ -20,8 +20,10 @@ package org.apache.isis.viewer.common.applib.mixins;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.Redirect;
@@ -53,6 +55,7 @@ import lombok.RequiredArgsConstructor;
         redirectPolicy = Redirect.EVEN_IF_SAME,
         sequence = "850.1"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE_SUDO + ".mixins.Object_impersonate")
 @RequiredArgsConstructor
 public class Object_impersonate {
 

--- a/viewers/common/src/main/java/org/apache/isis/viewer/common/applib/mixins/Object_impersonateWithRoles.java
+++ b/viewers/common/src/main/java/org/apache/isis/viewer/common/applib/mixins/Object_impersonateWithRoles.java
@@ -22,8 +22,10 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.Redirect;
@@ -56,6 +58,7 @@ import lombok.val;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "850.2"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE_SUDO + ".mixins.Object_impersonateWithRoles")
 @RequiredArgsConstructor
 public class Object_impersonateWithRoles {
 

--- a/viewers/common/src/main/java/org/apache/isis/viewer/common/applib/mixins/Object_stopImpersonating.java
+++ b/viewers/common/src/main/java/org/apache/isis/viewer/common/applib/mixins/Object_stopImpersonating.java
@@ -20,8 +20,10 @@ package org.apache.isis.viewer.common.applib.mixins;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.Redirect;
@@ -51,6 +53,7 @@ import lombok.RequiredArgsConstructor;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "850.3"
 )
+@DomainObject(logicalTypeName = IsisModuleApplib.NAMESPACE_SUDO + ".mixins.Object_stopImpersonating")
 @RequiredArgsConstructor
 public class Object_stopImpersonating {
 

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/IsisModuleViewerWicketViewer.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/IsisModuleViewerWicketViewer.java
@@ -69,4 +69,5 @@ import org.apache.isis.viewer.wicket.viewer.webmodule.WebModuleWicket;
 })
 public class IsisModuleViewerWicketViewer {
 
+    public static final String NAMESPACE = "isis.viewer.wicket";
 }

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/mixins/Object_clearHints.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/mixins/Object_clearHints.java
@@ -20,13 +20,16 @@ package org.apache.isis.viewer.wicket.viewer.mixins;
 
 import javax.inject.Inject;
 
+import org.apache.isis.applib.IsisModuleApplib;
 import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.applib.annotation.SemanticsOf;
 import org.apache.isis.applib.mixins.layout.LayoutMixinConstants;
 import org.apache.isis.applib.services.bookmark.BookmarkService;
 import org.apache.isis.applib.services.hint.HintStore;
+import org.apache.isis.viewer.wicket.viewer.IsisModuleViewerWicketViewer;
 import org.apache.isis.viewer.wicket.viewer.services.HintStoreUsingWicketSession;
 
 import lombok.RequiredArgsConstructor;
@@ -71,6 +74,7 @@ import lombok.val;
         associateWith = LayoutMixinConstants.METADATA_LAYOUT_GROUPNAME,
         sequence = "400.1"
 )
+@DomainObject(logicalTypeName = IsisModuleViewerWicketViewer.NAMESPACE + ".mixins.Object_clearHints")
 @RequiredArgsConstructor
 public class Object_clearHints {
 


### PR DESCRIPTION
except the DTOs generated by schemas, where it's not possible