### PR TITLE
Isis 2727 : factors out InteractionService as a low-level service available in the applib.

### DIFF
--- a/antora/components/refguide-index/modules/core/pages/index/security/authentication/Authentication.adoc
+++ b/antora/components/refguide-index/modules/core/pages/index/security/authentication/Authentication.adoc
@@ -14,7 +14,7 @@ interface Authentication {
   UserMemento getUser()     // <.>
   ExecutionContext getExecutionContext()     // <.>
   Type getType()     // <.>
-  Authentication withExecutionContext(ExecutionContext executionContext)     // <.>
+  Authentication withExecutionContext(ExecutionContext interactionContext)     // <.>
 }
 ----
 

--- a/api/applib/src/main/java/org/apache/isis/applib/clock/VirtualClock.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/clock/VirtualClock.java
@@ -34,17 +34,17 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import org.apache.isis.applib.jaxb.JavaSqlXMLGregorianCalendarMarshalling;
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 
 import lombok.NonNull;
 import lombok.val;
 
 /**
- * Works in connection with {@code org.apache.isis.core.interaction.session.InteractionFactory}, 
+ * Works in connection with {@code org.apache.isis.core.interaction.session.InteractionFactory},
  * such that it allows an {@link Interaction}
  * to run with its own simulated (or actual) time.
- * 
+ *
  * @see ExecutionContext
  *
  * @since 2.0 {@index}

--- a/api/applib/src/main/java/org/apache/isis/applib/clock/VirtualClock.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/clock/VirtualClock.java
@@ -34,7 +34,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import org.apache.isis.applib.jaxb.JavaSqlXMLGregorianCalendarMarshalling;
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 
 import lombok.NonNull;
@@ -45,7 +45,7 @@ import lombok.val;
  * such that it allows an {@link Interaction}
  * to run with its own simulated (or actual) time.
  *
- * @see ExecutionContext
+ * @see InteractionContext
  *
  * @since 2.0 {@index}
  */

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactn/ExecutionContext.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactn/ExecutionContext.java
@@ -33,7 +33,7 @@ import lombok.Value;
 import lombok.With;
 
 /**
- * Provides the user and scenario specific environment for an {@link Execution}
+ * Provides the user and scenario specific environment for an {@link Interaction}.
  *
  * @since 2.0 {@index}
  */

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactn/ExecutionContext.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactn/ExecutionContext.java
@@ -77,7 +77,12 @@ public class ExecutionContext implements Serializable {
      */
     public static ExecutionContext ofUserWithSystemDefaults(
             final @NonNull UserMemento user) {
-        return new ExecutionContext(user, VirtualClock.system(), Locale.getDefault(), TimeZone.getDefault());
+        return ExecutionContext.builder()
+                .user(user)
+                .clock(VirtualClock.system())
+                .locale(Locale.getDefault())
+                .timeZone(TimeZone.getDefault())
+                .build();
     }
 
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactn/InteractionProvider.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactn/InteractionProvider.java
@@ -21,6 +21,7 @@ package org.apache.isis.applib.services.iactn;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 
 /**
@@ -49,6 +50,11 @@ public interface InteractionProvider {
      * Optionally, the currently active {@link Interaction} for the calling thread.
      */
     Optional<Interaction> currentInteraction();
+
+    /**
+     * Optionally, the currently active {@link org.apache.isis.applib.services.iactnlayer.InteractionContext} for the calling thread.
+     */
+    Optional<InteractionContext> currentInteractionContext();
 
     /**
      * Unique id of the current request- or test-scoped {@link Interaction}.

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactn/InteractionProvider.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactn/InteractionProvider.java
@@ -38,19 +38,19 @@ import org.apache.isis.commons.internal.exceptions._Exceptions;
  *
  * @since 1.x {@index}
  */
-public interface InteractionContext {
+public interface InteractionProvider {
 
     /**
      * Whether there is a currently active {@link Interaction} for the calling thread.
      */
     boolean isInInteraction();
-    
+
     /**
      * Optionally, the currently active {@link Interaction} for the calling thread.
      */
     Optional<Interaction> currentInteraction();
-    
-    /** 
+
+    /**
      * Unique id of the current request- or test-scoped {@link Interaction}.
      */
     Optional<UUID> getInteractionId();

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactn/InteractionProvider.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactn/InteractionProvider.java
@@ -63,4 +63,10 @@ public interface InteractionProvider {
     }
 
 
+    /**
+     * interaction-layer-stack size
+     * */
+    int getInteractionLayerCount();
+
+
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactn/package-info.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactn/package-info.java
@@ -18,7 +18,7 @@
  */
 
 /**
- * The {@link org.apache.isis.applib.services.iactn.InteractionContext} is a request-scoped domain service that is used
+ * The {@link org.apache.isis.applib.services.iactn.InteractionProvider} is a request-scoped domain service that is used
  * to obtain the current {@link org.apache.isis.applib.services.iactn.Interaction}.
  * An Interaction in turn generally consists of a single top-level Execution, either to invoke an action or to edit
  * a property. If that top-level action or property uses the {@link org.apache.isis.applib.services.wrapper.WrapperFactory} to invoke child actions/properties, then

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/ExecutionContext.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/ExecutionContext.java
@@ -16,13 +16,14 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.applib.services.iactn;
+package org.apache.isis.applib.services.iactnlayer;
 
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.isis.applib.clock.VirtualClock;
+import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.user.UserMemento;
 
 import lombok.Builder;

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/InteractionContext.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/InteractionContext.java
@@ -19,12 +19,17 @@
 package org.apache.isis.applib.services.iactnlayer;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import org.apache.isis.applib.clock.VirtualClock;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.user.UserMemento;
+import org.apache.isis.commons.internal.base._Casts;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -70,6 +75,38 @@ public class InteractionContext implements Serializable {
     @With @Getter @Builder.Default
     @NonNull TimeZone timeZone = TimeZone.getDefault();
 
+    Map<String, Serializable> attributes = new HashMap<>();
+    public void putAttribute(String key, Serializable value) {
+        attributes.put(key, value);
+    }
+
+    public <T> Optional<T> getAttribute(String key, Class<T> castTo) {
+        return _Casts.castTo(attributes.get(key), castTo);
+    }
+
+
+    // -- EQUALS and HASHCODE
+
+    /**
+     * We exclude {@link #attributes}.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InteractionContext that = (InteractionContext) o;
+        return user.equals(that.user) && clock.equals(that.clock) && locale.equals(that.locale) && timeZone.equals(that.timeZone);
+    }
+
+    /**
+     * We exclude {@link #attributes}.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, clock, locale, timeZone);
+    }
+
+
     // -- FACTORIES
 
     /**
@@ -85,5 +122,6 @@ public class InteractionContext implements Serializable {
                 .timeZone(TimeZone.getDefault())
                 .build();
     }
+
 
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/InteractionContext.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/InteractionContext.java
@@ -40,7 +40,7 @@ import lombok.With;
  */
 @Value @Builder
 @RequiredArgsConstructor
-public class ExecutionContext implements Serializable {
+public class InteractionContext implements Serializable {
 
     private static final long serialVersionUID = -220896735209733865L;
 
@@ -73,12 +73,12 @@ public class ExecutionContext implements Serializable {
     // -- FACTORIES
 
     /**
-     * Creates a new {@link ExecutionContext} with the specified user and
+     * Creates a new {@link InteractionContext} with the specified user and
      * system defaults for clock, locale and time-zone.
      */
-    public static ExecutionContext ofUserWithSystemDefaults(
+    public static InteractionContext ofUserWithSystemDefaults(
             final @NonNull UserMemento user) {
-        return ExecutionContext.builder()
+        return InteractionContext.builder()
                 .user(user)
                 .clock(VirtualClock.system())
                 .locale(Locale.getDefault())

--- a/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/InteractionLayer.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/iactnlayer/InteractionLayer.java
@@ -16,17 +16,16 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.core.interaction.session;
+package org.apache.isis.applib.services.iactnlayer;
 
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Binds the {@link Interaction} (&quot;what&quot; is being executed) with
+ * Binds an {@link Interaction} (&quot;what&quot; is being executed) with
  * an {@link InteractionContext} (&quot;who&quot; is executing, &quot;when&quot; and &quot;where&quot;).
  *
  * <p>
@@ -37,34 +36,23 @@ import lombok.RequiredArgsConstructor;
  * </p>
  *
  * <p>
- * The stack of layers is per-thread, managed by {@link InteractionFactory} as a thread-local).
+ * The stack of layers is per-thread, managed by {@link InteractionService} as a thread-local).
  * </p>
  *
- * @since 2.0
+ * @since 2.0 {@index}
  */
 @RequiredArgsConstructor
 public class InteractionLayer {
 
 	/**
-	 *
-	 * Current thread's {@link Interaction} which this layer belongs to.
+	 * Current thread's {@link Interaction} : &quot;what&quot; is being executed
 	 */
 	@Getter private final Interaction interaction;
+
 	/**
-	 * Represents the 		// binds given interaction context (which normally would hold the Authentication in its attribute map)
-	 * 		// to this layer
+	 * &quot;who&quot; is performing this {@link #getInteraction()}, also
+	 * &quot;when&quot; and &quot;where&quot;.
 	 */
 	@Getter private final InteractionContext interactionContext;
-
-	public InteractionLayer(
-			final @NonNull IsisInteraction interaction,
-			final @NonNull InteractionContext interactionContext) {
-
-		this.interaction = interaction;
-
-		// binds given interaction context (which normally would hold the Authentication in its attribute map)
-		// to this layer
-		this.interactionContext = interactionContext;
-	}
 
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/metrics/MetricsService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/metrics/MetricsService.java
@@ -19,7 +19,7 @@
 package org.apache.isis.applib.services.metrics;
 
 import org.apache.isis.applib.annotation.DomainObject;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.schema.ixn.v2.MemberExecutionDto;
 
 /**
@@ -40,7 +40,7 @@ public interface MetricsService {
      * <p>
      * Corresponds to the number of times that <code>javax.jdo.listener.LoadLifecycleListener#postLoad(InstanceLifecycleEvent)</code> (or equivalent) is fired.
      * <p>
-     * Is captured within {@link MemberExecutionDto#getMetrics()} (accessible from {@link InteractionContext#currentInteraction()}).
+     * Is captured within {@link MemberExecutionDto#getMetrics()} (accessible from {@link InteractionProvider#currentInteraction()}).
      */
     int numberEntitiesLoaded();
 
@@ -50,7 +50,7 @@ public interface MetricsService {
      * <p>
      * Corresponds to the number of times that <code>javax.jdo.listener.DirtyLifecycleListener#preDirty(InstanceLifecycleEvent)</code> (or equivalent) callback is fired.
      * <p>
-     * Is captured within {@link MemberExecutionDto#getMetrics()} (accessible from {@link InteractionContext#currentInteraction()}.
+     * Is captured within {@link MemberExecutionDto#getMetrics()} (accessible from {@link InteractionProvider#currentInteraction()}.
      */
     int numberEntitiesDirtied();
 

--- a/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoService.java
@@ -21,7 +21,7 @@ package org.apache.isis.applib.services.sudo;
 import java.util.concurrent.Callable;
 import java.util.function.UnaryOperator;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.user.RoleMemento;
 import org.apache.isis.applib.services.user.UserService;
 import org.apache.isis.commons.functional.ThrowingRunnable;

--- a/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoService.java
@@ -21,7 +21,7 @@ package org.apache.isis.applib.services.sudo;
 import java.util.concurrent.Callable;
 import java.util.function.UnaryOperator;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.RoleMemento;
 import org.apache.isis.applib.services.user.UserService;
 import org.apache.isis.commons.functional.ThrowingRunnable;
@@ -30,7 +30,7 @@ import lombok.NonNull;
 
 /**
  * Allows a block of code to be executed within an arbitrary
- * {@link ExecutionContext}, allowing the who, when and where to be temporarily
+ * {@link InteractionContext}, allowing the who, when and where to be temporarily
  * switched.
  *
  * <p>
@@ -61,24 +61,24 @@ public interface SudoService {
 
     /**
      * Executes the supplied {@link Callable} block, within the provided
-     * {@link ExecutionContext}.
+     * {@link InteractionContext}.
      *
-     * @param sudoMapper - maps the current {@link ExecutionContext} to the sudo one
+     * @param sudoMapper - maps the current {@link InteractionContext} to the sudo one
      * @since 2.0
      */
     <T> T call(
-            final @NonNull UnaryOperator<ExecutionContext> sudoMapper,
+            final @NonNull UnaryOperator<InteractionContext> sudoMapper,
             final @NonNull Callable<T> supplier);
 
     /**
      * Executes the supplied {@link Callable} block, within the provided
-     * {@link ExecutionContext}.
+     * {@link InteractionContext}.
      *
-     * @param sudoMapper - maps the current {@link ExecutionContext} to the sudo one
+     * @param sudoMapper - maps the current {@link InteractionContext} to the sudo one
      * @since 2.0
      */
     default void run(
-            final @NonNull UnaryOperator<ExecutionContext> sudoMapper,
+            final @NonNull UnaryOperator<InteractionContext> sudoMapper,
             final @NonNull ThrowingRunnable runnable) {
         call(sudoMapper, ThrowingRunnable.toCallable(runnable));
     }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoService.java
@@ -24,7 +24,7 @@ import java.util.function.UnaryOperator;
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.RoleMemento;
 import org.apache.isis.applib.services.user.UserService;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 
 import lombok.NonNull;
 

--- a/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoServiceListener.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoServiceListener.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.applib.services.sudo;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 
 import lombok.NonNull;
 

--- a/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoServiceListener.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/sudo/SudoServiceListener.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.applib.services.sudo;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 
 import lombok.NonNull;
 
@@ -39,7 +39,7 @@ public interface SudoServiceListener {
      * @param before
      * @param after
      */
-    void beforeCall(@NonNull ExecutionContext before, @NonNull ExecutionContext after);
+    void beforeCall(@NonNull InteractionContext before, @NonNull InteractionContext after);
 
-    void afterCall(@NonNull ExecutionContext before, @NonNull ExecutionContext after);
+    void afterCall(@NonNull InteractionContext before, @NonNull InteractionContext after);
 }

--- a/api/applib/src/main/java/org/apache/isis/applib/services/user/UserService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/user/UserService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.sudo.SudoService;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 
@@ -44,7 +44,7 @@ public interface UserService {
 
     /**
      * Optionally gets the details about the current user,
-     * based on whether an {@link ExecutionContext} can be found with the current thread's context.
+     * based on whether an {@link InteractionContext} can be found with the current thread's context.
      */
     Optional<UserMemento> currentUser();
 
@@ -61,16 +61,16 @@ public interface UserService {
 
     /**
      * Gets the details about the current user.
-     * @throws IllegalStateException if no {@link ExecutionContext} can be found with the current thread's context.
+     * @throws IllegalStateException if no {@link InteractionContext} can be found with the current thread's context.
      */
     default UserMemento currentUserElseFail() {
         return currentUser()
-                .orElseThrow(()->_Exceptions.illegalState("Current thread has no ExecutionContext."));
+                .orElseThrow(()->_Exceptions.illegalState("Current thread has no InteractionContext."));
     }
 
     /**
      * Optionally gets the the current user's name,
-     * based on whether an {@link ExecutionContext} can be found with the current thread's context.
+     * based on whether an {@link InteractionContext} can be found with the current thread's context.
      */
     default Optional<String> currentUserName() {
         return currentUser()

--- a/api/applib/src/main/java/org/apache/isis/applib/services/user/UserService.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/user/UserService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.sudo.SudoService;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 

--- a/api/applib/src/main/java/org/apache/isis/applib/services/xactn/TransactionalProcessor.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/services/xactn/TransactionalProcessor.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import org.apache.isis.commons.functional.Result;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 
 import lombok.val;
 

--- a/api/applib/src/test/java/org/apache/isis/applib/services/iactnlayer/ResultTest.java
+++ b/api/applib/src/test/java/org/apache/isis/applib/services/iactnlayer/ResultTest.java
@@ -16,7 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.commons.functions;
+package org.apache.isis.applib.services.iactnlayer;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.commons.functional.Result;
-import org.apache.isis.commons.functional.ThrowingRunnable;
 
 import lombok.val;
 

--- a/commons/src/main/java/org/apache/isis/applib/services/iactnlayer/ThrowingRunnable.java
+++ b/commons/src/main/java/org/apache/isis/applib/services/iactnlayer/ThrowingRunnable.java
@@ -24,6 +24,11 @@ import org.apache.isis.commons.functional.Result;
 
 import lombok.NonNull;
 
+/**
+ * Similar to a {@link Runnable}, except that it can also throw exceptions.
+ *
+ * @since 2.x [@index}
+ */
 @FunctionalInterface
 public interface ThrowingRunnable {
 

--- a/commons/src/main/java/org/apache/isis/applib/services/iactnlayer/ThrowingRunnable.java
+++ b/commons/src/main/java/org/apache/isis/applib/services/iactnlayer/ThrowingRunnable.java
@@ -16,9 +16,11 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.commons.functional;
+package org.apache.isis.applib.services.iactnlayer;
 
 import java.util.concurrent.Callable;
+
+import org.apache.isis.commons.functional.Result;
 
 import lombok.NonNull;
 

--- a/commons/src/main/java/org/apache/isis/commons/functional/Result.java
+++ b/commons/src/main/java/org/apache/isis/commons/functional/Result.java
@@ -61,10 +61,6 @@ public final class Result<L> {
         }
     }
 
-    public static Result<Void> ofVoid(final @NonNull ThrowingRunnable runnable) {
-        return of(ThrowingRunnable.toCallable(runnable));
-    }
-
     public static <L> Result<L> success(final @Nullable L value) {
         return of(value, null, true);
     }

--- a/commons/src/main/java/org/apache/isis/commons/functional/ThrowingRunnable.java
+++ b/commons/src/main/java/org/apache/isis/commons/functional/ThrowingRunnable.java
@@ -25,6 +25,7 @@ import lombok.NonNull;
 @FunctionalInterface
 public interface ThrowingRunnable {
 
+
     // -- INTERFACE
 
     void run() throws Exception;
@@ -32,11 +33,13 @@ public interface ThrowingRunnable {
     // -- UTILITY
 
     static Callable<Void> toCallable(final @NonNull ThrowingRunnable runnable) {
-        final Callable<Void> callable = ()->{
+        return ()->{
             runnable.run();
             return null;
         };
-        return callable;
     }
 
+    static Result<Void> resultOf(final @NonNull ThrowingRunnable runnable) {
+        return Result.of(toCallable(runnable));
+    }
 }

--- a/commons/src/test/java/org/apache/isis/commons/functions/ResultTest.java
+++ b/commons/src/test/java/org/apache/isis/commons/functions/ResultTest.java
@@ -30,85 +30,86 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.commons.functional.Result;
+import org.apache.isis.commons.functional.ThrowingRunnable;
 
 import lombok.val;
 
 class ResultTest {
 
     // -- TEST DUMMIES
-    
+
     String hello_happy() {
         return "hello";
     }
-    
+
     String hello_nullable() {
         return null;
     }
-    
+
     String hello_throwing_uncatched() {
         throw new RuntimeException("hello failed");
     }
-    
+
     String hello_throwing_catched() throws Exception {
         throw new Exception("hello failed");
     }
 
     void void_happy() {
-        
+
     }
-    
+
     void void_throwing_uncatched() {
         throw new RuntimeException("void failed");
     }
-    
+
     void void_throwing_catched() throws Exception {
         throw new Exception("void failed");
     }
-    
-    
+
+
     // -- TESTS
-    
+
     @Test
     void hello_happy_case() {
-        
+
         val result = Result.<String>of(this::hello_happy);
         assertTrue(result.isSuccess());
         assertFalse(result.isFailure());
         assertEquals("hello", result.presentElse(""));
         assertEquals("hello", result.getValue().orElse(null));
         assertEquals("hello", result.presentElseFail());
-        
+
         // non-evaluated code-path
         result.presentElseGet(()->fail("unexpected code reach"));
-        
+
         // default value is not allowed to be null
         assertThrows(NullPointerException.class, ()->result.presentElse(null));
-        
+
         val mandatory = result.mapSuccessWithEmptyValueToNoSuchElement();
         assertTrue(mandatory.isSuccess());
         assertEquals("hello", mandatory.presentElse(""));
-        
+
     }
-    
+
     @Test
     void hello_nullable_case() {
-        
+
         val result = Result.<String>of(this::hello_nullable);
         assertTrue(result.isSuccess());
         assertFalse(result.isFailure());
         assertEquals("no value", result.getValue().orElse("no value"));
         assertThrows(NoSuchElementException.class, ()->result.presentElseFail());
         assertEquals(Optional.empty(), result.optionalElseFail());
-        
+
         val mandatory = result.mapSuccessWithEmptyValueToNoSuchElement();
         assertTrue(mandatory.isFailure());
         assertThrows(NoSuchElementException.class, ()->mandatory.optionalElseFail());
-        
+
     }
-    
+
     @Test
     void hello_throwing_uncatched_case() {
-        
+
         val result = Result.<String>of(this::hello_throwing_uncatched);
         assertFalse(result.isSuccess());
         assertTrue(result.isFailure());
@@ -117,15 +118,15 @@ class ResultTest {
         assertEquals("it failed", result.presentElseGet(()->"it failed"));
         assertThrows(RuntimeException.class, ()->result.presentElseFail());
         assertEquals(Optional.empty(), result.getValue());
-        
+
         val mandatory = result.mapSuccessWithEmptyValueToNoSuchElement();
         assertTrue(mandatory.isFailure());
-        
+
     }
-    
+
     @Test
     void hello_throwing_catched_case() {
-        
+
         val result = Result.<String>of(this::hello_throwing_catched);
         assertFalse(result.isSuccess());
         assertTrue(result.isFailure());
@@ -134,63 +135,63 @@ class ResultTest {
         assertEquals("it failed", result.presentElseGet(()->"it failed"));
         assertThrows(Exception.class, ()->result.presentElseFail());
         assertEquals(Optional.empty(), result.getValue());
-        
+
         val mandatory = result.mapSuccessWithEmptyValueToNoSuchElement();
         assertTrue(mandatory.isFailure());
-        
+
     }
-    
+
     @Test
     void void_happy_case() {
-        
-        val result = Result.ofVoid(this::void_happy);
+
+        val result = ThrowingRunnable.resultOf(this::void_happy);
         assertTrue(result.isSuccess());
         assertFalse(result.isFailure());
         assertEquals(null, result.getValue().orElse(null));
-        
+
         assertThrows(NoSuchElementException.class, ()->result.presentElseFail());
-        
+
         // default value is not allowed to be null
         assertThrows(NullPointerException.class, ()->result.presentElse(null));
-        
+
     }
-    
-    
+
+
     @Test
     void void_throwing_uncatched_case() {
-        
-        val result = Result.ofVoid(this::void_throwing_uncatched);
+
+        val result = ThrowingRunnable.resultOf(this::void_throwing_uncatched);
         assertFalse(result.isSuccess());
         assertTrue(result.isFailure());
         assertEquals("void failed", result.getFailure().get().getMessage());
-        
+
         // default value is not allowed to be null
         assertThrows(NullPointerException.class, ()->result.presentElse(null));
         assertThrows(NoSuchElementException.class, ()->result.presentElseGet(()->null));
         assertThrows(Exception.class, ()->result.presentElseFail());
         assertEquals(Optional.empty(), result.getValue());
-        
+
         val mandatory = result.mapSuccessWithEmptyValueToNoSuchElement();
         assertTrue(mandatory.isFailure());
     }
-    
+
     @Test
     void void_throwing_catched_case() {
-        
-        val result = Result.ofVoid(this::void_throwing_catched);
+
+        val result = ThrowingRunnable.resultOf(this::void_throwing_catched);
         assertFalse(result.isSuccess());
         assertTrue(result.isFailure());
         assertEquals("void failed", result.getFailure().get().getMessage());
-        
+
         // default value is not allowed to be null
         assertThrows(NullPointerException.class, ()->result.presentElse(null));
         assertThrows(NoSuchElementException.class, ()->result.presentElseGet(()->null));
         assertThrows(Exception.class, ()->result.presentElseFail());
         assertEquals(Optional.empty(), result.getValue());
-        
+
         val mandatory = result.mapSuccessWithEmptyValueToNoSuchElement();
         assertTrue(mandatory.isFailure());
     }
-    
-    
+
+
 }

--- a/core/config/src/main/java/org/apache/isis/core/config/presets/DebugRequestScopedServices.properties
+++ b/core/config/src/main/java/org/apache/isis/core/config/presets/DebugRequestScopedServices.properties
@@ -5,9 +5,9 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #         http://www.apache.org/licenses/LICENSE-2.0
-#         
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,6 +17,6 @@
 
 # -- framework internal request scoped --
 logging.level.org.apache.isis.viewer.restfulobjects.rendering.service.acceptheader.AcceptHeaderServiceForRest = DEBUG
-logging.level.org.apache.isis.applib.services.iactn.InteractionContext = DEBUG
+logging.level.org.apache.isis.applib.services.iactn.InteractionProvider = DEBUG
 logging.level.org.apache.isis.applib.services.scratchpad.Scratchpad = DEBUG
 logging.level.org.apache.isis.core.runtimeservices.publish.PublisherDispatchServiceDefault = DEBUG

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/InteractionAwareTransactionalBoundaryHandler.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/InteractionAwareTransactionalBoundaryHandler.java
@@ -35,7 +35,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.commons.internal.collections._Lists;
 import org.apache.isis.commons.internal.debug._Probe;
 import org.apache.isis.core.interaction.session.IsisInteraction;

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
@@ -56,7 +56,7 @@ public class IsisRequestCycle {
 
     public void onEndRequest() {
 
-        isisInteractionFactory.closeSessionStack();
+        isisInteractionFactory.closeInteractionLayers();
 
     }
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
@@ -47,7 +47,7 @@ public class IsisRequestCycle {
                         authentication.getValidationCode()))
                 .orElse(authentication);
 
-        isisInteractionFactory.openInteraction(authenticationToUse, authenticationToUse.getInteractionContext());
+        isisInteractionFactory.openInteraction(authenticationToUse.getInteractionContext());
     }
 
     public void onRequestHandlerExecuted() {

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
@@ -19,7 +19,7 @@
 package org.apache.isis.core.interaction.integration;
 
 import org.apache.isis.applib.services.user.ImpersonatedUserHolder;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
@@ -33,7 +33,7 @@ import lombok.val;
 @RequiredArgsConstructor(staticName = "next")
 public class IsisRequestCycle {
 
-    private final InteractionHandler interactionHandler;
+    private final InteractionService interactionService;
     private final ImpersonatedUserHolder impersonatedUserHolder;
 
     // -- SUPPORTING WEB REQUEST CYCLE FOR ISIS ...
@@ -47,7 +47,7 @@ public class IsisRequestCycle {
                         authentication.getValidationCode()))
                 .orElse(authentication);
 
-        interactionHandler.openInteraction(authenticationToUse.getInteractionContext());
+        interactionService.openInteraction(authenticationToUse.getInteractionContext());
     }
 
     public void onRequestHandlerExecuted() {
@@ -56,7 +56,7 @@ public class IsisRequestCycle {
 
     public void onEndRequest() {
 
-        interactionHandler.closeInteractionLayers();
+        interactionService.closeInteractionLayers();
 
     }
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
@@ -19,7 +19,7 @@
 package org.apache.isis.core.interaction.integration;
 
 import org.apache.isis.applib.services.user.ImpersonatedUserHolder;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
@@ -47,7 +47,7 @@ public class IsisRequestCycle {
                         authentication.getValidationCode()))
                 .orElse(authentication);
 
-        isisInteractionFactory.openInteraction(authenticationToUse);
+        isisInteractionFactory.openInteraction(authenticationToUse, authenticationToUse.getInteractionContext());
     }
 
     public void onRequestHandlerExecuted() {

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/integration/IsisRequestCycle.java
@@ -19,7 +19,7 @@
 package org.apache.isis.core.interaction.integration;
 
 import org.apache.isis.applib.services.user.ImpersonatedUserHolder;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
@@ -33,7 +33,7 @@ import lombok.val;
 @RequiredArgsConstructor(staticName = "next")
 public class IsisRequestCycle {
 
-    private final InteractionFactory isisInteractionFactory;
+    private final InteractionHandler interactionHandler;
     private final ImpersonatedUserHolder impersonatedUserHolder;
 
     // -- SUPPORTING WEB REQUEST CYCLE FOR ISIS ...
@@ -47,7 +47,7 @@ public class IsisRequestCycle {
                         authentication.getValidationCode()))
                 .orElse(authentication);
 
-        isisInteractionFactory.openInteraction(authenticationToUse.getInteractionContext());
+        interactionHandler.openInteraction(authenticationToUse.getInteractionContext());
     }
 
     public void onRequestHandlerExecuted() {
@@ -56,7 +56,7 @@ public class IsisRequestCycle {
 
     public void onEndRequest() {
 
-        isisInteractionFactory.closeInteractionLayers();
+        interactionHandler.closeInteractionLayers();
 
     }
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -22,6 +22,8 @@ package org.apache.isis.core.interaction.session;
 import java.util.concurrent.Callable;
 
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionLayer;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.manager.AnonymousInteractionFactory;

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -47,7 +47,7 @@ extends AnonymousInteractionFactory {
      * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
      * anonymous one.
      *
-     * @see #openInteraction(Authentication, InteractionContext)
+     * @see #openInteraction(InteractionContext)
      */
     InteractionLayer openInteraction();
 
@@ -60,8 +60,6 @@ extends AnonymousInteractionFactory {
      * The {@link InteractionLayer} represents a user's span of activities interacting with
      * the application. The session's stack is later closed using {@link #closeInteractionLayers()}.
      *
-     * @param authentication - the {@link Authentication} to associate with the new top of
-     * the stack (non-null)
      * @param interactionContext
      *
      * @apiNote if the current {@link InteractionLayer} (if any) has an {@link Authentication} that
@@ -69,7 +67,6 @@ extends AnonymousInteractionFactory {
      * instead the current one is returned
      */
     InteractionLayer openInteraction(
-            @NonNull Authentication authentication,
             @NonNull InteractionContext interactionContext);
 
     /**

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -41,56 +41,7 @@ import lombok.NonNull;
  * @since 2.0 {@index}
  */
 public interface InteractionFactory
-extends AnonymousInteractionFactory {
-
-    /**
-     * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
-     * anonymous one.
-     *
-     * @see #openInteraction(InteractionContext)
-     */
-    InteractionLayer openInteraction();
-
-    /**
-     * Returns a new or reused {@link InteractionLayer} that is a holder of {@link Authentication}
-     * on top of the current thread's authentication layer stack.
-     * <p>
-     * If available reuses an existing {@link Authentication}, otherwise creates a new one.
-     * <p>
-     * The {@link InteractionLayer} represents a user's span of activities interacting with
-     * the application. The session's stack is later closed using {@link #closeInteractionLayers()}.
-     *
-     * @param interactionContext
-     *
-     * @apiNote if the current {@link InteractionLayer} (if any) has an {@link Authentication} that
-     * equals that of the given one, as an optimization, no new layer is pushed onto the stack;
-     * instead the current one is returned
-     */
-    InteractionLayer openInteraction(
-            @NonNull InteractionContext interactionContext);
-
-    /**
-     * @return whether the calling thread is within the context of an open {@link InteractionLayer}
-     */
-    boolean isInInteraction();
-
-    /**
-     * Executes a block of code with a new or reused {@link InteractionContext} using a new or
-     * reused {@link InteractionLayer}.
-     *
-     * <p>
-     * If there is currently no {@link InteractionLayer} a new one is created.
-     * </p>
-     *
-     * <p>
-     * If there is currently an {@link InteractionLayer} that has an equal {@link InteractionContext}
-     * to the given one, it is reused, otherwise a new one is created.
-     * </p>
-     *
-     * @param interactionContext - the context to run under (non-null)
-     * @param callable - the piece of code to run (non-null)
-     */
-    <R> R call(@NonNull InteractionContext interactionContext, @NonNull Callable<R> callable);
+extends AnonymousInteractionFactory, InteractionHandler {
 
     /**
      * As per {@link #call(InteractionContext, Callable)}, using the {@link InteractionContext}
@@ -102,12 +53,13 @@ extends AnonymousInteractionFactory {
     <R> R callAuthenticated(@NonNull Authentication authentication, @NonNull Callable<R> callable);
 
     /**
-     * Variant of {@link #call(InteractionContext, Callable)} that takes a runnable.
+     * As per {@link #call(InteractionContext, Callable)}, but using an {@link InteractionContext}
+     * {@link Authentication#getInteractionContext() obtained} from an anonymous {@link Authentication}.
      *
-     * @param interactionContext - the user details to run under (non-null)
-     * @param runnable (non-null)
+     * @param <R>
+     * @param callable (non-null)
      */
-    void run(@NonNull InteractionContext interactionContext, @NonNull ThrowingRunnable runnable);
+    <R> R callAnonymous(@NonNull Callable<R> callable);
 
     /**
      * As per {@link #callAuthenticated(Authentication, Callable)}, but for a runnable.
@@ -118,26 +70,12 @@ extends AnonymousInteractionFactory {
     void runAuthenticated(@NonNull Authentication authentication, @NonNull ThrowingRunnable runnable);
 
     /**
-     * As per {@link #call(InteractionContext, Callable)}, but using an {@link InteractionContext}
-     * {@link Authentication#getInteractionContext() obtained} from an anonymous {@link Authentication}.
-     *
-     * @param <R>
-     * @param callable (non-null)
-     */
-    <R> R callAnonymous(@NonNull Callable<R> callable);
-
-    /**
      * As per {@link #callAnonymous(Callable)}, but for a runnable.
      *
      * @param runnable (non-null)
      */
     @Override
     void runAnonymous(@NonNull ThrowingRunnable runnable);
-
-    /**
-     * closes all open {@link InteractionLayer}(s) as stacked on the current thread
-     */
-    void closeInteractionLayers();
 
 
 }

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -28,13 +28,10 @@ import org.apache.isis.core.security.authentication.manager.AnonymousInteraction
 import lombok.NonNull;
 
 /**
- * The factory of {@link InteractionSession}(s) and {@link AuthenticationLayer}(s),
- * also holding a reference to the current authentication layer stack using
+ * The factory of {@link Authentication}(s) and {@link InteractionLayer}(s),
+ * holding a reference to the current
+ * {@link InteractionLayer authentication layer} stack using
  * a thread-local.
- *
- * <p>
- * The implementation is a singleton service.
- * </p>
  *
  * <p>
  * @apiNote This is a framework internal class and so does not constitute a formal API.
@@ -46,42 +43,43 @@ public interface InteractionFactory
 extends AnonymousInteractionFactory {
 
     /**
-     * If present, reuses the current top level {@link AuthenticationLayer}, otherwise creates a new
+     * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
      * anonymous one.
+     *
      * @see {@link #openInteraction(Authentication)}
      */
-    AuthenticationLayer openInteraction();
+    InteractionLayer openInteraction();
 
     /**
-     * Returns a new or reused {@link AuthenticationLayer} that is a holder of {@link Authentication}
+     * Returns a new or reused {@link InteractionLayer} that is a holder of {@link Authentication}
      * on top of the current thread's authentication layer stack.
      * <p>
-     * If available reuses an existing {@link InteractionSession}, otherwise creates a new one.
+     * If available reuses an existing {@link Authentication}, otherwise creates a new one.
      * <p>
-     * The {@link InteractionSession} represents a user's span of activities interacting with
-     * the application. The session's stack is later closed using {@link #closeSessionStack()}.
+     * The {@link InteractionLayer} represents a user's span of activities interacting with
+     * the application. The session's stack is later closed using {@link #closeInteractionLayers()}.
      *
      * @param authentication - the {@link Authentication} to associate with the new top of
      * the stack (non-null)
      *
-     * @apiNote if the current {@link AuthenticationLayer} (if any) has an {@link Authentication} that
+     * @apiNote if the current {@link InteractionLayer} (if any) has an {@link Authentication} that
      * equals that of the given one, as an optimization, no new layer is pushed onto the stack;
      * instead the current one is returned
      */
-    AuthenticationLayer openInteraction(@NonNull Authentication authentication);
+    InteractionLayer openInteraction(@NonNull Authentication authentication);
 
     /**
-     * @return whether the calling thread is within the context of an open {@link InteractionSession}
+     * @return whether the calling thread is within the context of an open {@link InteractionLayer}
      */
     boolean isInInteraction();
 
     /**
-     * Executes a block of code with a new or reused {@link InteractionSession} using a new or
-     * reused {@link AuthenticationLayer}.
+     * Executes a block of code with a new or reused {@link Authentication} using a new or
+     * reused {@link InteractionLayer}.
      * <p>
-     * If there is currently no {@link InteractionSession} a new one is created.
+     * If there is currently no {@link InteractionLayer} a new one is created.
      * <p>
-     * If there is currently an {@link AuthenticationLayer} that has an equal {@link Authentication}
+     * If there is currently an {@link InteractionLayer} that has an equal {@link Authentication}
      * to the given one, it is reused, otherwise a new one is created.
      *
      * @param authentication - the user details to run under (non-null)
@@ -98,11 +96,11 @@ extends AnonymousInteractionFactory {
     void runAuthenticated(@NonNull Authentication authentication, @NonNull ThrowingRunnable runnable);
 
     /**
-     * Executes a block of code with a new or reused {@link InteractionSession} using a new or
-     * reused {@link AuthenticationLayer}.
+     * Executes a block of code with a new or reused {@link Authentication} using a new or
+     * reused {@link InteractionLayer}.
      * <p>
-     * If there is currently no {@link InteractionSession} a new one is created and a new
-     * anonymous {@link AuthenticationLayer} is returned. Otherwise both, session and layer are reused.
+     * If there is currently no {@link InteractionLayer} a new one is created and a new
+     * anonymous {@link InteractionLayer} is returned. Otherwise both, session and layer are reused.
      *
      * @param <R>
      * @param callable (non-null)
@@ -117,9 +115,9 @@ extends AnonymousInteractionFactory {
     void runAnonymous(@NonNull ThrowingRunnable runnable);
 
     /**
-     * closes all open {@link AuthenticationLayer}(s) as stacked on the current thread
+     * closes all open {@link InteractionLayer}(s) as stacked on the current thread
      */
-    void closeSessionStack();
+    void closeInteractionLayers();
 
 
 }

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -46,7 +46,7 @@ extends AnonymousInteractionFactory {
      * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
      * anonymous one.
      *
-     * @see {@link #openInteraction(Authentication)}
+     * @see #openInteraction(Authentication)
      */
     InteractionLayer openInteraction();
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -75,33 +75,51 @@ extends AnonymousInteractionFactory {
     boolean isInInteraction();
 
     /**
-     * Executes a block of code with a new or reused {@link Authentication} using a new or
+     * Executes a block of code with a new or reused {@link InteractionContext} using a new or
      * reused {@link InteractionLayer}.
+     *
      * <p>
      * If there is currently no {@link InteractionLayer} a new one is created.
+     * </p>
+     *
      * <p>
-     * If there is currently an {@link InteractionLayer} that has an equal {@link Authentication}
+     * If there is currently an {@link InteractionLayer} that has an equal {@link InteractionContext}
      * to the given one, it is reused, otherwise a new one is created.
+     * </p>
+     *
+     * @param interactionContext - the context to run under (non-null)
+     * @param callable - the piece of code to run (non-null)
+     */
+    <R> R call(@NonNull InteractionContext interactionContext, @NonNull Callable<R> callable);
+
+    /**
+     * As per {@link #call(InteractionContext, Callable)}, using the {@link InteractionContext}
+     * {@link Authentication#getInteractionContext() obtained} from the provided {@link Authentication}.
      *
      * @param authentication - the user details to run under (non-null)
      * @param callable - the piece of code to run (non-null)
-     *
      */
     <R> R callAuthenticated(@NonNull Authentication authentication, @NonNull Callable<R> callable);
 
     /**
-     * Variant of {@link #callAuthenticated(Authentication, Callable)} that takes a runnable.
+     * Variant of {@link #call(InteractionContext, Callable)} that takes a runnable.
+     *
+     * @param interactionContext - the user details to run under (non-null)
+     * @param runnable (non-null)
+     */
+    void run(@NonNull InteractionContext interactionContext, @NonNull ThrowingRunnable runnable);
+
+    /**
+     * As per {@link #callAuthenticated(Authentication, Callable)}, but for a runnable.
+     *
      * @param authentication - the user details to run under (non-null)
      * @param runnable (non-null)
      */
     void runAuthenticated(@NonNull Authentication authentication, @NonNull ThrowingRunnable runnable);
 
     /**
-     * Executes a block of code with a new or reused {@link Authentication} using a new or
-     * reused {@link InteractionLayer}.
-     * <p>
-     * If there is currently no {@link InteractionLayer} a new one is created and a new
-     * anonymous {@link InteractionLayer} is returned. Otherwise both, session and layer are reused.
+     * As per {@link #call(InteractionContext, Callable)}, but using an {@link InteractionContext}
+     * {@link Authentication#getInteractionContext() obtained} from an anonymous {@link Authentication}.
      *
      * @param <R>
      * @param callable (non-null)
@@ -109,7 +127,8 @@ extends AnonymousInteractionFactory {
     <R> R callAnonymous(@NonNull Callable<R> callable);
 
     /**
-     * Variant of {@link #callAnonymous(Callable)} that takes a runnable.
+     * As per {@link #callAnonymous(Callable)}, but for a runnable.
+     *
      * @param runnable (non-null)
      */
     @Override

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -21,6 +21,7 @@ package org.apache.isis.core.interaction.session;
 
 import java.util.concurrent.Callable;
 
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.commons.functional.ThrowingRunnable;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.manager.AnonymousInteractionFactory;
@@ -46,7 +47,7 @@ extends AnonymousInteractionFactory {
      * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
      * anonymous one.
      *
-     * @see #openInteraction(Authentication)
+     * @see #openInteraction(Authentication, InteractionContext)
      */
     InteractionLayer openInteraction();
 
@@ -61,12 +62,15 @@ extends AnonymousInteractionFactory {
      *
      * @param authentication - the {@link Authentication} to associate with the new top of
      * the stack (non-null)
+     * @param interactionContext
      *
      * @apiNote if the current {@link InteractionLayer} (if any) has an {@link Authentication} that
      * equals that of the given one, as an optimization, no new layer is pushed onto the stack;
      * instead the current one is returned
      */
-    InteractionLayer openInteraction(@NonNull Authentication authentication);
+    InteractionLayer openInteraction(
+            @NonNull Authentication authentication,
+            @NonNull InteractionContext interactionContext);
 
     /**
      * @return whether the calling thread is within the context of an open {@link InteractionLayer}

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -22,7 +22,7 @@ package org.apache.isis.core.interaction.session;
 import java.util.concurrent.Callable;
 
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.manager.AnonymousInteractionFactory;
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionFactory.java
@@ -41,7 +41,7 @@ import lombok.NonNull;
  * @since 2.0 {@index}
  */
 public interface InteractionFactory
-extends AnonymousInteractionFactory, InteractionHandler {
+extends AnonymousInteractionFactory, InteractionService {
 
     /**
      * As per {@link #call(InteractionContext, Callable)}, using the {@link InteractionContext}

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionHandler.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionHandler.java
@@ -1,0 +1,73 @@
+package org.apache.isis.core.interaction.session;
+
+import java.util.concurrent.Callable;
+
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
+import org.apache.isis.core.security.authentication.Authentication;
+
+import lombok.NonNull;
+
+public interface InteractionHandler {
+    /**
+     * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
+     * anonymous one.
+     *
+     * @see #openInteraction(InteractionContext)
+     */
+    InteractionLayer openInteraction();
+
+    /**
+     * Returns a new or reused {@link InteractionLayer} that is a holder of {@link Authentication}
+     * on top of the current thread's authentication layer stack.
+     * <p>
+     * If available reuses an existing {@link Authentication}, otherwise creates a new one.
+     * <p>
+     * The {@link InteractionLayer} represents a user's span of activities interacting with
+     * the application. The session's stack is later closed using {@link #closeInteractionLayers()}.
+     *
+     * @param interactionContext
+     *
+     * @apiNote if the current {@link InteractionLayer} (if any) has an {@link Authentication} that
+     * equals that of the given one, as an optimization, no new layer is pushed onto the stack;
+     * instead the current one is returned
+     */
+    InteractionLayer openInteraction(
+            @NonNull InteractionContext interactionContext);
+
+    /**
+     * @return whether the calling thread is within the context of an open {@link InteractionLayer}
+     */
+    boolean isInInteraction();
+
+    /**
+     * Executes a block of code with a new or reused {@link InteractionContext} using a new or
+     * reused {@link InteractionLayer}.
+     *
+     * <p>
+     * If there is currently no {@link InteractionLayer} a new one is created.
+     * </p>
+     *
+     * <p>
+     * If there is currently an {@link InteractionLayer} that has an equal {@link InteractionContext}
+     * to the given one, it is reused, otherwise a new one is created.
+     * </p>
+     *
+     * @param interactionContext - the context to run under (non-null)
+     * @param callable - the piece of code to run (non-null)
+     */
+    <R> R call(@NonNull InteractionContext interactionContext, @NonNull Callable<R> callable);
+
+    /**
+     * Variant of {@link #call(InteractionContext, Callable)} that takes a runnable.
+     *
+     * @param interactionContext - the user details to run under (non-null)
+     * @param runnable (non-null)
+     */
+    void run(@NonNull InteractionContext interactionContext, @NonNull ThrowingRunnable runnable);
+
+    /**
+     * closes all open {@link InteractionLayer}(s) as stacked on the current thread
+     */
+    void closeInteractionLayers();
+}

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.interaction.session;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.core.security.authentication.Authentication;
 
 import lombok.Getter;
@@ -49,7 +49,7 @@ public class InteractionLayer {
 		this.authentication = authentication;
 	}
 
-	public ExecutionContext getExecutionContext() {
+	public InteractionContext getExecutionContext() {
 	    return authentication.getExecutionContext();
 	}
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -23,28 +23,43 @@ import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Provides the environment for an (or parts of an) user interaction to be executed.
+ * Binds the {@link Interaction} (&quot;what&quot; is being executed) with
+ * an {@link InteractionContext} (&quot;who&quot; is executing, &quot;when&quot; and &quot;where&quot;).
  *
  * <p>
- * These may be nested (held in a stack), for example for the {@link org.apache.isis.applib.services.sudo.SudoService},
- * or for fixtures that mock the clock.
+ * {@link InteractionLayer}s are so called because they may be nested (held in a stack).  For example the
+ * {@link org.apache.isis.applib.services.sudo.SudoService} creates a new temporary layer with a different
+ * {@link InteractionContext#getUser() user}, while fixtures that mock the clock switch out the
+ * {@link InteractionContext#getClock() clock}.
+ * </p>
+ *
+ * <p>
+ * The stack of layers is per-thread, managed by {@link InteractionFactory} as a thread-local).
+ * </p>
  *
  * @since 2.0
- *
  */
+@RequiredArgsConstructor
 public class InteractionLayer {
 
+	/**
+	 *
+	 * Current thread's {@link Interaction} which this layer belongs to.
+	 */
 	@Getter private final Interaction interaction;
+	/**
+	 * Represents the 		// binds given interaction context (which normally would hold the Authentication in its attribute map)
+	 * 		// to this layer
+	 */
 	@Getter private final InteractionContext interactionContext;
 
 	public InteractionLayer(
 			final @NonNull IsisInteraction interaction,
 			final @NonNull InteractionContext interactionContext) {
 
-		// current thread's Interaction which this layer belongs to,
-		// meaning the Interaction that holds the stack containing this layer
 		this.interaction = interaction;
 
 		// binds given interaction context (which normally would hold the Authentication in its attribute map)

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -35,7 +35,11 @@ import lombok.NonNull;
 public class InteractionLayer {
 
 	@Getter private final IsisInteraction interaction;
-	@Getter private final Authentication authentication;
+	 private final Authentication authentication;
+
+	public Authentication getAuthentication() {
+		return authentication;
+	}
 
 	public InteractionLayer(
 			final @NonNull IsisInteraction interaction,
@@ -49,7 +53,7 @@ public class InteractionLayer {
 		this.authentication = authentication;
 	}
 
-	public InteractionContext getExecutionContext() {
+	public InteractionContext getInteractionContext() {
 	    return authentication.getInteractionContext();
 	}
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -19,15 +19,16 @@
 package org.apache.isis.core.interaction.session;
 
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
-import org.apache.isis.core.security.authentication.Authentication;
 
 import lombok.Getter;
 import lombok.NonNull;
 
 /**
  * Provides the environment for an (or parts of an) user interaction to be executed.
+ *
  * <p>
- * Can be nested by pushing onto the current thread's {@link InteractionTracker} Stack.
+ * These may be nested (held in a stack), for example for the {@link org.apache.isis.applib.services.sudo.SudoService},
+ * or for fixtures that mock the clock.
  *
  * @since 2.0
  *

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.isis.core.interaction.session;
 
+import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 
 import lombok.Getter;
@@ -35,7 +36,7 @@ import lombok.NonNull;
  */
 public class InteractionLayer {
 
-	@Getter private final IsisInteraction interaction;
+	@Getter private final Interaction interaction;
 	@Getter private final InteractionContext interactionContext;
 
 	public InteractionLayer(

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.interaction.session;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.core.security.authentication.Authentication;
 
 import lombok.Getter;

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -37,10 +37,6 @@ public class InteractionLayer {
 	@Getter private final IsisInteraction interaction;
 	@Getter private final InteractionContext interactionContext;
 
-	public Authentication getAuthentication() {
-		return Authentication.authenticationFrom(interactionContext).orElse(null);
-	}
-
 	public InteractionLayer(
 			final @NonNull IsisInteraction interaction,
 			final @NonNull InteractionContext interactionContext) {

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -43,7 +43,8 @@ public class InteractionLayer {
 
 	public InteractionLayer(
 			final @NonNull IsisInteraction interaction,
-			final @NonNull Authentication authentication) {
+			final @NonNull Authentication authentication,
+			final @NonNull InteractionContext interactionContext) {
 
 		// current thread's Interaction which this layer belongs to,
 		// meaning the Interaction that holds the stack containing this layer

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -35,10 +35,10 @@ import lombok.NonNull;
 public class InteractionLayer {
 
 	@Getter private final IsisInteraction interaction;
-	 private final Authentication authentication;
+	@Getter private final InteractionContext interactionContext;
 
 	public Authentication getAuthentication() {
-		return authentication;
+		return Authentication.authenticationFrom(interactionContext).orElse(null);
 	}
 
 	public InteractionLayer(
@@ -50,12 +50,9 @@ public class InteractionLayer {
 		// meaning the Interaction that holds the stack containing this layer
 		this.interaction = interaction;
 
-		// binds given authentication to this layer
-		this.authentication = authentication;
-	}
-
-	public InteractionContext getInteractionContext() {
-	    return authentication.getInteractionContext();
+		// binds given interaction context (which normally would hold the Authentication in its attribute map)
+		// to this layer
+		this.interactionContext = interactionContext;
 	}
 
 }

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -50,7 +50,7 @@ public class InteractionLayer {
 	}
 
 	public InteractionContext getExecutionContext() {
-	    return authentication.getExecutionContext();
+	    return authentication.getInteractionContext();
 	}
 
 }

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -32,12 +32,12 @@ import lombok.NonNull;
  * @since 2.0
  *
  */
-public class AuthenticationLayer {
+public class InteractionLayer {
 
 	@Getter private final IsisInteraction interaction;
 	@Getter private final Authentication authentication;
 
-	public AuthenticationLayer(
+	public InteractionLayer(
 			final @NonNull IsisInteraction interaction,
 			final @NonNull Authentication authentication) {
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionLayer.java
@@ -43,7 +43,6 @@ public class InteractionLayer {
 
 	public InteractionLayer(
 			final @NonNull IsisInteraction interaction,
-			final @NonNull Authentication authentication,
 			final @NonNull InteractionContext interactionContext) {
 
 		// current thread's Interaction which this layer belongs to,

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionService.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionService.java
@@ -8,7 +8,7 @@ import org.apache.isis.core.security.authentication.Authentication;
 
 import lombok.NonNull;
 
-public interface InteractionHandler {
+public interface InteractionService {
     /**
      * If present, reuses the current top level {@link InteractionLayer}, otherwise creates a new
      * anonymous one.

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -61,6 +61,16 @@ extends InteractionProvider, AuthenticationProvider {
         return currentInteractionLayer().map(InteractionLayer::getAuthentication);
     }
 
+    // -- INTERACTION CONTEXT
+
+    /**
+     * Returns the {@link InteractionContext} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
+     */
+    @Override
+    default Optional<InteractionContext> currentInteractionContext() {
+        return currentInteractionLayer().map(InteractionLayer::getInteractionContext);
+    }
+
 
     // -- INTERACTION
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -25,14 +25,14 @@ import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 /**
  *
  * @since 2.0
  */
 public interface InteractionTracker
-extends InteractionProvider, AuthenticationContext {
+extends InteractionProvider, AuthenticationProvider {
 
     /** @return the AuthenticationLayer that sits on top of the current
      * request- or test-scoped InteractionSession's stack*/

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -20,7 +20,7 @@ package org.apache.isis.core.interaction.session;
 
 import java.util.Optional;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
@@ -44,9 +44,9 @@ extends InteractionProvider, AuthenticationProvider {
     }
 
     /**
-     * Returns the {@link ExecutionContext} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
+     * Returns the {@link InteractionContext} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
      */
-    default Optional<ExecutionContext> currentExecutionContext() {
+    default Optional<InteractionContext> currentExecutionContext() {
         return currentInteractionLayer().map(InteractionLayer::getExecutionContext);
     }
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.iactn.InteractionProvider;
+import org.apache.isis.applib.services.iactnlayer.InteractionLayer;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.AuthenticationProvider;

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -30,38 +30,46 @@ import org.apache.isis.core.security.authentication.AuthenticationContext;
 /**
  *
  * @since 2.0
- *
  */
 public interface InteractionTracker
 extends InteractionContext, AuthenticationContext {
 
     /** @return the AuthenticationLayer that sits on top of the current
      * request- or test-scoped InteractionSession's stack*/
-    Optional<AuthenticationLayer> currentAuthenticationLayer();
+    Optional<InteractionLayer> currentInteractionLayer();
 
-    default AuthenticationLayer currentAuthenticationLayerElseFail() {
-        return currentAuthenticationLayer()
-        .orElseThrow(()->_Exceptions.illegalState("No InteractionSession available on current thread"));
+    default InteractionLayer currentInteractionLayerElseFail() {
+        return currentInteractionLayer()
+        .orElseThrow(()->_Exceptions.illegalState("No InteractionLayer available on current thread"));
     }
 
+    /**
+     * Returns the {@link ExecutionContext} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
+     */
     default Optional<ExecutionContext> currentExecutionContext() {
-        return currentAuthenticationLayer().map(AuthenticationLayer::getExecutionContext);
+        return currentInteractionLayer().map(InteractionLayer::getExecutionContext);
     }
 
-    // -- AUTHENTICATION CONTEXT
 
+    // -- AUTHENTICATION
+
+    /**
+     * Returns the {@link Authentication} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
+     */
     @Override
     default Optional<Authentication> currentAuthentication() {
-        return currentAuthenticationLayer().map(AuthenticationLayer::getAuthentication);
+        return currentInteractionLayer().map(InteractionLayer::getAuthentication);
     }
 
-    // -- INTERACTION CONTEXT
 
+    // -- INTERACTION
+
+    /**
+     * Returns the {@link Interaction} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
+     */
     @Override
     default Optional<Interaction> currentInteraction(){
-    	return currentAuthenticationLayer().map(AuthenticationLayer::getInteraction);
+    	return currentInteractionLayer().map(InteractionLayer::getInteraction);
     }
-
-
 
 }

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -58,7 +58,9 @@ extends InteractionProvider, AuthenticationProvider {
      */
     @Override
     default Optional<Authentication> currentAuthentication() {
-        return currentInteractionLayer().map(InteractionLayer::getAuthentication);
+        return currentInteractionLayer()
+                .map(InteractionLayer::getInteractionContext)
+                .flatMap(Authentication::authenticationFrom);
     }
 
     // -- INTERACTION CONTEXT

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 import org.apache.isis.applib.services.iactn.ExecutionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.AuthenticationContext;
@@ -32,7 +32,7 @@ import org.apache.isis.core.security.authentication.AuthenticationContext;
  * @since 2.0
  */
 public interface InteractionTracker
-extends InteractionContext, AuthenticationContext {
+extends InteractionProvider, AuthenticationContext {
 
     /** @return the AuthenticationLayer that sits on top of the current
      * request- or test-scoped InteractionSession's stack*/

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -20,7 +20,7 @@ package org.apache.isis.core.interaction.session;
 
 import java.util.Optional;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.exceptions._Exceptions;

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/InteractionTracker.java
@@ -47,7 +47,7 @@ extends InteractionProvider, AuthenticationProvider {
      * Returns the {@link InteractionContext} wrapped by the {@link #currentInteractionLayer()} (if within an interaction layer).
      */
     default Optional<InteractionContext> currentExecutionContext() {
-        return currentInteractionLayer().map(InteractionLayer::getExecutionContext);
+        return currentInteractionLayer().map(InteractionLayer::getInteractionContext);
     }
 
 

--- a/core/interaction/src/main/java/org/apache/isis/core/interaction/session/IsisInteraction.java
+++ b/core/interaction/src/main/java/org/apache/isis/core/interaction/session/IsisInteraction.java
@@ -247,16 +247,12 @@ implements InteractionInternal {
 
     @Override
     public <T> T getAttribute(Class<T> type) {
-        return (attributes!=null)
-                ? _Casts.uncheckedCast(attributes.get(type))
-                : null;
+        return _Casts.uncheckedCast(attributes.get(type));
     }
 
     @Override
     public void removeAttribute(Class<?> type) {
-        if(attributes!=null) {
-            attributes.remove(type);
-        }
+        attributes.remove(type);
     }
 
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/_testing/MetaModelContext_forTesting.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/_testing/MetaModelContext_forTesting.java
@@ -54,7 +54,7 @@ import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoaderDefault;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.manager.AuthenticationManager;
 import org.apache.isis.core.security.authorization.manager.AuthorizationManager;
 
@@ -95,7 +95,7 @@ public final class MetaModelContext_forTesting implements MetaModelContext {
 
     private ProgrammingModel programmingModel;
 
-    private AuthenticationContext authenticationContext;
+    private AuthenticationProvider authenticationProvider;
 
     private TranslationService translationService;
 
@@ -163,7 +163,7 @@ public final class MetaModelContext_forTesting implements MetaModelContext {
                 serviceRegistry,
                 metamodelEventService,
                 specificationLoader,
-                authenticationContext,
+                authenticationProvider,
                 getTranslationService(),
                 authentication,
                 authorizationManager,

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/consent/InteractionAdvisor.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/consent/InteractionAdvisor.java
@@ -35,7 +35,7 @@ import org.apache.isis.core.metamodel.interactions.InteractionAdvisorFacet;
  */
 public interface InteractionAdvisor {
 
-    //boolean handles(InteractionContext ic);
+    //boolean handles(InteractionProvider ic);
 
     /**
      * For testing purposes only.

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/HasMetaModelContext.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/HasMetaModelContext.java
@@ -36,7 +36,7 @@ import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.manager.AuthenticationManager;
 import org.apache.isis.core.security.authorization.manager.AuthorizationManager;
 
@@ -89,7 +89,7 @@ public interface HasMetaModelContext {
         return getMetaModelContext().getAuthenticationManager();
     }
 
-    default AuthenticationContext getAuthenticationContext() {
+    default AuthenticationProvider getAuthenticationContext() {
         return getMetaModelContext().getAuthenticationContext();
     }
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/HasMetaModelContext.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/HasMetaModelContext.java
@@ -90,7 +90,7 @@ public interface HasMetaModelContext {
     }
 
     default AuthenticationProvider getAuthenticationContext() {
-        return getMetaModelContext().getAuthenticationContext();
+        return getMetaModelContext().getAuthenticationProvider();
     }
 
     default TitleService getTitleService() {

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/MetaModelContext.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/MetaModelContext.java
@@ -40,7 +40,7 @@ import org.apache.isis.core.metamodel.objectmanager.load.ObjectLoader;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.manager.AuthenticationManager;
 import org.apache.isis.core.security.authorization.manager.AuthorizationManager;
 
@@ -88,7 +88,7 @@ public interface MetaModelContext {
 
     AuthenticationManager getAuthenticationManager();
 
-    AuthenticationContext getAuthenticationContext();
+    AuthenticationProvider getAuthenticationContext();
 
     TitleService getTitleService();
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/MetaModelContext.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/MetaModelContext.java
@@ -88,7 +88,7 @@ public interface MetaModelContext {
 
     AuthenticationManager getAuthenticationManager();
 
-    AuthenticationProvider getAuthenticationContext();
+    AuthenticationProvider getAuthenticationProvider();
 
     TitleService getTitleService();
 

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/MetaModelContext_usingIoc.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/context/MetaModelContext_usingIoc.java
@@ -43,7 +43,7 @@ import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
 import org.apache.isis.core.metamodel.services.ServiceUtil;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.manager.AuthenticationManager;
 import org.apache.isis.core.security.authorization.manager.AuthorizationManager;
 
@@ -95,8 +95,8 @@ class MetaModelContext_usingIoc implements MetaModelContext {
     getSingletonElseFail(AuthenticationManager.class);
 
     @Getter(lazy=true)
-    private final AuthenticationContext authenticationContext =
-    getSingletonElseFail(AuthenticationContext.class);
+    private final AuthenticationProvider authenticationProvider =
+    getSingletonElseFail(AuthenticationProvider.class);
 
     @Getter(lazy=true)
     private final TitleService titleService =

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/allbutparam/authorization/AuthorizationFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/allbutparam/authorization/AuthorizationFacetAbstract.java
@@ -24,7 +24,7 @@ import org.apache.isis.core.metamodel.facetapi.FacetAbstract;
 import org.apache.isis.core.metamodel.facetapi.FacetHolder;
 import org.apache.isis.core.metamodel.interactions.UsabilityContext;
 import org.apache.isis.core.metamodel.interactions.VisibilityContext;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authorization.manager.AuthorizationManager;
 
 import lombok.val;
@@ -38,13 +38,13 @@ public abstract class AuthorizationFacetAbstract extends FacetAbstract implement
     }
 
     private final AuthorizationManager authorizationManager;
-    private final AuthenticationContext authenticationContext;
+    private final AuthenticationProvider authenticationProvider;
 
     public AuthorizationFacetAbstract(
             final FacetHolder holder) {
         super(type(), holder, Derivation.NOT_DERIVED);
         this.authorizationManager = getAuthorizationManager();
-        this.authenticationContext = getAuthenticationContext();
+        this.authenticationProvider = getAuthenticationContext();
     }
 
     @Override
@@ -52,7 +52,7 @@ public abstract class AuthorizationFacetAbstract extends FacetAbstract implement
 
         val hides = authorizationManager
                 .isVisible(
-                        authenticationContext.currentAuthenticationElseFail(),
+                        authenticationProvider.currentAuthenticationElseFail(),
                         ic.getIdentifier())
                 ? null
                 : "Not authorized to view";
@@ -69,7 +69,7 @@ public abstract class AuthorizationFacetAbstract extends FacetAbstract implement
 
         val disables = authorizationManager
                 .isUsable(
-                        authenticationContext.currentAuthenticationElseFail(),
+                        authenticationProvider.currentAuthenticationElseFail(),
                         ic.getIdentifier())
                 ? null
                 : "Not authorized to edit";

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/command/CommandDtoFactory.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/services/command/CommandDtoFactory.java
@@ -20,6 +20,7 @@ package org.apache.isis.core.metamodel.services.command;
 
 import java.util.UUID;
 
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.metamodel.interactions.InteractionHead;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
@@ -85,7 +86,7 @@ public interface CommandDtoFactory {
      * </p>
      *
      * @see org.apache.isis.schema.ixn.v2.ActionInvocationDto
-     * @see org.apache.isis.applib.services.iactn.InteractionContext
+     * @see InteractionProvider
      * @see org.apache.isis.applib.services.iactn.Interaction
      */
     void addActionArgs(
@@ -103,7 +104,7 @@ public interface CommandDtoFactory {
      * </p>
      *
      * @see org.apache.isis.schema.ixn.v2.PropertyEditDto
-     * @see org.apache.isis.applib.services.iactn.InteractionContext
+     * @see InteractionProvider
      * @see org.apache.isis.applib.services.iactn.Interaction
      */
     void addPropertyValue(

--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/specloader/specimpl/ObjectMemberAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/specloader/specimpl/ObjectMemberAbstract.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import org.apache.isis.applib.Identifier;
 import org.apache.isis.applib.annotation.Where;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.assertions._Assert;
 import org.apache.isis.core.metamodel.commons.StringExtensions;
 import org.apache.isis.core.metamodel.consent.Consent;
@@ -298,8 +299,8 @@ implements ObjectMember, HasMetaModelContext, HasFacetHolder {
 
     // -- Dependencies
 
-    protected org.apache.isis.applib.services.iactn.InteractionContext getInteractionContext() {
-        return getServiceRegistry().lookupServiceElseFail(org.apache.isis.applib.services.iactn.InteractionContext.class);
+    protected InteractionProvider getInteractionContext() {
+        return getServiceRegistry().lookupServiceElseFail(InteractionProvider.class);
     }
 
     protected CommandDtoFactory getCommandDtoFactory() {

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/AbstractFacetFactoryJUnit4TestCase.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/AbstractFacetFactoryJUnit4TestCase.java
@@ -50,7 +50,7 @@ import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
 import org.apache.isis.core.metamodel.spec.feature.OneToOneActionParameter;
 import org.apache.isis.core.metamodel.spec.feature.OneToOneAssociation;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 public abstract class AbstractFacetFactoryJUnit4TestCase {
 
@@ -63,7 +63,7 @@ public abstract class AbstractFacetFactoryJUnit4TestCase {
     @Mock protected ServiceInjector mockServiceInjector;
     @Mock protected ServiceRegistry mockServiceRegistry;
     @Mock protected TranslationService mockTranslationService;
-    @Mock protected AuthenticationContext mockAuthenticationTracker;
+    @Mock protected AuthenticationProvider mockAuthenticationTracker;
 
     @Mock protected ObjectSpecification mockOnType;
     @Mock protected ObjectSpecification mockObjSpec;
@@ -72,7 +72,7 @@ public abstract class AbstractFacetFactoryJUnit4TestCase {
     @Mock protected OneToOneActionParameter mockOneToOneActionParameter;
     @Mock protected MetamodelEventService mockMetamodelEventService;
 
-    
+
     protected MetaModelContext metaModelContext;
     protected IdentifiedHolder facetHolder;
     protected FacetedMethod facetedMethod;
@@ -106,7 +106,7 @@ public abstract class AbstractFacetFactoryJUnit4TestCase {
             allowing(mockServiceRegistry).lookupService(TranslationService.class);
             will(returnValue(Optional.of(mockTranslationService)));
 
-            allowing(mockServiceRegistry).lookupService(AuthenticationContext.class);
+            allowing(mockServiceRegistry).lookupService(AuthenticationProvider.class);
             will(returnValue(Optional.of(mockAuthenticationTracker)));
 
             allowing(mockServiceRegistry).lookupServiceElseFail(MetamodelEventService.class);
@@ -121,11 +121,11 @@ public abstract class AbstractFacetFactoryJUnit4TestCase {
                 Identifier.propertyOrCollectionIdentifier(LogicalType.fqcn(Customer.class), "firstName"));
         facetedMethod = FacetedMethod.createForProperty(AbstractFacetFactoryTest.Customer.class, "firstName");
         facetedMethodParameter = new FacetedMethodParameter(FeatureType.ACTION_PARAMETER_SCALAR, facetedMethod.getOwningType(), facetedMethod.getMethod(), String.class);
-        
+
         ((MetaModelContextAware)facetHolder).setMetaModelContext(metaModelContext);
         facetedMethod.setMetaModelContext(metaModelContext);
         facetedMethodParameter.setMetaModelContext(metaModelContext);
-        
+
     }
 
     @After

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/AbstractFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/AbstractFacetFactoryTest.java
@@ -44,7 +44,7 @@ import org.apache.isis.core.metamodel.facets.properties.propertylayout.PropertyL
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import junit.framework.TestCase;
 
@@ -67,7 +67,7 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
     }
 
     protected TranslationService mockTranslationService;
-    protected AuthenticationContext mockAuthenticationContext;
+    protected AuthenticationProvider mockAuthenticationProvider;
     protected Authentication mockAuthentication;
     protected SpecificationLoader mockSpecificationLoader;
     protected MethodRemoverForTesting methodRemover;
@@ -106,7 +106,7 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
 
         methodRemover = new MethodRemoverForTesting();
 
-        mockAuthenticationContext = context.mock(AuthenticationContext.class);
+        mockAuthenticationProvider = context.mock(AuthenticationProvider.class);
 
         mockTranslationService = context.mock(TranslationService.class);
         mockAuthentication = context.mock(Authentication.class);
@@ -116,15 +116,15 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
                 .translationService(mockTranslationService)
-                .authenticationContext(mockAuthenticationContext)
+                .authenticationProvider(mockAuthenticationProvider)
                 .build();
 
         context.checking(new Expectations() {{
 
-            allowing(mockAuthenticationContext).currentAuthentication();
+            allowing(mockAuthenticationProvider).currentAuthentication();
             will(returnValue(Optional.of(mockAuthentication)));
         }});
-        
+
         ((MetaModelContextAware)facetHolder).setMetaModelContext(metaModelContext);
         facetedMethod.setMetaModelContext(metaModelContext);
         facetedMethodParameter.setMetaModelContext(metaModelContext);
@@ -169,33 +169,33 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
     }
 
     // -- FACTORIES
-    
-    protected static PropertyLayoutFacetFactory createPropertyLayoutFacetFactory() { 
+
+    protected static PropertyLayoutFacetFactory createPropertyLayoutFacetFactory() {
         return new PropertyLayoutFacetFactory() {
             @Override
             public IsisConfiguration getConfiguration() {
                 return new IsisConfiguration(null);
-            }  
+            }
         };
     }
-    
-    protected static CollectionLayoutFacetFactory createCollectionLayoutFacetFactory() { 
+
+    protected static CollectionLayoutFacetFactory createCollectionLayoutFacetFactory() {
         return new CollectionLayoutFacetFactory() {
             @Override
             public IsisConfiguration getConfiguration() {
                 return new IsisConfiguration(null);
-            }  
+            }
         };
     }
-    
-    protected static ActionLayoutFacetFactory createActionLayoutFacetFactory() { 
+
+    protected static ActionLayoutFacetFactory createActionLayoutFacetFactory() {
         return new ActionLayoutFacetFactory() {
             @Override
             public IsisConfiguration getConfiguration() {
                 return new IsisConfiguration(null);
-            }  
+            }
         };
     }
-    
-    
+
+
 }

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/actions/ActionMethodsFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/actions/ActionMethodsFacetFactoryTest.java
@@ -77,7 +77,7 @@ public class ActionMethodsFacetFactoryTest extends AbstractFacetFactoryTest {
 
         context.checking(new Expectations() {{
 
-            allowing(mockAuthenticationContext).currentAuthentication();
+            allowing(mockAuthenticationProvider).currentAuthentication();
             will(returnValue(Optional.of(mockAuthentication)));
         }});
 
@@ -117,7 +117,7 @@ public class ActionMethodsFacetFactoryTest extends AbstractFacetFactoryTest {
 
         @SuppressWarnings("unused")
         class Customer {
-            
+
             public void someAction() {
             }
 

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/actions/action/ActionAnnotationFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/actions/action/ActionAnnotationFacetFactoryTest.java
@@ -32,7 +32,7 @@ import org.apache.isis.core.config.metamodel.facets.PublishingPolicies;
 import org.apache.isis.core.metamodel.facets.AbstractFacetFactoryJUnit4TestCase;
 import org.apache.isis.core.metamodel.facets.object.domainobject.domainevents.ActionDomainEventDefaultFacetForDomainObjectAnnotation;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import lombok.val;
 
@@ -69,7 +69,7 @@ public class ActionAnnotationFacetFactoryTest extends AbstractFacetFactoryJUnit4
         facetFactory.setMetaModelContext(super.metaModelContext);
 
         context.checking(new Expectations() {{
-            allowing(mockServiceRegistry).lookupServiceElseFail(AuthenticationContext.class);
+            allowing(mockServiceRegistry).lookupServiceElseFail(AuthenticationProvider.class);
             will(returnValue(mockAuthenticationTracker));
 
             allowing(mockTypeSpec).getFacet(ActionDomainEventDefaultFacetForDomainObjectAnnotation.class);

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/ident/title/annotation/TitleAnnotationFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/ident/title/annotation/TitleAnnotationFacetFactoryTest.java
@@ -41,7 +41,7 @@ import org.apache.isis.core.metamodel.facets.object.title.annotation.TitleAnnota
 import org.apache.isis.core.metamodel.facets.object.title.annotation.TitleFacetViaTitleAnnotation;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -66,7 +66,7 @@ public class TitleAnnotationFacetFactoryTest extends AbstractFacetFactoryJUnit4T
 
         context.checking(new Expectations() {
             {
-                allowing(mockServiceRegistry).lookupService(AuthenticationContext.class);
+                allowing(mockServiceRegistry).lookupService(AuthenticationProvider.class);
                 will(returnValue(Optional.of(mockAuthenticationTracker)));
 
                 allowing(mockAuthenticationTracker).currentAuthentication();

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/navparent/annotation/NavigableParentAnnotationFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/navparent/annotation/NavigableParentAnnotationFacetFactoryTest.java
@@ -37,7 +37,7 @@ import org.apache.isis.core.metamodel.facets.object.navparent.annotation.Navigab
 import org.apache.isis.core.metamodel.facets.object.navparent.method.NavigableParentFacetMethod;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 public class NavigableParentAnnotationFacetFactoryTest extends AbstractFacetFactoryJUnit4TestCase {
 
@@ -59,7 +59,7 @@ public class NavigableParentAnnotationFacetFactoryTest extends AbstractFacetFact
 
         context.checking(new Expectations() {
             {
-                allowing(mockServiceRegistry).lookupService(AuthenticationContext.class);
+                allowing(mockServiceRegistry).lookupService(AuthenticationProvider.class);
                 will(returnValue(Optional.of(mockAuthenticationTracker)));
 
                 allowing(mockAuthenticationTracker).currentAuthentication();
@@ -103,7 +103,7 @@ public class NavigableParentAnnotationFacetFactoryTest extends AbstractFacetFact
         final Method parentMethod = domainClass.getMethod(parentMethodName);
 
         Assert.assertEquals(
-                parentMethod.invoke(domainObject, _Constants.emptyObjects), 
+                parentMethod.invoke(domainObject, _Constants.emptyObjects),
                 navigableParentFacetMethod.navigableParent(domainObject)	);
 
     }

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/parseable/ParseableFacetUsingParserTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/object/parseable/ParseableFacetUsingParserTest.java
@@ -39,7 +39,7 @@ import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.metamodel.facetapi.FacetHolder;
 import org.apache.isis.core.metamodel.facets.object.parseable.parser.ParseableFacetUsingParser;
 import org.apache.isis.core.metamodel.facets.object.value.ValueFacet;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 public class ParseableFacetUsingParserTest {
 
@@ -47,7 +47,7 @@ public class ParseableFacetUsingParserTest {
     public JUnitRuleMockery2 context = JUnitRuleMockery2.createFor(Mode.INTERFACES_AND_CLASSES);
 
     @Mock private FacetHolder mockFacetHolder;
-    @Mock private AuthenticationContext mockAuthenticationContext;
+    @Mock private AuthenticationProvider mockAuthenticationProvider;
     @Mock private ServiceInjector mockServicesInjector;
     @Mock private ServiceRegistry mockServiceRegistry;
 
@@ -58,18 +58,18 @@ public class ParseableFacetUsingParserTest {
     public void setUp() throws Exception {
 
         metaModelContext = MetaModelContext_forTesting.builder()
-                .authenticationContext(mockAuthenticationContext)
+                .authenticationProvider(mockAuthenticationProvider)
                 .build();
 
 
         context.checking(new Expectations() {
             {
-                never(mockAuthenticationContext);
+                never(mockAuthenticationProvider);
                 //never(mockAdapterManager);
 
                 allowing(mockFacetHolder).getMetaModelContext();
                 will(returnValue(metaModelContext));
-                
+
                 allowing(mockFacetHolder).containsFacet(ValueFacet.class);
                 will(returnValue(Boolean.FALSE));
 

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/value/ValueSemanticsProviderAbstractTestCase.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/facets/value/ValueSemanticsProviderAbstractTestCase.java
@@ -41,7 +41,7 @@ import org.apache.isis.core.metamodel.facets.object.parseable.ParseableFacet;
 import org.apache.isis.core.metamodel.facets.object.parseable.parser.ParseableFacetUsingParser;
 import org.apache.isis.core.metamodel.facets.object.value.vsp.ValueSemanticsProviderAndFacetAbstract;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -56,11 +56,11 @@ public abstract class ValueSemanticsProviderAbstractTestCase {
     public JUnitRuleMockery2 context = JUnitRuleMockery2.createFor(Mode.INTERFACES_AND_CLASSES);
 
     @Mock protected FacetHolder mockFacetHolder;
-    @Mock protected AuthenticationContext mockAuthenticationContext;
+    @Mock protected AuthenticationProvider mockAuthenticationProvider;
     @Mock protected ManagedObject mockAdapter;
-    
+
     protected MetaModelContext metaModelContext;
-    
+
     private ValueSemanticsProviderAndFacetAbstract<?> valueSemanticsProvider;
     private EncodableFacetUsingEncoderDecoder encodeableFacet;
     private ParseableFacetUsingParser parseableFacet;
@@ -71,15 +71,15 @@ public abstract class ValueSemanticsProviderAbstractTestCase {
         Locale.setDefault(Locale.UK);
 
         metaModelContext = MetaModelContext_forTesting.builder()
-                .authenticationContext(mockAuthenticationContext)
+                .authenticationProvider(mockAuthenticationProvider)
                 .build();
 
         context.checking(new Expectations() {
             {
 
-                never(mockAuthenticationContext);
+                never(mockAuthenticationProvider);
                 //never(mockSessionServiceInternal);
-                
+
                 allowing(mockFacetHolder).getMetaModelContext();
                 will(returnValue(metaModelContext));
             }
@@ -103,7 +103,7 @@ public abstract class ValueSemanticsProviderAbstractTestCase {
     protected void setValue(final ValueSemanticsProviderAndFacetAbstract<?> value) {
         this.valueSemanticsProvider = value;
         this.encodeableFacet = new EncodableFacetUsingEncoderDecoder(
-                value, 
+                value,
                 mockFacetHolder);
         this.parseableFacet = new ParseableFacetUsingParser(value, mockFacetHolder);
     }

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/objects/ObjectActionLayoutXmlDefaultTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/objects/ObjectActionLayoutXmlDefaultTest.java
@@ -40,7 +40,7 @@ import org.apache.isis.core.metamodel.facets.all.named.NamedFacetAbstract;
 import org.apache.isis.core.metamodel.id.TypeIdentifierTestFactory;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.specimpl.ObjectActionDefault;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 public class ObjectActionLayoutXmlDefaultTest {
 
@@ -50,7 +50,7 @@ public class ObjectActionLayoutXmlDefaultTest {
     private ObjectActionDefault action;
 
     @Mock private FacetedMethod mockFacetedMethod;
-    @Mock private AuthenticationContext mockAuthenticationContext;
+    @Mock private AuthenticationProvider mockAuthenticationProvider;
     @Mock private SpecificationLoader mockSpecificationLoader;
 
     protected MetaModelContext metaModelContext;
@@ -60,7 +60,7 @@ public class ObjectActionLayoutXmlDefaultTest {
 
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
-                .authenticationContext(mockAuthenticationContext)
+                .authenticationProvider(mockAuthenticationProvider)
                 .build();
 
         context.checking(new Expectations() {

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/objects/OneToManyAssociationDefaultTest.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/objects/OneToManyAssociationDefaultTest.java
@@ -42,7 +42,7 @@ import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.spec.feature.OneToManyAssociation;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.specimpl.OneToManyAssociationDefault;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 public class OneToManyAssociationDefaultTest {
 
@@ -58,7 +58,7 @@ public class OneToManyAssociationDefaultTest {
 
     @Mock ManagedObject mockOwnerAdapter;
     @Mock ManagedObject mockAssociatedAdapter;
-    @Mock AuthenticationContext mockAuthenticationContext;
+    @Mock AuthenticationProvider mockAuthenticationProvider;
     @Mock SpecificationLoader mockSpecificationLoader;
     @Mock ObjectSpecification mockOwnerAdapterSpec;
     @Mock MessageService mockMessageService;
@@ -73,7 +73,7 @@ public class OneToManyAssociationDefaultTest {
 
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
-                .authenticationContext(mockAuthenticationContext)
+                .authenticationProvider(mockAuthenticationProvider)
                 .singleton(mockMessageService)
                 .build();
 

--- a/core/metamodel/src/test/java/org/apache/isis/core/metamodel/specloader/SpecificationLoaderTestAbstract.java
+++ b/core/metamodel/src/test/java/org/apache/isis/core/metamodel/specloader/SpecificationLoaderTestAbstract.java
@@ -45,7 +45,7 @@ import org.apache.isis.core.metamodel.progmodel.ProgrammingModelAbstract;
 import org.apache.isis.core.metamodel.progmodel.ProgrammingModelInitFilterDefault;
 import org.apache.isis.core.metamodel.progmodels.dflt.ProgrammingModelFacetsJava8;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -69,8 +69,8 @@ abstract class SpecificationLoaderTestAbstract {
             return config;
         }
 
-        AuthenticationContext mockAuthenticationProvider() {
-            return Mockito.mock(AuthenticationContext.class);
+        AuthenticationProvider mockAuthenticationProvider() {
+            return Mockito.mock(AuthenticationProvider.class);
         }
 
         GridService mockGridService() {
@@ -103,7 +103,7 @@ abstract class SpecificationLoaderTestAbstract {
 
     protected IsisConfiguration isisConfiguration;
     protected SpecificationLoader specificationLoader;
-    protected AuthenticationContext mockAuthenticationContext;
+    protected AuthenticationProvider mockAuthenticationProvider;
     protected GridService mockGridService;
     protected MessageService mockMessageService;
     protected MetaModelContext metaModelContext;
@@ -126,7 +126,7 @@ abstract class SpecificationLoaderTestAbstract {
                 .translationService(producers.mockTranslationService())
                 .titleService(producers.mockTitleService())
 //                .objectAdapterProvider(mockPersistenceSessionServiceInternal = producers.mockPersistenceSessionServiceInternal())
-                .authenticationContext(mockAuthenticationContext =
+                .authenticationProvider(mockAuthenticationProvider =
                     producers.mockAuthenticationProvider())
                 .singleton(mockMessageService = producers.mockMessageService())
                 .singleton(mockGridService = producers.mockGridService())

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
@@ -25,6 +25,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.xactn.TransactionService;
 import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
@@ -51,7 +52,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
     @Getter(onMethod = @__(@Override)) protected final SpecificationLoader specificationLoader;
     @Getter(onMethod = @__(@Override)) protected final InteractionTracker interactionTracker;
 
-    @Getter protected final InteractionFactory interactionFactory;
+    @Getter protected final InteractionHandler interactionHandler;
     @Getter protected final AuthenticationManager authenticationManager;
     @Getter protected final TransactionService transactionService;
     @Getter protected final Supplier<ManagedObject> homePageSupplier;
@@ -68,7 +69,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
         this.objectManager = mmc.getObjectManager();
         this.transactionService = mmc.getTransactionService();
         this.homePageSupplier = mmc::getHomePageAdapter;
-        this.interactionFactory = serviceRegistry.lookupServiceElseFail(InteractionFactory.class);
+        this.interactionHandler = serviceRegistry.lookupServiceElseFail(InteractionFactory.class);
         this.authenticationManager = serviceRegistry.lookupServiceElseFail(AuthenticationManager.class);
         this.interactionTracker = serviceRegistry.lookupServiceElseFail(InteractionTracker.class);
     }
@@ -89,7 +90,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
         .ifPresent(authentication->{
 
             authenticationManager.closeSession(authentication);
-            interactionFactory.closeInteractionLayers();
+            interactionHandler.closeInteractionLayers();
 
         });
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
@@ -30,7 +30,7 @@ import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.manager.AuthenticationManager;
 
 import lombok.Getter;
@@ -75,7 +75,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
 
     // -- AUTH
 
-    public AuthenticationContext getAuthenticationContext() {
+    public AuthenticationProvider getAuthenticationContext() {
         return interactionTracker;
     }
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
@@ -25,7 +25,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.xactn.TransactionService;
 import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
@@ -89,7 +89,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
         .ifPresent(authentication->{
 
             authenticationManager.closeSession(authentication);
-            interactionFactory.closeSessionStack();
+            interactionFactory.closeInteractionLayers();
 
         });
 

--- a/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
+++ b/core/runtime/src/main/java/org/apache/isis/core/runtime/context/RuntimeContextBase.java
@@ -25,7 +25,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.xactn.TransactionService;
 import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
@@ -52,7 +52,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
     @Getter(onMethod = @__(@Override)) protected final SpecificationLoader specificationLoader;
     @Getter(onMethod = @__(@Override)) protected final InteractionTracker interactionTracker;
 
-    @Getter protected final InteractionHandler interactionHandler;
+    @Getter protected final InteractionService interactionService;
     @Getter protected final AuthenticationManager authenticationManager;
     @Getter protected final TransactionService transactionService;
     @Getter protected final Supplier<ManagedObject> homePageSupplier;
@@ -69,7 +69,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
         this.objectManager = mmc.getObjectManager();
         this.transactionService = mmc.getTransactionService();
         this.homePageSupplier = mmc::getHomePageAdapter;
-        this.interactionHandler = serviceRegistry.lookupServiceElseFail(InteractionFactory.class);
+        this.interactionService = serviceRegistry.lookupServiceElseFail(InteractionFactory.class);
         this.authenticationManager = serviceRegistry.lookupServiceElseFail(AuthenticationManager.class);
         this.interactionTracker = serviceRegistry.lookupServiceElseFail(InteractionTracker.class);
     }
@@ -90,7 +90,7 @@ public abstract class RuntimeContextBase implements RuntimeContext {
         .ifPresent(authentication->{
 
             authenticationManager.closeSession(authentication);
-            interactionHandler.closeInteractionLayers();
+            interactionService.closeInteractionLayers();
 
         });
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/clock/ClockServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/clock/ClockServiceDefault.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Service;
 import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.clock.VirtualClock;
 import org.apache.isis.applib.services.clock.ClockService;
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 
 import lombok.RequiredArgsConstructor;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/clock/ClockServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/clock/ClockServiceDefault.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Service;
 import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.clock.VirtualClock;
 import org.apache.isis.applib.services.clock.ClockService;
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 
 import lombok.RequiredArgsConstructor;
@@ -47,7 +47,7 @@ public class ClockServiceDefault implements ClockService {
     @Override
     public VirtualClock getClock() {
         return interactionTracker.currentExecutionContext()
-        .map(ExecutionContext::getClock)
+        .map(InteractionContext::getClock)
         .orElseGet(VirtualClock::system);
     }
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
@@ -52,7 +52,7 @@ import org.apache.isis.commons.collections.Can;
 import org.apache.isis.commons.functional.Result;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.isis.core.metamodel.facets.actions.action.invocation.CommandUtil;
@@ -101,7 +101,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
     @Inject final InteractionTracker isisInteractionTracker;
     @Inject final Provider<InteractionProvider> interactionProviderProvider;
 
-    @Inject @Getter final InteractionHandler interactionHandler;
+    @Inject @Getter final InteractionService interactionService;
     @Inject @Getter final SpecificationLoader specificationLoader;
 
     @Override

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
@@ -52,7 +52,7 @@ import org.apache.isis.commons.collections.Can;
 import org.apache.isis.commons.functional.Result;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.isis.core.metamodel.facets.actions.action.invocation.CommandUtil;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
@@ -52,7 +52,7 @@ import org.apache.isis.commons.collections.Can;
 import org.apache.isis.commons.functional.Result;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.isis.core.metamodel.facets.actions.action.invocation.CommandUtil;
@@ -101,7 +101,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
     @Inject final InteractionTracker isisInteractionTracker;
     @Inject final Provider<InteractionProvider> interactionProviderProvider;
 
-    @Inject @Getter final InteractionFactory isisInteractionFactory;
+    @Inject @Getter final InteractionHandler interactionHandler;
     @Inject @Getter final SpecificationLoader specificationLoader;
 
     @Override

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
@@ -42,7 +42,7 @@ import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.command.CommandOutcomeHandler;
 import org.apache.isis.applib.services.iactn.Execution;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.sudo.SudoService;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.applib.services.xactn.TransactionService;
@@ -99,7 +99,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
     @Inject final ClockService clockService;
     @Inject final TransactionService transactionService;
     @Inject final InteractionTracker isisInteractionTracker;
-    @Inject final Provider<InteractionContext> interactionContextProvider;
+    @Inject final Provider<InteractionProvider> interactionContextProvider;
 
     @Inject @Getter final InteractionFactory isisInteractionFactory;
     @Inject @Getter final SpecificationLoader specificationLoader;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/command/CommandExecutorServiceDefault.java
@@ -99,7 +99,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
     @Inject final ClockService clockService;
     @Inject final TransactionService transactionService;
     @Inject final InteractionTracker isisInteractionTracker;
-    @Inject final Provider<InteractionProvider> interactionContextProvider;
+    @Inject final Provider<InteractionProvider> interactionProviderProvider;
 
     @Inject @Getter final InteractionFactory isisInteractionFactory;
     @Inject @Getter final SpecificationLoader specificationLoader;
@@ -139,7 +139,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
             final CommandDto dto,
             final CommandOutcomeHandler commandUpdater) {
 
-        val interaction = interactionContextProvider.get().currentInteractionElseFail();
+        val interaction = interactionProviderProvider.get().currentInteractionElseFail();
         val command = interaction.getCommand();
         if(command.getCommandDto() != dto) {
             command.updater().setCommandDto(dto);
@@ -165,7 +165,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
     private void copyStartedAtFromInteractionExecution(
             final CommandOutcomeHandler commandOutcomeHandler) {
 
-        val interaction = interactionContextProvider.get().currentInteractionElseFail();
+        val interaction = interactionProviderProvider.get().currentInteractionElseFail();
         val currentExecution = interaction.getCurrentExecution();
 
         val startedAt = currentExecution != null
@@ -271,7 +271,7 @@ public class CommandExecutorServiceDefault implements CommandExecutorService {
         // there was an exception when performing the action invocation/property
         // edit.  We therefore need to guard that case.
         //
-        val interaction = interactionContextProvider.get().currentInteractionElseFail();
+        val interaction = interactionProviderProvider.get().currentInteractionElseFail();
 
         final Execution<?, ?> priorExecution = interaction.getPriorExecution();
         if(priorExecution != null) {

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/factory/FactoryServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/factory/FactoryServiceDefault.java
@@ -40,7 +40,7 @@ import org.apache.isis.commons.internal.base._Casts;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.reflection._Reflect;
 import org.apache.isis.core.config.environment.IsisSystemEnvironment;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.metamodel.facets.object.mixin.MixinFacet;
 import org.apache.isis.core.metamodel.facets.object.viewmodel.ViewModelFacet;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
@@ -56,7 +56,7 @@ import lombok.val;
 @Qualifier("Default")
 public class FactoryServiceDefault implements FactoryService {
 
-    @Inject InteractionHandler interactionHandler; // dependsOn
+    @Inject InteractionService interactionService; // dependsOn
     @Inject private SpecificationLoader specificationLoader;
     @Inject private ServiceInjector serviceInjector;
     @Inject private IsisSystemEnvironment isisSystemEnvironment;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/factory/FactoryServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/factory/FactoryServiceDefault.java
@@ -40,7 +40,7 @@ import org.apache.isis.commons.internal.base._Casts;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.reflection._Reflect;
 import org.apache.isis.core.config.environment.IsisSystemEnvironment;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.metamodel.facets.object.mixin.MixinFacet;
 import org.apache.isis.core.metamodel.facets.object.viewmodel.ViewModelFacet;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
@@ -56,7 +56,7 @@ import lombok.val;
 @Qualifier("Default")
 public class FactoryServiceDefault implements FactoryService {
 
-    @Inject InteractionFactory isisInteractionFactory; // dependsOn
+    @Inject InteractionHandler interactionHandler; // dependsOn
     @Inject private SpecificationLoader specificationLoader;
     @Inject private ServiceInjector serviceInjector;
     @Inject private IsisSystemEnvironment isisSystemEnvironment;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/factory/FactoryServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/factory/FactoryServiceDefault.java
@@ -40,7 +40,7 @@ import org.apache.isis.commons.internal.base._Casts;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.reflection._Reflect;
 import org.apache.isis.core.config.environment.IsisSystemEnvironment;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.metamodel.facets.object.mixin.MixinFacet;
 import org.apache.isis.core.metamodel.facets.object.viewmodel.ViewModelFacet;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/interaction/InteractionDtoFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/interaction/InteractionDtoFactoryDefault.java
@@ -72,7 +72,7 @@ public class InteractionDtoFactoryDefault implements InteractionDtoFactory {
 
     @Inject private CommandDtoFactory commandDtoServiceInternal;
     @Inject private BookmarkService bookmarkService;
-    @Inject private javax.inject.Provider<InteractionProvider> interactionContextProvider;
+    @Inject private javax.inject.Provider<InteractionProvider> interactionProviderProvider;
     @Inject private UserService userService;
 
     @Override
@@ -84,7 +84,7 @@ public class InteractionDtoFactoryDefault implements InteractionDtoFactory {
         _Assert.assertEquals(objectAction.getParameterCount(), argumentAdapters.size(),
                 "action's parameter count and provided argument count must match");
 
-        val interaction = interactionContextProvider.get().currentInteractionElseFail();
+        val interaction = interactionProviderProvider.get().currentInteractionElseFail();
         final int nextEventSequence = ((InteractionInternal) interaction).getThenIncrementExecutionSequence();
 
         val owner = head.getOwner();
@@ -128,7 +128,7 @@ public class InteractionDtoFactoryDefault implements InteractionDtoFactory {
             final ManagedObject targetAdapter,
             final ManagedObject newValueAdapterIfAny) {
 
-        final Interaction interaction = interactionContextProvider.get().currentInteractionElseFail();
+        final Interaction interaction = interactionProviderProvider.get().currentInteractionElseFail();
         final int nextEventSequence = ((InteractionInternal) interaction).getThenIncrementExecutionSequence();
 
         final Bookmark targetBookmark = targetAdapter.getBookmark()

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/interaction/InteractionDtoFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/interaction/InteractionDtoFactoryDefault.java
@@ -33,7 +33,7 @@ import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.services.bookmark.Bookmark;
 import org.apache.isis.applib.services.bookmark.BookmarkService;
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.user.UserService;
 import org.apache.isis.applib.util.schema.CommandDtoUtils;
 import org.apache.isis.applib.util.schema.InteractionDtoUtils;
@@ -72,7 +72,7 @@ public class InteractionDtoFactoryDefault implements InteractionDtoFactory {
 
     @Inject private CommandDtoFactory commandDtoServiceInternal;
     @Inject private BookmarkService bookmarkService;
-    @Inject private javax.inject.Provider<InteractionContext> interactionContextProvider;
+    @Inject private javax.inject.Provider<InteractionProvider> interactionContextProvider;
     @Inject private UserService userService;
 
     @Override

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/AnonymousAuthentication.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/AnonymousAuthentication.java
@@ -22,14 +22,14 @@ import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 
-final class AnonymousSession extends AuthenticationAbstract {
+public final class AnonymousAuthentication extends AuthenticationAbstract {
 
     private static final long serialVersionUID = 1L;
 
     private static final InteractionContext INITIALISATION_CONTEXT =
             InteractionContext.ofUserWithSystemDefaults(UserMemento.system());
 
-    public AnonymousSession() {
+    public AnonymousAuthentication() {
         super(INITIALISATION_CONTEXT, AuthenticationAbstract.DEFAULT_AUTH_VALID_CODE);
     }
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/AnonymousSession.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/AnonymousSession.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.runtimeservices.session;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/AnonymousSession.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/AnonymousSession.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.runtimeservices.session;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 
@@ -26,8 +26,8 @@ final class AnonymousSession extends AuthenticationAbstract {
 
     private static final long serialVersionUID = 1L;
 
-    private static final ExecutionContext INITIALISATION_CONTEXT =
-            ExecutionContext.ofUserWithSystemDefaults(UserMemento.system());
+    private static final InteractionContext INITIALISATION_CONTEXT =
+            InteractionContext.ofUserWithSystemDefaults(UserMemento.system());
 
     public AnonymousSession() {
         super(INITIALISATION_CONTEXT, AuthenticationAbstract.DEFAULT_AUTH_VALID_CODE);

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
@@ -160,7 +160,7 @@ implements
         return currentInteractionLayer()
                 // or else create an anonymous authentication layer
                 .orElseGet(()-> {
-                    final AnonymousSession authToUse = new AnonymousSession();
+                    final AnonymousAuthentication authToUse = new AnonymousAuthentication();
                     return openInteraction(authToUse.getInteractionContext());
                 });
     }
@@ -282,7 +282,7 @@ implements
             serviceInjector.injectServicesInto(callable);
             return callable.call(); // reuse existing session
         }
-        return callAuthenticated(new AnonymousSession(), callable);
+        return callAuthenticated(new AnonymousAuthentication(), callable);
     }
 
     /**
@@ -297,7 +297,7 @@ implements
             runnable.run(); // reuse existing session
             return;
         }
-        runAuthenticated(new AnonymousSession(), runnable);
+        runAuthenticated(new AnonymousAuthentication(), runnable);
     }
 
     // -- CONVERSATION ID

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
@@ -61,7 +61,7 @@ import org.apache.isis.core.interaction.integration.InteractionAwareTransactiona
 import org.apache.isis.core.interaction.scope.InteractionScopeAware;
 import org.apache.isis.core.interaction.scope.InteractionScopeBeanFactoryPostProcessor;
 import org.apache.isis.core.interaction.scope.InteractionScopeLifecycleHandler;
-import org.apache.isis.core.interaction.session.InteractionLayer;
+import org.apache.isis.applib.services.iactnlayer.InteractionLayer;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.interaction.session.IsisInteraction;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
@@ -174,8 +174,8 @@ implements
         // check whether we should reuse any current authenticationLayer,
         // that is, if current authentication and authToUse are equal
 
-        val reuseCurrentLayer = currentInteraction()
-                .map(currentInteraction -> Objects.equals(currentInteraction, interactionContextToUse))
+        val reuseCurrentLayer = currentInteractionContext()
+                .map(currentInteractionContext -> Objects.equals(currentInteractionContext, interactionContextToUse))
                 .orElse(false);
 
         if(reuseCurrentLayer) {

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
@@ -161,13 +161,12 @@ implements
                 // or else create an anonymous authentication layer
                 .orElseGet(()-> {
                     final AnonymousSession authToUse = new AnonymousSession();
-                    return openInteraction(authToUse, authToUse.getInteractionContext());
+                    return openInteraction(authToUse.getInteractionContext());
                 });
     }
 
     @Override
     public InteractionLayer openInteraction(
-            final @NonNull Authentication authToUse,
             final @NonNull InteractionContext interactionContextToUse) {
 
         val isisInteraction = getOrCreateIsisInteraction();
@@ -184,7 +183,7 @@ implements
             return interactionLayerStack.get().peek();
         }
 
-        val interactionLayer = new InteractionLayer(isisInteraction, authToUse, interactionContextToUse);
+        val interactionLayer = new InteractionLayer(isisInteraction, interactionContextToUse);
 
         interactionLayerStack.get().push(interactionLayer);
 
@@ -245,7 +244,7 @@ implements
             @NonNull final Callable<R> callable) {
 
         final int stackSizeWhenEntering = interactionLayerStack.get().size();
-        openInteraction(authentication, authentication.getInteractionContext());
+        openInteraction(authentication.getInteractionContext());
 
         try {
             serviceInjector.injectServicesInto(callable);
@@ -263,7 +262,7 @@ implements
             @NonNull final ThrowingRunnable runnable) {
 
         final int stackSizeWhenEntering = interactionLayerStack.get().size();
-        openInteraction(authentication, authentication.getInteractionContext());
+        openInteraction(authentication.getInteractionContext());
 
         try {
             serviceInjector.injectServicesInto(runnable);

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
@@ -184,7 +184,7 @@ implements
             return interactionLayerStack.get().peek();
         }
 
-        val interactionLayer = new InteractionLayer(isisInteraction, authToUse);
+        val interactionLayer = new InteractionLayer(isisInteraction, authToUse, interactionContextToUse);
 
         interactionLayerStack.get().push(interactionLayer);
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionFactoryDefault.java
@@ -50,7 +50,7 @@ import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.applib.util.schema.ChangesDtoUtils;
 import org.apache.isis.applib.util.schema.CommandDtoUtils;
 import org.apache.isis.applib.util.schema.InteractionDtoUtils;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.commons.internal.base._Casts;
 import org.apache.isis.commons.internal.concurrent._ConcurrentContext;
 import org.apache.isis.commons.internal.concurrent._ConcurrentTaskList;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/_Xray.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/_Xray.java
@@ -39,7 +39,7 @@ final class _Xray {
         // make defensive copies, so can use in another thread
         final int authStackSize = afterEnter.size();
         val interactionId = afterEnter.peek().getInteraction().getInteractionId();
-        val executionContext = afterEnter.peek().getExecutionContext();
+        val executionContext = afterEnter.peek().getInteractionContext();
 
         val threadId = XrayUtil.currentThreadAsMemento();
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/_Xray.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/_Xray.java
@@ -22,7 +22,7 @@ import java.util.Stack;
 
 import org.apache.isis.commons.internal.debug.xray.XrayDataModel;
 import org.apache.isis.commons.internal.debug.xray.XrayUi;
-import org.apache.isis.core.interaction.session.AuthenticationLayer;
+import org.apache.isis.core.interaction.session.InteractionLayer;
 import org.apache.isis.core.security.util.XrayUtil;
 
 import lombok.val;
@@ -30,7 +30,7 @@ import lombok.val;
 //@Log4j2
 final class _Xray {
 
-    static void newAuthenticationLayer(Stack<AuthenticationLayer> afterEnter) {
+    static void newInteractionLayer(Stack<InteractionLayer> afterEnter) {
 
         if(!XrayUi.isXrayEnabled()) {
             return;
@@ -85,7 +85,7 @@ final class _Xray {
 
     }
 
-    public static void closeAuthenticationLayer(Stack<AuthenticationLayer> beforeClose) {
+    public static void closeInteractionLayer(Stack<InteractionLayer> beforeClose) {
 
         if(!XrayUi.isXrayEnabled()) {
             return;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/_Xray.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/_Xray.java
@@ -22,7 +22,7 @@ import java.util.Stack;
 
 import org.apache.isis.commons.internal.debug.xray.XrayDataModel;
 import org.apache.isis.commons.internal.debug.xray.XrayUi;
-import org.apache.isis.core.interaction.session.InteractionLayer;
+import org.apache.isis.applib.services.iactnlayer.InteractionLayer;
 import org.apache.isis.core.security.util.XrayUtil;
 
 import lombok.val;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -31,7 +31,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
 import org.apache.isis.applib.annotation.OrderPrecedence;
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.sudo.SudoService;
 import org.apache.isis.applib.services.sudo.SudoServiceListener;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -31,7 +31,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
 import org.apache.isis.applib.annotation.OrderPrecedence;
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.sudo.SudoService;
 import org.apache.isis.applib.services.sudo.SudoServiceListener;
@@ -69,7 +69,7 @@ public class SudoServiceDefault implements SudoService {
 
     @Override
     public <T> T call(
-            final @NonNull UnaryOperator<ExecutionContext> sudoMapper,
+            final @NonNull UnaryOperator<InteractionContext> sudoMapper,
             final @NonNull Callable<T> callable) {
 
         val currentInteractionLayer = interactionTracker.currentInteractionLayerElseFail();
@@ -92,16 +92,16 @@ public class SudoServiceDefault implements SudoService {
     // -- HELPER
 
     private void beforeCall(
-            final @NonNull ExecutionContext before,
-            final @NonNull ExecutionContext after) {
+            final @NonNull InteractionContext before,
+            final @NonNull InteractionContext after) {
         for (val sudoListener : sudoListeners) {
             sudoListener.beforeCall(before, after);
         }
     }
 
     private void afterCall(
-            final @NonNull ExecutionContext before,
-            final @NonNull ExecutionContext after) {
+            final @NonNull InteractionContext before,
+            final @NonNull InteractionContext after) {
         for (val sudoListener : sudoListeners) {
             sudoListener.afterCall(before, after);
         }

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -19,6 +19,7 @@
 
 package org.apache.isis.core.runtimeservices.sudo;
 
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.UnaryOperator;
 
@@ -38,6 +39,9 @@ import org.apache.isis.applib.services.sudo.SudoServiceListener;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
+import org.apache.isis.core.runtimeservices.session.AnonymousAuthentication;
+import org.apache.isis.core.security.authentication.Authentication;
+import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -76,9 +80,9 @@ public class SudoServiceDefault implements SudoService {
         val currentInteractionContext = currentInteractionLayer.getInteractionContext();
         val sudoInteractionContext = sudoMapper.apply(currentInteractionContext);
 
-        val sudoAuthentication = currentInteractionLayer
-                .getAuthentication()
-                .withInteractionContext(sudoInteractionContext);
+        val authentication = Authentication.authenticationFrom(currentInteractionContext)
+                                .orElse(SimpleAuthentication.validOf(currentInteractionContext));
+        val sudoAuthentication = authentication.withInteractionContext(sudoInteractionContext);
 
         try {
             beforeCall(currentInteractionContext, sudoInteractionContext);

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -73,19 +73,19 @@ public class SudoServiceDefault implements SudoService {
             final @NonNull Callable<T> callable) {
 
         val currentInteractionLayer = interactionTracker.currentInteractionLayerElseFail();
-        val currentExecutionContext = currentInteractionLayer.getInteractionContext();
-        val sudoExecutionContext = sudoMapper.apply(currentExecutionContext);
+        val currentInteractionContext = currentInteractionLayer.getInteractionContext();
+        val sudoInteractionContext = sudoMapper.apply(currentInteractionContext);
 
-        val sodoSession = currentInteractionLayer
+        val sudoAuthentication = currentInteractionLayer
                 .getAuthentication()
-                .withInteractionContext(sudoExecutionContext);
+                .withInteractionContext(sudoInteractionContext);
 
         try {
-            beforeCall(currentExecutionContext, sudoExecutionContext);
+            beforeCall(currentInteractionContext, sudoInteractionContext);
 
-            return interactionFactory.callAuthenticated(sodoSession, callable);
+            return interactionFactory.callAuthenticated(sudoAuthentication, callable);
         } finally {
-            afterCall(sudoExecutionContext, currentExecutionContext);
+            afterCall(sudoInteractionContext, currentInteractionContext);
         }
     }
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -72,7 +72,7 @@ public class SudoServiceDefault implements SudoService {
             final @NonNull UnaryOperator<ExecutionContext> sudoMapper,
             final @NonNull Callable<T> callable) {
 
-        val currentInteractionLayer = interactionTracker.currentAuthenticationLayerElseFail();
+        val currentInteractionLayer = interactionTracker.currentInteractionLayerElseFail();
         val currentExecutionContext = currentInteractionLayer.getExecutionContext();
         val sudoExecutionContext = sudoMapper.apply(currentExecutionContext);
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -78,7 +78,7 @@ public class SudoServiceDefault implements SudoService {
 
         val sodoSession = currentInteractionLayer
                 .getAuthentication()
-                .withExecutionContext(sudoExecutionContext);
+                .withInteractionContext(sudoExecutionContext);
 
         try {
             beforeCall(currentExecutionContext, sudoExecutionContext);

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/sudo/SudoServiceDefault.java
@@ -73,7 +73,7 @@ public class SudoServiceDefault implements SudoService {
             final @NonNull Callable<T> callable) {
 
         val currentInteractionLayer = interactionTracker.currentInteractionLayerElseFail();
-        val currentExecutionContext = currentInteractionLayer.getExecutionContext();
+        val currentExecutionContext = currentInteractionLayer.getInteractionContext();
         val sudoExecutionContext = sudoMapper.apply(currentExecutionContext);
 
         val sodoSession = currentInteractionLayer

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/user/UserServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/user/UserServiceDefault.java
@@ -30,7 +30,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
 import org.apache.isis.applib.annotation.OrderPrecedence;
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.ImpersonatedUserHolder;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.applib.services.user.UserService;
@@ -62,7 +62,7 @@ public class UserServiceDefault implements UserService {
         Optional<UserMemento> optional = getImpersonatedUser();
         return optional.isPresent()
                 ? optional
-                : isisInteractionTracker.currentExecutionContext().map(ExecutionContext::getUser);
+                : isisInteractionTracker.currentExecutionContext().map(InteractionContext::getUser);
     }
 
     @Override

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/user/UserServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/user/UserServiceDefault.java
@@ -30,7 +30,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
 import org.apache.isis.applib.annotation.OrderPrecedence;
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.user.ImpersonatedUserHolder;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.applib.services.user.UserService;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -362,7 +362,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
         val asyncInteractionContext = interactionContextFrom(asyncControl, interactionContext);
 
         val authIfAny = Authentication.authenticationFrom(interactionLayer.getInteractionContext());
-        if(authIfAny.isEmpty()) {
+        if(!authIfAny.isPresent()) {
             return null;
         }
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -471,7 +471,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
                 .orElseGet(executionContext::getUser))
         .build();
 
-        return auth.withExecutionContext(newExecutionContext);
+        return auth.withInteractionContext(newExecutionContext);
 
     }
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -361,7 +361,12 @@ public class WrapperFactoryDefault implements WrapperFactory {
         val interactionContext = interactionLayer.getInteractionContext();
         val asyncInteractionContext = interactionContextFrom(asyncControl, interactionContext);
 
-        val auth = interactionLayer.getAuthentication();
+        val authIfAny = Authentication.authenticationFrom(interactionLayer.getInteractionContext());
+        if(authIfAny.isEmpty()) {
+            return null;
+        }
+
+        val auth = authIfAny.get();
         val asyncAuth = auth.withInteractionContext(asyncInteractionContext);
 
         val command = interactionProviderProvider.get().currentInteractionElseFail().getCommand();

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -81,7 +81,7 @@ import org.apache.isis.commons.collections.ImmutableEnumSet;
 import org.apache.isis.commons.internal.base._Casts;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.proxy._ProxyFactoryService;
-import org.apache.isis.core.interaction.session.InteractionLayer;
+import org.apache.isis.applib.services.iactnlayer.InteractionLayer;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.context.MetaModelContext;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -47,7 +47,7 @@ import org.apache.isis.applib.services.bookmark.BookmarkService;
 import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.factory.FactoryService;
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
@@ -460,7 +460,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
 
         val executionContext = auth.getExecutionContext();
 
-        val newExecutionContext = ExecutionContext.builder()
+        val newExecutionContext = InteractionContext.builder()
         .clock(Optional.ofNullable(asyncControl.getClock())
                 .orElseGet(executionContext::getClock))
         .locale(Optional.ofNullable(asyncControl.getLocale())

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -124,7 +124,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
     @Inject FactoryService factoryService;
     @Inject MetaModelContext metaModelContext;
     @Inject SpecificationLoader specificationLoader;
-    @Inject Provider<InteractionProvider> interactionContextProvider;
+    @Inject Provider<InteractionProvider> interactionProviderProvider;
     @Inject ServiceInjector serviceInjector;
     @Inject _ProxyFactoryService proxyFactoryService; // protected to allow JUnit test
     @Inject CommandDtoFactory commandDtoFactory;
@@ -359,7 +359,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
 
         val interactionLayer = currentInteractionLayer();
         val asyncAuth = authFrom(asyncControl, interactionLayer.getAuthentication());
-        val command = interactionContextProvider.get().currentInteractionElseFail().getCommand();
+        val command = interactionProviderProvider.get().currentInteractionElseFail().getCommand();
         val commandInteractionId = command.getInteractionId();
 
         val targetAdapter = memberAndTarget.getTarget();
@@ -597,7 +597,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
         @Inject InteractionFactory interactionFactory;
         @Inject TransactionService transactionService;
         @Inject CommandExecutorService commandExecutorService;
-        @Inject Provider<InteractionProvider> interactionContextProvider;
+        @Inject Provider<InteractionProvider> interactionProviderProvider;
         @Inject BookmarkService bookmarkService;
         @Inject RepositoryService repositoryService;
         @Inject MetaModelService metaModelService;
@@ -616,7 +616,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
 
         private R updateDomainObject() {
 
-            val childCommand = interactionContextProvider.get().currentInteractionElseFail().getCommand();
+            val childCommand = interactionProviderProvider.get().currentInteractionElseFail().getCommand();
             childCommand.updater().setParent(parentCommand);
 
             val bookmark = commandExecutorService.executeCommand(commandDto, childCommand.updater());

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -458,7 +458,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
 
     private static <R> Authentication authFrom(AsyncControl<R> asyncControl, Authentication auth) {
 
-        val executionContext = auth.getExecutionContext();
+        val executionContext = auth.getInteractionContext();
 
         val newExecutionContext = InteractionContext.builder()
         .clock(Optional.ofNullable(asyncControl.getClock())

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -48,7 +48,7 @@ import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.factory.FactoryService;
 import org.apache.isis.applib.services.iactn.ExecutionContext;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
 import org.apache.isis.applib.services.repository.RepositoryService;
@@ -124,7 +124,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
     @Inject FactoryService factoryService;
     @Inject MetaModelContext metaModelContext;
     @Inject SpecificationLoader specificationLoader;
-    @Inject Provider<InteractionContext> interactionContextProvider;
+    @Inject Provider<InteractionProvider> interactionContextProvider;
     @Inject ServiceInjector serviceInjector;
     @Inject _ProxyFactoryService proxyFactoryService; // protected to allow JUnit test
     @Inject CommandDtoFactory commandDtoFactory;
@@ -597,7 +597,7 @@ public class WrapperFactoryDefault implements WrapperFactory {
         @Inject InteractionFactory interactionFactory;
         @Inject TransactionService transactionService;
         @Inject CommandExecutorService commandExecutorService;
-        @Inject Provider<InteractionContext> interactionContextProvider;
+        @Inject Provider<InteractionProvider> interactionContextProvider;
         @Inject BookmarkService bookmarkService;
         @Inject RepositoryService repositoryService;
         @Inject MetaModelService metaModelService;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -47,7 +47,7 @@ import org.apache.isis.applib.services.bookmark.BookmarkService;
 import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.factory.FactoryService;
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.applib.services.metamodel.MetaModelService;

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/wrapper/WrapperFactoryDefault.java
@@ -81,7 +81,7 @@ import org.apache.isis.commons.collections.ImmutableEnumSet;
 import org.apache.isis.commons.internal.base._Casts;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.proxy._ProxyFactoryService;
-import org.apache.isis.core.interaction.session.AuthenticationLayer;
+import org.apache.isis.core.interaction.session.InteractionLayer;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.metamodel.context.MetaModelContext;
@@ -576,8 +576,8 @@ public class WrapperFactoryDefault implements WrapperFactory {
         dispatchersByEventClass.put(type, dispatcher);
     }
 
-    private AuthenticationLayer currentInteractionLayer() {
-        return interactionTracker.currentAuthenticationLayerElseFail();
+    private InteractionLayer currentInteractionLayer() {
+        return interactionTracker.currentInteractionLayerElseFail();
     }
 
     private ObjectManager currentObjectManager() {

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
@@ -21,7 +21,7 @@ package org.apache.isis.core.security.authentication;
 
 import java.io.Serializable;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.user.UserMemento;
 
@@ -29,7 +29,7 @@ import org.apache.isis.applib.services.user.UserMemento;
  * An immutable, serializable value type, that holds details about a user's authentication.
  *
  * <p>
- *     This is really little more than a thin wrapper around {@link ExecutionContext},
+ *     This is really little more than a thin wrapper around {@link InteractionContext},
  *     surfaces a number of the security-specific attributes of that field.
  * </p>
  *
@@ -67,12 +67,12 @@ public interface Authentication extends Serializable {
     }
 
     /**
-     * The {@link ExecutionContext} (programmatically) simulated (or actual), belonging to this session.
+     * The {@link InteractionContext} (programmatically) simulated (or actual), belonging to this session.
      *
      * @apiNote immutable, allows an {@link Interaction} to (logically) run with its
      * own simulated (or actual) clock
      */
-    ExecutionContext getExecutionContext();
+    InteractionContext getExecutionContext();
 
     /**
      * To support external security mechanisms such as keycloak, where the validity of the session is defined by
@@ -96,8 +96,8 @@ public interface Authentication extends Serializable {
     // -- WITHERS
 
     /**
-     * Returns a copy with given {@code executionContext}.
-     * @param executionContext
+     * Returns a copy with given {@code interactionContext}.
+     * @param interactionContext
      */
-    Authentication withExecutionContext(ExecutionContext executionContext);
+    Authentication withExecutionContext(InteractionContext interactionContext);
 }

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
@@ -99,5 +99,5 @@ public interface Authentication extends Serializable {
      * Returns a copy with given {@code interactionContext}.
      * @param interactionContext
      */
-    Authentication withExecutionContext(InteractionContext interactionContext);
+    Authentication withInteractionContext(InteractionContext interactionContext);
 }

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
@@ -20,10 +20,13 @@
 package org.apache.isis.core.security.authentication;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.user.UserMemento;
+
+import lombok.NonNull;
 
 /**
  * An immutable, serializable value type, that holds details about a user's authentication.
@@ -38,6 +41,8 @@ import org.apache.isis.applib.services.user.UserMemento;
  * @since 2.0 {@index}
  */
 public interface Authentication extends Serializable {
+
+    String INTERACTION_CONTEXT_KEY = Authentication.class.getName();
 
     /**
      * The name of the authenticated user; for display purposes only.
@@ -100,4 +105,20 @@ public interface Authentication extends Serializable {
      * @param interactionContext
      */
     Authentication withInteractionContext(InteractionContext interactionContext);
+
+    /**
+     * Looks up an {@link Authentication} from the provided {@link InteractionContext}.
+     *
+     * <p>
+     *     If the {@link InteractionContext} was created as the result of an authentication process (as opposed to
+     *     programmatically) then there will be an attached {@link Authentication} object.
+     * </p>
+     *
+     * @param interactionContext
+     * @return
+     */
+    public static Optional<Authentication> authenticationFrom(final @NonNull InteractionContext interactionContext) {
+        return interactionContext.getAttribute(INTERACTION_CONTEXT_KEY, Authentication.class);
+    }
+
 }

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
@@ -28,6 +28,11 @@ import org.apache.isis.applib.services.user.UserMemento;
 /**
  * An immutable, serializable value type, that holds details about a user's authentication.
  *
+ * <p>
+ *     This is really little more than a thin wrapper around {@link ExecutionContext},
+ *     surfaces a number of the security-specific attributes of that field.
+ * </p>
+ *
  * @apiNote This is a framework internal class and so does not constitute a formal API.
  *
  * @since 2.0 {@index}

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
@@ -21,7 +21,7 @@ package org.apache.isis.core.security.authentication;
 
 import java.io.Serializable;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.user.UserMemento;
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/Authentication.java
@@ -63,7 +63,7 @@ public interface Authentication extends Serializable {
      * own simulated (or actual) user
      */
     default UserMemento getUser() {
-        return getExecutionContext().getUser();
+        return getInteractionContext().getUser();
     }
 
     /**
@@ -72,7 +72,7 @@ public interface Authentication extends Serializable {
      * @apiNote immutable, allows an {@link Interaction} to (logically) run with its
      * own simulated (or actual) clock
      */
-    InteractionContext getExecutionContext();
+    InteractionContext getInteractionContext();
 
     /**
      * To support external security mechanisms such as keycloak, where the validity of the session is defined by

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
@@ -50,6 +50,8 @@ implements Authentication, Serializable {
             final @NonNull String validationCode) {
 
         this.interactionContext = interactionContext;
+        this.interactionContext.putAttribute(this.getClass().getName(), this);
+
         this.validationCode = validationCode;
     }
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
@@ -21,7 +21,7 @@ package org.apache.isis.core.security.authentication;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.util.ToString;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
@@ -21,7 +21,7 @@ package org.apache.isis.core.security.authentication;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.util.ToString;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
@@ -38,7 +38,7 @@ implements Authentication, Serializable {
     // -- FIELDS
 
     @Getter(onMethod_ = {@Override})
-    private final @NonNull ExecutionContext executionContext;
+    private final @NonNull InteractionContext interactionContext;
 
     @Getter(onMethod_ = {@Override})
     private final @NonNull String validationCode;
@@ -46,22 +46,21 @@ implements Authentication, Serializable {
     // -- CONSTRUCTOR
 
     protected AuthenticationAbstract(
-            final @NonNull ExecutionContext executionContext,
+            final @NonNull InteractionContext interactionContext,
             final @NonNull String validationCode) {
 
-        this.executionContext = executionContext;
+        this.interactionContext = interactionContext;
         this.validationCode = validationCode;
     }
 
     // -- WITHERS
 
     /**
-     * Returns a copy with given {@code executionContext}.
-     * @param executionContext
+     * Returns a copy with given {@code interactionContext}.
+     * @param interactionContext
      */
-    @Override
-    public Authentication withExecutionContext(final @NonNull ExecutionContext executionContext) {
-        return new SimpleAuthentication(executionContext, validationCode);
+    public Authentication withInteractionContext(final @NonNull InteractionContext interactionContext) {
+        return new SimpleAuthentication(interactionContext, validationCode);
     }
 
     // -- TO STRING, EQUALS, HASHCODE
@@ -96,7 +95,7 @@ implements Authentication, Serializable {
         if(!Objects.equals(this.getValidationCode(), other.getValidationCode())) {
             return false;
         }
-        if(!Objects.equals(this.getExecutionContext(), other.getExecutionContext())) {
+        if(!Objects.equals(this.getInteractionContext(), other.getInteractionContext())) {
             return false;
         }
         return true;

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationAbstract.java
@@ -20,6 +20,7 @@ package org.apache.isis.core.security.authentication;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.util.ToString;
@@ -29,7 +30,7 @@ import lombok.Getter;
 import lombok.NonNull;
 
 public abstract class AuthenticationAbstract
-implements Authentication, Serializable {
+implements Authentication {
 
     private static final long serialVersionUID = 1L;
 
@@ -50,10 +51,11 @@ implements Authentication, Serializable {
             final @NonNull String validationCode) {
 
         this.interactionContext = interactionContext;
-        this.interactionContext.putAttribute(this.getClass().getName(), this);
+        this.interactionContext.putAttribute(INTERACTION_CONTEXT_KEY, this);
 
         this.validationCode = validationCode;
     }
+
 
     // -- WITHERS
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationContext.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationContext.java
@@ -31,8 +31,7 @@ import org.apache.isis.commons.internal.exceptions._Exceptions;
 public interface AuthenticationContext {
 
     /**
-     * Optionally provides the current thread's {@link Authentication}, based
-     * on whether there is an open {@link org.apache.isis.core.interaction.session.InteractionSession}.
+     * Optionally provides the current thread's {@link Authentication}.
      * <p>
      * That is the {@link Authentication} that sits at the top of
      * the current thread's {@link org.apache.isis.core.interaction.session.InteractionSession}'s

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationContext.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationContext.java
@@ -49,6 +49,6 @@ public interface AuthenticationContext {
     }
 
     /** authentication-layer-stack size */
-    int getAuthenticationLayerCount();
+    int getInteractionLayerCount();
 
 }

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationProvider.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationProvider.java
@@ -28,7 +28,7 @@ import org.apache.isis.commons.internal.exceptions._Exceptions;
  * Provides the current thread's {@link Authentication}.
  * @since 2.0
  */
-public interface AuthenticationContext {
+public interface AuthenticationProvider {
 
     /**
      * Optionally provides the current thread's {@link Authentication}.

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationProvider.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationProvider.java
@@ -43,11 +43,13 @@ public interface AuthenticationProvider {
         return currentAuthentication()
                 .orElseThrow(()->
                     _Exceptions.illegalState(
-                            "no InteractionSession available on current %s",
+                            "no InteractionLayer available on current %s",
                             _Probe.currentThreadId()));
     }
 
-    /** authentication-layer-stack size */
+    /**
+     * interaction-layer-stack size
+     * */
     int getInteractionLayerCount();
 
 }

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationProvider.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/AuthenticationProvider.java
@@ -47,9 +47,5 @@ public interface AuthenticationProvider {
                             _Probe.currentThreadId()));
     }
 
-    /**
-     * interaction-layer-stack size
-     * */
-    int getInteractionLayerCount();
 
 }

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/health/HealthAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/health/HealthAuthentication.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.security.authentication.health;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 
@@ -26,8 +26,8 @@ public class HealthAuthentication extends AuthenticationAbstract {
 
     private static final long serialVersionUID = 1L;
 
-    private static final ExecutionContext HEALTH_EXEC_CTX =
-            ExecutionContext.ofUserWithSystemDefaults(
+    private static final InteractionContext HEALTH_EXEC_CTX =
+            InteractionContext.ofUserWithSystemDefaults(
                     UserMemento.ofNameAndRoleNames(
                             "__health", // user name
                             "__health-role") // role(s)

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/health/HealthAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/health/HealthAuthentication.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.security.authentication.health;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/logout/LogoutMenu.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/logout/LogoutMenu.java
@@ -51,7 +51,7 @@ public class LogoutMenu {
     public static final String LOGICAL_TYPE_NAME = IsisModuleCoreSecurity.NAMESPACE + ".LogoutMenu"; // referenced by secman seeding
 
     private final List<LogoutHandler> logoutHandler;
-    private final AuthenticationProvider authenticationTracker;
+    private final AuthenticationProvider authenticationProvider;
     //private final IsisConfiguration configuration;
 
     public static class LogoutDomainEvent
@@ -73,7 +73,7 @@ public class LogoutMenu {
     }
 
     private Object getRedirect() {
-        val redirect =  authenticationTracker.currentAuthentication()
+        val redirect =  authenticationProvider.currentAuthentication()
         .map(authentication->
             authentication.getType() == Authentication.Type.EXTERNAL
             ? "logout"

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/logout/LogoutMenu.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/logout/LogoutMenu.java
@@ -37,7 +37,7 @@ import org.apache.isis.applib.value.OpenUrlStrategy;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.core.security.IsisModuleCoreSecurity;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -51,7 +51,7 @@ public class LogoutMenu {
     public static final String LOGICAL_TYPE_NAME = IsisModuleCoreSecurity.NAMESPACE + ".LogoutMenu"; // referenced by secman seeding
 
     private final List<LogoutHandler> logoutHandler;
-    private final AuthenticationContext authenticationTracker;
+    private final AuthenticationProvider authenticationTracker;
     //private final IsisConfiguration configuration;
 
     public static class LogoutDomainEvent

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/manager/AnonymousInteractionFactory.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/manager/AnonymousInteractionFactory.java
@@ -20,7 +20,7 @@ package org.apache.isis.core.security.authentication.manager;
 
 import java.util.concurrent.Callable;
 
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 
 import lombok.NonNull;
 import lombok.SneakyThrows;

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/manager/AnonymousInteractionFactory.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/manager/AnonymousInteractionFactory.java
@@ -38,10 +38,19 @@ import lombok.SneakyThrows;
  */
 public interface AnonymousInteractionFactory {
 
-    // for java-doc see InteractionFactory
+    /**
+     * Executes a block of code with anonymous credentials.
+     *
+     * @param runnable
+     */
     void runAnonymous(@NonNull ThrowingRunnable runnable);
 
-    // for java-doc see InteractionFactory
+    /**
+     * Executes a block of code with anonymous credentials.
+     *
+     * @param <R>
+     * @param callable (non-null)
+     */
     <R> R callAnonymous(@NonNull Callable<R> callable);
 
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/singleuser/SingleUserAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/singleuser/SingleUserAuthentication.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.security.authentication.singleuser;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/singleuser/SingleUserAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/singleuser/SingleUserAuthentication.java
@@ -18,7 +18,7 @@
  */
 package org.apache.isis.core.security.authentication.singleuser;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 
@@ -26,8 +26,8 @@ public final class SingleUserAuthentication extends AuthenticationAbstract {
 
     private static final long serialVersionUID = 1L;
 
-    private static final ExecutionContext DEFAULT_SINGLE_USER_ENVIRONMENT =
-            ExecutionContext.ofUserWithSystemDefaults(
+    private static final InteractionContext DEFAULT_SINGLE_USER_ENVIRONMENT =
+            InteractionContext.ofUserWithSystemDefaults(
                     UserMemento.ofName("prototyping"));
 
     /**

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/standard/SimpleAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/standard/SimpleAuthentication.java
@@ -19,7 +19,7 @@
 
 package org.apache.isis.core.security.authentication.standard;
 
-import org.apache.isis.applib.services.iactn.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/standard/SimpleAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/standard/SimpleAuthentication.java
@@ -45,6 +45,11 @@ extends AuthenticationAbstract {
         return of(user, DEFAULT_AUTH_VALID_CODE);
     }
 
+    public static SimpleAuthentication validOf(
+            final @NonNull InteractionContext interactionContext) {
+        return new SimpleAuthentication(interactionContext, DEFAULT_AUTH_VALID_CODE);
+    }
+
     // -- CONSTRUCTOR
 
     public SimpleAuthentication(

--- a/core/security/src/main/java/org/apache/isis/core/security/authentication/standard/SimpleAuthentication.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/authentication/standard/SimpleAuthentication.java
@@ -19,7 +19,7 @@
 
 package org.apache.isis.core.security.authentication.standard;
 
-import org.apache.isis.applib.services.iactnlayer.ExecutionContext;
+import org.apache.isis.applib.services.iactnlayer.InteractionContext;
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.core.security.authentication.AuthenticationAbstract;
 
@@ -37,7 +37,7 @@ extends AuthenticationAbstract {
     public static SimpleAuthentication of(
             final @NonNull UserMemento user,
             final @NonNull String validationCode) {
-        return new SimpleAuthentication(ExecutionContext.ofUserWithSystemDefaults(user), validationCode);
+        return new SimpleAuthentication(InteractionContext.ofUserWithSystemDefaults(user), validationCode);
     }
 
     public static SimpleAuthentication validOf(
@@ -48,9 +48,9 @@ extends AuthenticationAbstract {
     // -- CONSTRUCTOR
 
     public SimpleAuthentication(
-            final @NonNull ExecutionContext executionContext,
+            final @NonNull InteractionContext interactionContext,
             final @NonNull String validationCode) {
-        super(executionContext, validationCode);
+        super(interactionContext, validationCode);
     }
 
     @Getter @Setter

--- a/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.commons.internal.debug.xray.XrayModel.ThreadMemento;
 import org.apache.isis.commons.internal.debug.xray.XrayUi;
@@ -41,7 +41,7 @@ public final class XrayUtil {
      * Returns the sequence diagram data model's id, that is bound to the current thread and interaction.
      * @param iaContext
      */
-    public static Optional<String> currentSequenceId(final @NonNull InteractionContext iaContext) {
+    public static Optional<String> currentSequenceId(final @NonNull InteractionProvider iaContext) {
         return iaContext.getInteractionId()
                 .map(XrayUtil::sequenceId);
     }
@@ -65,7 +65,7 @@ public final class XrayUtil {
     // -- SEQUENCE HANDLE
 
     public static Optional<SequenceHandle> createSequenceHandle(
-            final @NonNull InteractionContext iaContext,
+            final @NonNull InteractionProvider iaContext,
             final @NonNull AuthenticationContext authContext,
             final String ... callees) {
 
@@ -89,7 +89,7 @@ public final class XrayUtil {
     }
 
     // Using parameter that implements multiple interfaces, because we have no access to InteractionTracker
-    public static <T extends InteractionContext & AuthenticationContext>
+    public static <T extends InteractionProvider & AuthenticationContext>
     Optional<SequenceHandle> createSequenceHandle(
             final @NonNull T iaTracker,
             final String ... callees) {

--- a/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
@@ -39,10 +39,10 @@ public final class XrayUtil {
 
     /**
      * Returns the sequence diagram data model's id, that is bound to the current thread and interaction.
-     * @param iaContext
+     * @param interactionProvider
      */
-    public static Optional<String> currentSequenceId(final @NonNull InteractionProvider iaContext) {
-        return iaContext.getInteractionId()
+    public static Optional<String> currentSequenceId(final @NonNull InteractionProvider interactionProvider) {
+        return interactionProvider.getInteractionId()
                 .map(XrayUtil::sequenceId);
     }
 
@@ -65,16 +65,16 @@ public final class XrayUtil {
     // -- SEQUENCE HANDLE
 
     public static Optional<SequenceHandle> createSequenceHandle(
-            final @NonNull InteractionProvider iaContext,
+            final @NonNull InteractionProvider interactionProvider,
             final @NonNull AuthenticationProvider authenticationProvider,
             final String ... callees) {
 
-        if(!iaContext.isInInteraction()) {
+        if(!interactionProvider.isInInteraction()) {
             return Optional.empty();
         }
 
-        final int authStackSize = iaContext.getInteractionLayerCount();
-        val interactionId = iaContext.getInteractionId().orElseThrow(_Exceptions::unexpectedCodeReach);
+        final int authStackSize = interactionProvider.getInteractionLayerCount();
+        val interactionId = interactionProvider.getInteractionId().orElseThrow(_Exceptions::unexpectedCodeReach);
 
         val handle = SequenceHandle.builder()
                 .sequenceId(XrayUtil.sequenceId(interactionId))

--- a/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
@@ -66,14 +66,14 @@ public final class XrayUtil {
 
     public static Optional<SequenceHandle> createSequenceHandle(
             final @NonNull InteractionProvider iaContext,
-            final @NonNull AuthenticationProvider authContext,
+            final @NonNull AuthenticationProvider authenticationProvider,
             final String ... callees) {
 
         if(!iaContext.isInInteraction()) {
             return Optional.empty();
         }
 
-        final int authStackSize = authContext.getInteractionLayerCount();
+        final int authStackSize = authenticationProvider.getInteractionLayerCount();
         val interactionId = iaContext.getInteractionId().orElseThrow(_Exceptions::unexpectedCodeReach);
 
         val handle = SequenceHandle.builder()

--- a/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
@@ -73,7 +73,7 @@ public final class XrayUtil {
             return Optional.empty();
         }
 
-        final int authStackSize = authenticationProvider.getInteractionLayerCount();
+        final int authStackSize = iaContext.getInteractionLayerCount();
         val interactionId = iaContext.getInteractionId().orElseThrow(_Exceptions::unexpectedCodeReach);
 
         val handle = SequenceHandle.builder()

--- a/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
@@ -73,7 +73,7 @@ public final class XrayUtil {
             return Optional.empty();
         }
 
-        final int authStackSize = authContext.getAuthenticationLayerCount();
+        final int authStackSize = authContext.getInteractionLayerCount();
         val interactionId = iaContext.getInteractionId().orElseThrow(_Exceptions::unexpectedCodeReach);
 
         val handle = SequenceHandle.builder()

--- a/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
+++ b/core/security/src/main/java/org/apache/isis/core/security/util/XrayUtil.java
@@ -28,7 +28,7 @@ import org.apache.isis.commons.internal.debug.xray.XrayModel.ThreadMemento;
 import org.apache.isis.commons.internal.debug.xray.XrayUi;
 import org.apache.isis.commons.internal.debug.xray.sequence.SequenceDiagram;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -66,7 +66,7 @@ public final class XrayUtil {
 
     public static Optional<SequenceHandle> createSequenceHandle(
             final @NonNull InteractionProvider iaContext,
-            final @NonNull AuthenticationContext authContext,
+            final @NonNull AuthenticationProvider authContext,
             final String ... callees) {
 
         if(!iaContext.isInInteraction()) {
@@ -89,7 +89,7 @@ public final class XrayUtil {
     }
 
     // Using parameter that implements multiple interfaces, because we have no access to InteractionTracker
-    public static <T extends InteractionProvider & AuthenticationContext>
+    public static <T extends InteractionProvider & AuthenticationProvider>
     Optional<SequenceHandle> createSequenceHandle(
             final @NonNull T iaTracker,
             final String ... callees) {

--- a/core/security/src/test/java/org/apache/isis/security/authentication/standard/SimpleSessionEncodabilityTestAbstract.java
+++ b/core/security/src/test/java/org/apache/isis/security/authentication/standard/SimpleSessionEncodabilityTestAbstract.java
@@ -34,13 +34,13 @@ public abstract class SimpleSessionEncodabilityTestAbstract extends Encodability
         final AuthenticationAbstract original = (AuthenticationAbstract) originalEncodable;
 
         assertThat(decoded.getUser(), is(equalTo(original.getUser()))); // redundant shortcut
-        
-        assertThat(decoded.getExecutionContext().getTimeZone(), is(equalTo(original.getExecutionContext().getTimeZone())));
-        assertThat(decoded.getExecutionContext().getLocale(), is(equalTo(original.getExecutionContext().getLocale())));
-        assertThat(decoded.getExecutionContext().getUser(), is(equalTo(original.getExecutionContext().getUser())));
-        assertThat(decoded.getExecutionContext().getClock(), is(equalTo(original.getExecutionContext().getClock())));
-        
-        assertThat(decoded.getExecutionContext(), is(equalTo(original.getExecutionContext())));
+
+        assertThat(decoded.getInteractionContext().getTimeZone(), is(equalTo(original.getInteractionContext().getTimeZone())));
+        assertThat(decoded.getInteractionContext().getLocale(), is(equalTo(original.getInteractionContext().getLocale())));
+        assertThat(decoded.getInteractionContext().getUser(), is(equalTo(original.getInteractionContext().getUser())));
+        assertThat(decoded.getInteractionContext().getClock(), is(equalTo(original.getInteractionContext().getClock())));
+
+        assertThat(decoded.getInteractionContext(), is(equalTo(original.getInteractionContext())));
     }
 
 }

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/EntityChangeTrackerDefault.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/EntityChangeTrackerDefault.java
@@ -42,7 +42,7 @@ import org.apache.isis.applib.events.lifecycle.AbstractLifecycleEvent;
 import org.apache.isis.applib.services.bookmark.Bookmark;
 import org.apache.isis.applib.services.eventbus.EventBusService;
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.metrics.MetricsService;
 import org.apache.isis.applib.services.publishing.spi.EntityChanges;
 import org.apache.isis.applib.services.publishing.spi.EntityPropertyChange;
@@ -101,7 +101,7 @@ implements
     @Inject private EntityPropertyChangePublisher entityPropertyChangePublisher;
     @Inject private EntityChangesPublisher entityChangesPublisher;
     @Inject private EventBusService eventBusService;
-    @Inject private Provider<InteractionContext> interactionContextProvider;
+    @Inject private Provider<InteractionProvider> interactionContextProvider;
     @Inject private Provider<AuthenticationContext> authenticationContextProvider;
 
 

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/EntityChangeTrackerDefault.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/EntityChangeTrackerDefault.java
@@ -71,7 +71,7 @@ import org.apache.isis.core.metamodel.facets.object.publish.entitychange.EntityC
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.spec.ManagedObjects;
 import org.apache.isis.core.metamodel.spec.feature.MixedIn;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.transaction.changetracking.events.IsisTransactionPlaceholder;
 import org.apache.isis.core.transaction.events.TransactionBeforeCompletionEvent;
 
@@ -102,7 +102,7 @@ implements
     @Inject private EntityChangesPublisher entityChangesPublisher;
     @Inject private EventBusService eventBusService;
     @Inject private Provider<InteractionProvider> interactionProviderProvider;
-    @Inject private Provider<AuthenticationContext> authenticationContextProvider;
+    @Inject private Provider<AuthenticationProvider> authenticationContextProvider;
 
 
     /**

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/EntityChangeTrackerDefault.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/EntityChangeTrackerDefault.java
@@ -101,7 +101,7 @@ implements
     @Inject private EntityPropertyChangePublisher entityPropertyChangePublisher;
     @Inject private EntityChangesPublisher entityChangesPublisher;
     @Inject private EventBusService eventBusService;
-    @Inject private Provider<InteractionProvider> interactionContextProvider;
+    @Inject private Provider<InteractionProvider> interactionProviderProvider;
     @Inject private Provider<AuthenticationContext> authenticationContextProvider;
 
 
@@ -189,7 +189,7 @@ implements
     }
 
     private void doPublish() {
-        _Xray.publish(this, interactionContextProvider, authenticationContextProvider);
+        _Xray.publish(this, interactionProviderProvider, authenticationContextProvider);
 
         log.debug("about to publish entity changes");
         entityPropertyChangePublisher.publishChangedProperties(this);
@@ -221,7 +221,7 @@ implements
     }
 
     Interaction currentInteraction() {
-        return interactionContextProvider.get().currentInteractionElseFail();
+        return interactionProviderProvider.get().currentInteractionElseFail();
     }
 
     // -- HELPER
@@ -319,7 +319,7 @@ implements
 
     @Override
     public void enlistCreated(ManagedObject entity) {
-        _Xray.enlistCreated(entity, interactionContextProvider, authenticationContextProvider);
+        _Xray.enlistCreated(entity, interactionProviderProvider, authenticationContextProvider);
         val hasAlreadyBeenEnlisted = isEnlisted(entity);
         enlistCreatedInternal(entity);
 
@@ -331,7 +331,7 @@ implements
 
     @Override
     public void enlistDeleting(ManagedObject entity) {
-        _Xray.enlistDeleting(entity, interactionContextProvider, authenticationContextProvider);
+        _Xray.enlistDeleting(entity, interactionProviderProvider, authenticationContextProvider);
         enlistDeletingInternal(entity);
         CallbackFacet.Util.callCallback(entity, RemovingCallbackFacet.class);
         postLifecycleEventIfRequired(entity, RemovingLifecycleEventFacet.class);
@@ -339,7 +339,7 @@ implements
 
     @Override
     public void enlistUpdating(ManagedObject entity) {
-        _Xray.enlistUpdating(entity, interactionContextProvider, authenticationContextProvider);
+        _Xray.enlistUpdating(entity, interactionProviderProvider, authenticationContextProvider);
         val hasAlreadyBeenEnlisted = isEnlisted(entity);
         // we call this come what may;
         // additional properties may now have been changed, and the changeKind for publishing might also be modified
@@ -354,7 +354,7 @@ implements
 
     @Override
     public void recognizeLoaded(ManagedObject entity) {
-        _Xray.recognizeLoaded(entity, interactionContextProvider, authenticationContextProvider);
+        _Xray.recognizeLoaded(entity, interactionProviderProvider, authenticationContextProvider);
         CallbackFacet.Util.callCallback(entity, LoadedCallbackFacet.class);
         postLifecycleEventIfRequired(entity, LoadedLifecycleEventFacet.class);
         numberEntitiesLoaded.increment();
@@ -362,14 +362,14 @@ implements
 
     @Override
     public void recognizePersisting(ManagedObject entity) {
-        _Xray.recognizePersisting(entity, interactionContextProvider, authenticationContextProvider);
+        _Xray.recognizePersisting(entity, interactionProviderProvider, authenticationContextProvider);
         CallbackFacet.Util.callCallback(entity, PersistingCallbackFacet.class);
         postLifecycleEventIfRequired(entity, PersistingLifecycleEventFacet.class);
     }
 
     @Override
     public void recognizeUpdating(ManagedObject entity) {
-        _Xray.recognizeUpdating(entity, interactionContextProvider, authenticationContextProvider);
+        _Xray.recognizeUpdating(entity, interactionProviderProvider, authenticationContextProvider);
         CallbackFacet.Util.callCallback(entity, UpdatedCallbackFacet.class);
         postLifecycleEventIfRequired(entity, UpdatedLifecycleEventFacet.class);
     }

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/_Xray.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/_Xray.java
@@ -35,7 +35,7 @@ final class _Xray {
 
     public static void publish(
             final EntityChangeTrackerDefault entityChangeTrackerDefault,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
 
         if(!XrayUi.isXrayEnabled()) {
@@ -47,7 +47,7 @@ final class _Xray {
         val enteringLabel = String.format("do publish %d entity change records",
                 propertyChangeRecordCount);
 
-        XrayUtil.createSequenceHandle(iaContextProvider.get(), authContextProvider.get(), "ec-tracker")
+        XrayUtil.createSequenceHandle(interactionProviderProvider.get(), authContextProvider.get(), "ec-tracker")
         .ifPresent(handle->{
 
             handle.submit(sequenceData->{
@@ -69,44 +69,44 @@ final class _Xray {
 
     public static void enlistCreated(
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
-        addSequence("enlistCreated", entity, iaContextProvider, authContextProvider);
+        addSequence("enlistCreated", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void enlistDeleting(
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
-        addSequence("enlistDeleting", entity, iaContextProvider, authContextProvider);
+        addSequence("enlistDeleting", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void enlistUpdating(
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
-        addSequence("enlistUpdating", entity, iaContextProvider, authContextProvider);
+        addSequence("enlistUpdating", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void recognizeLoaded(
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
-        addSequence("recognizeLoaded", entity, iaContextProvider, authContextProvider);
+        addSequence("recognizeLoaded", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void recognizePersisting(
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
-        addSequence("recognizePersisting", entity, iaContextProvider, authContextProvider);
+        addSequence("recognizePersisting", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void recognizeUpdating(
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
-        addSequence("recognizeUpdating", entity, iaContextProvider, authContextProvider);
+        addSequence("recognizeUpdating", entity, interactionProviderProvider, authContextProvider);
     }
 
     // -- HELPER
@@ -114,7 +114,7 @@ final class _Xray {
     private static void addSequence(
             final String what,
             final ManagedObject entity,
-            final Provider<InteractionProvider> iaContextProvider,
+            final Provider<InteractionProvider> interactionProviderProvider,
             final Provider<AuthenticationContext> authContextProvider) {
 
         if(!XrayUi.isXrayEnabled()) {
@@ -129,7 +129,7 @@ final class _Xray {
                             entity.getSpecification().getLogicalTypeName(),
                             "" + entity.getPojo()));
 
-        XrayUtil.createSequenceHandle(iaContextProvider.get(), authContextProvider.get(), "ec-tracker")
+        XrayUtil.createSequenceHandle(interactionProviderProvider.get(), authContextProvider.get(), "ec-tracker")
         .ifPresent(handle->{
 
             handle.submit(sequenceData->{

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/_Xray.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/_Xray.java
@@ -22,7 +22,7 @@ import java.awt.Color;
 
 import javax.inject.Provider;
 
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.debug.xray.XrayUi;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.spec.ManagedObjects;
@@ -35,7 +35,7 @@ final class _Xray {
 
     public static void publish(
             final EntityChangeTrackerDefault entityChangeTrackerDefault,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
 
         if(!XrayUi.isXrayEnabled()) {
@@ -69,42 +69,42 @@ final class _Xray {
 
     public static void enlistCreated(
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
         addSequence("enlistCreated", entity, iaContextProvider, authContextProvider);
     }
 
     public static void enlistDeleting(
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
         addSequence("enlistDeleting", entity, iaContextProvider, authContextProvider);
     }
 
     public static void enlistUpdating(
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
         addSequence("enlistUpdating", entity, iaContextProvider, authContextProvider);
     }
 
     public static void recognizeLoaded(
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
         addSequence("recognizeLoaded", entity, iaContextProvider, authContextProvider);
     }
 
     public static void recognizePersisting(
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
         addSequence("recognizePersisting", entity, iaContextProvider, authContextProvider);
     }
 
     public static void recognizeUpdating(
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
         addSequence("recognizeUpdating", entity, iaContextProvider, authContextProvider);
     }
@@ -114,7 +114,7 @@ final class _Xray {
     private static void addSequence(
             final String what,
             final ManagedObject entity,
-            final Provider<InteractionContext> iaContextProvider,
+            final Provider<InteractionProvider> iaContextProvider,
             final Provider<AuthenticationContext> authContextProvider) {
 
         if(!XrayUi.isXrayEnabled()) {

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/_Xray.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/_Xray.java
@@ -26,7 +26,7 @@ import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.commons.internal.debug.xray.XrayUi;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.spec.ManagedObjects;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.util.XrayUtil;
 
 import lombok.val;
@@ -36,7 +36,7 @@ final class _Xray {
     public static void publish(
             final EntityChangeTrackerDefault entityChangeTrackerDefault,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
 
         if(!XrayUi.isXrayEnabled()) {
             return;
@@ -70,42 +70,42 @@ final class _Xray {
     public static void enlistCreated(
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
         addSequence("enlistCreated", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void enlistDeleting(
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
         addSequence("enlistDeleting", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void enlistUpdating(
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
         addSequence("enlistUpdating", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void recognizeLoaded(
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
         addSequence("recognizeLoaded", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void recognizePersisting(
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
         addSequence("recognizePersisting", entity, interactionProviderProvider, authContextProvider);
     }
 
     public static void recognizeUpdating(
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
         addSequence("recognizeUpdating", entity, interactionProviderProvider, authContextProvider);
     }
 
@@ -115,7 +115,7 @@ final class _Xray {
             final String what,
             final ManagedObject entity,
             final Provider<InteractionProvider> interactionProviderProvider,
-            final Provider<AuthenticationContext> authContextProvider) {
+            final Provider<AuthenticationProvider> authContextProvider) {
 
         if(!XrayUi.isXrayEnabled()) {
             return;

--- a/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdoRepository.java
+++ b/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdoRepository.java
@@ -43,7 +43,7 @@ import org.apache.isis.applib.jaxb.JavaSqlXMLGregorianCalendarMarshalling;
 import org.apache.isis.applib.query.Query;
 import org.apache.isis.applib.query.QueryRange;
 import org.apache.isis.applib.services.bookmark.Bookmark;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.repository.RepositoryService;
 import org.apache.isis.applib.util.schema.CommandDtoUtils;
 import org.apache.isis.extensions.commandlog.model.command.CommandModel;
@@ -72,7 +72,7 @@ import lombok.val;
 public class CommandJdoRepository
 implements CommandModelRepository<CommandJdo> {
 
-    @Inject final Provider<InteractionContext> interactionContextProvider;
+    @Inject final Provider<InteractionProvider> interactionContextProvider;
     @Inject final Provider<RepositoryService> repositoryServiceProvider;
     @Inject final JdoSupportService jdoSupport;
 

--- a/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdoRepository.java
+++ b/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdoRepository.java
@@ -72,7 +72,7 @@ import lombok.val;
 public class CommandJdoRepository
 implements CommandModelRepository<CommandJdo> {
 
-    @Inject final Provider<InteractionProvider> interactionContextProvider;
+    @Inject final Provider<InteractionProvider> interactionProviderProvider;
     @Inject final Provider<RepositoryService> repositoryServiceProvider;
     @Inject final JdoSupportService jdoSupport;
 

--- a/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdo_retry.java
+++ b/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdo_retry.java
@@ -29,7 +29,7 @@ import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
 import org.apache.isis.applib.services.repository.RepositoryService;
 import org.apache.isis.applib.services.xactn.TransactionService;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.extensions.commandlog.jdo.IsisModuleExtCommandLogJdo;
 import org.apache.isis.extensions.commandlog.model.command.ReplayState;
 

--- a/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdo_retry.java
+++ b/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdo_retry.java
@@ -29,7 +29,7 @@ import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
 import org.apache.isis.applib.services.repository.RepositoryService;
 import org.apache.isis.applib.services.xactn.TransactionService;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.extensions.commandlog.jdo.IsisModuleExtCommandLogJdo;
 import org.apache.isis.extensions.commandlog.model.command.ReplayState;
 
@@ -59,7 +59,7 @@ public class CommandJdo_retry {
         return commandJdo;
     }
 
-    @Inject InteractionHandler interactionHandler;
+    @Inject InteractionService interactionService;
     @Inject TransactionService transactionService;
     @Inject CommandExecutorService commandExecutorService;
     @Inject RepositoryService repositoryService;

--- a/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdo_retry.java
+++ b/extensions/core/command-log/jdo/src/main/java/org/apache/isis/extensions/commandlog/jdo/entities/CommandJdo_retry.java
@@ -29,7 +29,7 @@ import org.apache.isis.applib.services.command.CommandExecutorService;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
 import org.apache.isis.applib.services.repository.RepositoryService;
 import org.apache.isis.applib.services.xactn.TransactionService;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.extensions.commandlog.jdo.IsisModuleExtCommandLogJdo;
 import org.apache.isis.extensions.commandlog.model.command.ReplayState;
 
@@ -59,7 +59,7 @@ public class CommandJdo_retry {
         return commandJdo;
     }
 
-    @Inject InteractionFactory isisInteractionFactory;
+    @Inject InteractionHandler interactionHandler;
     @Inject TransactionService transactionService;
     @Inject CommandExecutorService commandExecutorService;
     @Inject RepositoryService repositoryService;

--- a/extensions/core/command-log/jpa/src/main/java/org/apache/isis/extensions/commandlog/jpa/entities/CommandJpaRepository.java
+++ b/extensions/core/command-log/jpa/src/main/java/org/apache/isis/extensions/commandlog/jpa/entities/CommandJpaRepository.java
@@ -71,7 +71,7 @@ import lombok.val;
 public class CommandJpaRepository
 implements CommandModelRepository<CommandJpa> {
 
-    @Inject final Provider<InteractionProvider> interactionContextProvider;
+    @Inject final Provider<InteractionProvider> interactionProviderProvider;
     @Inject final Provider<RepositoryService> repositoryServiceProvider;
 
 

--- a/extensions/core/command-log/jpa/src/main/java/org/apache/isis/extensions/commandlog/jpa/entities/CommandJpaRepository.java
+++ b/extensions/core/command-log/jpa/src/main/java/org/apache/isis/extensions/commandlog/jpa/entities/CommandJpaRepository.java
@@ -43,7 +43,7 @@ import org.apache.isis.applib.jaxb.JavaSqlXMLGregorianCalendarMarshalling;
 import org.apache.isis.applib.query.Query;
 import org.apache.isis.applib.query.QueryRange;
 import org.apache.isis.applib.services.bookmark.Bookmark;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.repository.RepositoryService;
 import org.apache.isis.applib.util.schema.CommandDtoUtils;
 import org.apache.isis.extensions.commandlog.model.command.CommandModel;
@@ -71,7 +71,7 @@ import lombok.val;
 public class CommandJpaRepository
 implements CommandModelRepository<CommandJpa> {
 
-    @Inject final Provider<InteractionContext> interactionContextProvider;
+    @Inject final Provider<InteractionProvider> interactionContextProvider;
     @Inject final Provider<RepositoryService> repositoryServiceProvider;
 
 

--- a/incubator/viewers/vaadin/model/src/main/java/org/apache/isis/incubator/viewer/vaadin/model/context/UiContextVaa.java
+++ b/incubator/viewers/vaadin/model/src/main/java/org/apache/isis/incubator/viewer/vaadin/model/context/UiContextVaa.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 
 import com.vaadin.flow.component.Component;
 
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 
 public interface UiContextVaa {

--- a/incubator/viewers/vaadin/model/src/main/java/org/apache/isis/incubator/viewer/vaadin/model/context/UiContextVaa.java
+++ b/incubator/viewers/vaadin/model/src/main/java/org/apache/isis/incubator/viewer/vaadin/model/context/UiContextVaa.java
@@ -24,14 +24,14 @@ import java.util.function.Supplier;
 
 import com.vaadin.flow.component.Component;
 
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 
 public interface UiContextVaa {
 
     //JavaFxViewerConfig getJavaFxViewerConfig();
 
-    InteractionHandler getIsisInteractionFactory();
+    InteractionService getIsisInteractionFactory();
     //ActionUiModelFactoryFx getActionUiModelFactory();
 
     void setNewPageHandler(Consumer<Component> onNewPage);

--- a/incubator/viewers/vaadin/model/src/main/java/org/apache/isis/incubator/viewer/vaadin/model/context/UiContextVaa.java
+++ b/incubator/viewers/vaadin/model/src/main/java/org/apache/isis/incubator/viewer/vaadin/model/context/UiContextVaa.java
@@ -24,14 +24,14 @@ import java.util.function.Supplier;
 
 import com.vaadin.flow.component.Component;
 
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 
 public interface UiContextVaa {
 
     //JavaFxViewerConfig getJavaFxViewerConfig();
 
-    InteractionFactory getIsisInteractionFactory();
+    InteractionHandler getIsisInteractionFactory();
     //ActionUiModelFactoryFx getActionUiModelFactory();
 
     void setNewPageHandler(Consumer<Component> onNewPage);

--- a/incubator/viewers/vaadin/ui/src/main/java/org/apache/isis/incubator/viewer/vaadin/ui/auth/VaadinAuthenticationHandler.java
+++ b/incubator/viewers/vaadin/ui/src/main/java/org/apache/isis/incubator/viewer/vaadin/ui/auth/VaadinAuthenticationHandler.java
@@ -121,7 +121,7 @@ implements
 
         val authentication = AuthSessionStoreUtil.get().orElse(null);
         if(authentication!=null) {
-            isisInteractionFactory.openInteraction(authentication);
+            isisInteractionFactory.openInteraction(authentication, authentication.getInteractionContext());
             return; // access granted
         }
         // otherwise redirect to login page

--- a/incubator/viewers/vaadin/ui/src/main/java/org/apache/isis/incubator/viewer/vaadin/ui/auth/VaadinAuthenticationHandler.java
+++ b/incubator/viewers/vaadin/ui/src/main/java/org/apache/isis/incubator/viewer/vaadin/ui/auth/VaadinAuthenticationHandler.java
@@ -121,7 +121,7 @@ implements
 
         val authentication = AuthSessionStoreUtil.get().orElse(null);
         if(authentication!=null) {
-            isisInteractionFactory.openInteraction(authentication, authentication.getInteractionContext());
+            isisInteractionFactory.openInteraction(authentication.getInteractionContext());
             return; // access granted
         }
         // otherwise redirect to login page

--- a/incubator/viewers/vaadin/ui/src/main/java/org/apache/isis/incubator/viewer/vaadin/ui/auth/VaadinAuthenticationHandler.java
+++ b/incubator/viewers/vaadin/ui/src/main/java/org/apache/isis/incubator/viewer/vaadin/ui/auth/VaadinAuthenticationHandler.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.theme.lumo.Lumo;
 
 import org.springframework.stereotype.Component;
 
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
@@ -41,7 +41,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.incubator.viewer.vaadin.ui.IsisModuleIncViewerVaadinUi;
 
 import lombok.val;

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
@@ -41,7 +41,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.incubator.viewer.vaadin.ui.IsisModuleIncViewerVaadinUi;
 
 import lombok.val;
@@ -71,7 +71,7 @@ public class IsisModuleIncViewerVaadinViewer {
 
     @Inject private WebApplicationContext context;
     @Inject private VaadinConfigurationProperties configurationProperties;
-    @Inject private InteractionService interactionService;
+    @Inject private InteractionFactory interactionFactory;
 
     /**
      * Creates a {@link ServletContextInitializer} instance.
@@ -99,7 +99,7 @@ public class IsisModuleIncViewerVaadinViewer {
                     makeContextRelative(urlMapping.replace("*", "")));
         }
         val registration = new ServletRegistrationBean<SpringServlet>(
-                new IsisServletForVaadin(interactionService, context, isRootMapping),
+                new IsisServletForVaadin(interactionFactory, context, isRootMapping),
                 urlMapping);
         registration.setInitParameters(initParameters);
         registration.setAsyncSupported(configurationProperties.isAsyncSupported());

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
@@ -41,7 +41,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.incubator.viewer.vaadin.ui.IsisModuleIncViewerVaadinUi;
 
 import lombok.val;
@@ -71,7 +71,7 @@ public class IsisModuleIncViewerVaadinViewer {
 
     @Inject private WebApplicationContext context;
     @Inject private VaadinConfigurationProperties configurationProperties;
-    @Inject private InteractionFactory isisInteractionFactory;
+    @Inject private InteractionHandler interactionHandler;
 
     /**
      * Creates a {@link ServletContextInitializer} instance.
@@ -99,7 +99,7 @@ public class IsisModuleIncViewerVaadinViewer {
                     makeContextRelative(urlMapping.replace("*", "")));
         }
         val registration = new ServletRegistrationBean<SpringServlet>(
-                new IsisServletForVaadin(isisInteractionFactory, context, isRootMapping),
+                new IsisServletForVaadin(interactionHandler, context, isRootMapping),
                 urlMapping);
         registration.setInitParameters(initParameters);
         registration.setAsyncSupported(configurationProperties.isAsyncSupported());

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisModuleIncViewerVaadinViewer.java
@@ -41,7 +41,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.incubator.viewer.vaadin.ui.IsisModuleIncViewerVaadinUi;
 
 import lombok.val;
@@ -71,7 +71,7 @@ public class IsisModuleIncViewerVaadinViewer {
 
     @Inject private WebApplicationContext context;
     @Inject private VaadinConfigurationProperties configurationProperties;
-    @Inject private InteractionHandler interactionHandler;
+    @Inject private InteractionService interactionService;
 
     /**
      * Creates a {@link ServletContextInitializer} instance.
@@ -99,7 +99,7 @@ public class IsisModuleIncViewerVaadinViewer {
                     makeContextRelative(urlMapping.replace("*", "")));
         }
         val registration = new ServletRegistrationBean<SpringServlet>(
-                new IsisServletForVaadin(interactionHandler, context, isRootMapping),
+                new IsisServletForVaadin(interactionService, context, isRootMapping),
                 urlMapping);
         registration.setInitParameters(initParameters);
         registration.setAsyncSupported(configurationProperties.isAsyncSupported());

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
@@ -80,7 +80,7 @@ extends SpringServlet {
         log.debug("request was successfully serviced (authentication={})", authentication);
 
         if(isisInteractionFactory.isInInteraction()) {
-            isisInteractionFactory.closeSessionStack();
+            isisInteractionFactory.closeInteractionLayers();
             log.warn("after servicing current request some interactions have been closed forcefully (authentication={})", authentication);
         }
 

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.spring.SpringServlet;
 import org.springframework.context.ApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.incubator.viewer.vaadin.ui.auth.AuthSessionStoreUtil;
 
 import lombok.NonNull;
@@ -47,14 +47,14 @@ extends SpringServlet {
 
     private static final long serialVersionUID = 1L;
 
-    private final InteractionFactory isisInteractionFactory;
+    private final InteractionHandler interactionHandler;
 
     public IsisServletForVaadin(
-            @NonNull final InteractionFactory isisInteractionFactory,
+            @NonNull final InteractionHandler interactionHandler,
             @NonNull final ApplicationContext context,
             final boolean forwardingEnforced) {
         super(context, forwardingEnforced);
-        this.isisInteractionFactory = isisInteractionFactory;
+        this.interactionHandler = interactionHandler;
     }
 
 
@@ -68,7 +68,7 @@ extends SpringServlet {
         log.debug("new request incoming (authentication={})", authentication);
 
         if(authentication!=null) {
-            isisInteractionFactory.runAuthenticated(authentication, ()->{
+            interactionHandler.runAuthenticated(authentication, ()->{
                 super.service(request, response);
             });
         } else {
@@ -79,8 +79,8 @@ extends SpringServlet {
 
         log.debug("request was successfully serviced (authentication={})", authentication);
 
-        if(isisInteractionFactory.isInInteraction()) {
-            isisInteractionFactory.closeInteractionLayers();
+        if(interactionHandler.isInInteraction()) {
+            interactionHandler.closeInteractionLayers();
             log.warn("after servicing current request some interactions have been closed forcefully (authentication={})", authentication);
         }
 

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
@@ -30,6 +30,7 @@ import org.springframework.context.ApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.incubator.viewer.vaadin.ui.auth.AuthSessionStoreUtil;
 
 import lombok.NonNull;
@@ -47,14 +48,14 @@ extends SpringServlet {
 
     private static final long serialVersionUID = 1L;
 
-    private final InteractionService interactionService;
+    private final InteractionFactory interactionFactory;
 
     public IsisServletForVaadin(
-            @NonNull final InteractionService interactionService,
+            @NonNull final InteractionFactory interactionFactory,
             @NonNull final ApplicationContext context,
             final boolean forwardingEnforced) {
         super(context, forwardingEnforced);
-        this.interactionService = interactionService;
+        this.interactionFactory = interactionFactory;
     }
 
 
@@ -68,7 +69,7 @@ extends SpringServlet {
         log.debug("new request incoming (authentication={})", authentication);
 
         if(authentication!=null) {
-            interactionService.runAuthenticated(authentication, ()->{
+            interactionFactory.runAuthenticated(authentication, ()->{
                 super.service(request, response);
             });
         } else {
@@ -79,8 +80,8 @@ extends SpringServlet {
 
         log.debug("request was successfully serviced (authentication={})", authentication);
 
-        if(interactionService.isInInteraction()) {
-            interactionService.closeInteractionLayers();
+        if(interactionFactory.isInInteraction()) {
+            interactionFactory.closeInteractionLayers();
             log.warn("after servicing current request some interactions have been closed forcefully (authentication={})", authentication);
         }
 

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.spring.SpringServlet;
 import org.springframework.context.ApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.incubator.viewer.vaadin.ui.auth.AuthSessionStoreUtil;
 
 import lombok.NonNull;
@@ -47,14 +47,14 @@ extends SpringServlet {
 
     private static final long serialVersionUID = 1L;
 
-    private final InteractionHandler interactionHandler;
+    private final InteractionService interactionService;
 
     public IsisServletForVaadin(
-            @NonNull final InteractionHandler interactionHandler,
+            @NonNull final InteractionService interactionService,
             @NonNull final ApplicationContext context,
             final boolean forwardingEnforced) {
         super(context, forwardingEnforced);
-        this.interactionHandler = interactionHandler;
+        this.interactionService = interactionService;
     }
 
 
@@ -68,7 +68,7 @@ extends SpringServlet {
         log.debug("new request incoming (authentication={})", authentication);
 
         if(authentication!=null) {
-            interactionHandler.runAuthenticated(authentication, ()->{
+            interactionService.runAuthenticated(authentication, ()->{
                 super.service(request, response);
             });
         } else {
@@ -79,8 +79,8 @@ extends SpringServlet {
 
         log.debug("request was successfully serviced (authentication={})", authentication);
 
-        if(interactionHandler.isInInteraction()) {
-            interactionHandler.closeInteractionLayers();
+        if(interactionService.isInInteraction()) {
+            interactionService.closeInteractionLayers();
             log.warn("after servicing current request some interactions have been closed forcefully (authentication={})", authentication);
         }
 

--- a/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
+++ b/incubator/viewers/vaadin/viewer/src/main/java/org/apache/isis/incubator/viewer/vaadin/viewer/IsisServletForVaadin.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.spring.SpringServlet;
 import org.springframework.context.ApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.incubator.viewer.vaadin.ui.auth.AuthSessionStoreUtil;
 
 import lombok.NonNull;

--- a/persistence/jdo/metamodel/src/test/java/org/apache/isis/persistence/jdo/metamodel/specloader/SpecificationLoaderTestAbstract.java
+++ b/persistence/jdo/metamodel/src/test/java/org/apache/isis/persistence/jdo/metamodel/specloader/SpecificationLoaderTestAbstract.java
@@ -50,7 +50,7 @@ import org.apache.isis.core.metamodel.progmodel.ProgrammingModelInitFilterDefaul
 import org.apache.isis.core.metamodel.progmodels.dflt.ProgrammingModelFacetsJava8;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 
 import lombok.val;
 
@@ -70,8 +70,8 @@ abstract class SpecificationLoaderTestAbstract {
             return config;
         }
 
-        AuthenticationContext mockAuthenticationContext() {
-            return Mockito.mock(AuthenticationContext.class);
+        AuthenticationProvider mockAuthenticationContext() {
+            return Mockito.mock(AuthenticationProvider.class);
         }
 
         GridService mockGridService() {
@@ -104,7 +104,7 @@ abstract class SpecificationLoaderTestAbstract {
 
     protected IsisConfiguration isisConfiguration;
     protected SpecificationLoader specificationLoader;
-    protected AuthenticationContext mockAuthenticationContext;
+    protected AuthenticationProvider mockAuthenticationProvider;
     protected GridService mockGridService;
     protected MessageService mockMessageService;
     protected MetaModelContext metaModelContext;
@@ -127,7 +127,7 @@ abstract class SpecificationLoaderTestAbstract {
                 .translationService(producers.mockTranslationService())
                 .titleService(producers.mockTitleService())
 //                .objectAdapterProvider(mockPersistenceSessionServiceInternal = producers.mockPersistenceSessionServiceInternal())
-                .authenticationContext(mockAuthenticationContext =
+                .authenticationProvider(mockAuthenticationProvider =
                     producers.mockAuthenticationContext())
                 .singleton(mockMessageService = producers.mockMessageService())
                 .singleton(mockGridService = producers.mockGridService())

--- a/persistence/jdo/metamodel/src/test/java/org/apache/isis/persistence/jdo/metamodel/testing/AbstractFacetFactoryTest.java
+++ b/persistence/jdo/metamodel/src/test/java/org/apache/isis/persistence/jdo/metamodel/testing/AbstractFacetFactoryTest.java
@@ -43,7 +43,7 @@ import org.apache.isis.core.metamodel.facets.FacetedMethodParameter;
 import org.apache.isis.core.metamodel.spec.ObjectSpecification;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.persistence.jdo.provider.entities.JdoFacetContext;
 
 import junit.framework.TestCase;
@@ -67,7 +67,7 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
     }
 
     protected TranslationService mockTranslationService;
-    protected AuthenticationContext mockAuthenticationContext;
+    protected AuthenticationProvider mockAuthenticationProvider;
     protected Authentication mockAuthentication;
     protected SpecificationLoader mockSpecificationLoader;
     protected MethodRemoverForTesting methodRemover;
@@ -107,7 +107,7 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
 
         methodRemover = new MethodRemoverForTesting();
 
-        mockAuthenticationContext = context.mock(AuthenticationContext.class);
+        mockAuthenticationProvider = context.mock(AuthenticationProvider.class);
 
         mockTranslationService = context.mock(TranslationService.class);
         mockAuthentication = context.mock(Authentication.class);
@@ -117,19 +117,19 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
                 .translationService(mockTranslationService)
-                .authenticationContext(mockAuthenticationContext)
+                .authenticationProvider(mockAuthenticationProvider)
                 .build();
 
         context.checking(new Expectations() {{
 
-            allowing(mockAuthenticationContext).currentAuthentication();
+            allowing(mockAuthenticationProvider).currentAuthentication();
             will(returnValue(Optional.of(mockAuthentication)));
         }});
-        
+
         ((MetaModelContextAware)facetHolder).setMetaModelContext(metaModelContext);
         facetedMethod.setMetaModelContext(metaModelContext);
         facetedMethodParameter.setMetaModelContext(metaModelContext);
-        
+
         jdoFacetContext = jdoFacetContextForTesting();
     }
 
@@ -170,7 +170,7 @@ public abstract class AbstractFacetFactoryTest extends TestCase {
         assertTrue(methodRemover.getRemovedMethodMethodCalls().isEmpty());
         assertTrue(methodRemover.getRemoveMethodArgsCalls().isEmpty());
     }
-    
+
     public static JdoFacetContext jdoFacetContextForTesting() {
         return new JdoFacetContext() {
             @Override public boolean isPersistenceEnhanced(Class<?> cls) {

--- a/regressiontests/stable-bootstrapping/src/test/resources/org/apache/isis/testdomain/bootstrapping/builtin-requestscoped.list
+++ b/regressiontests/stable-bootstrapping/src/test/resources/org/apache/isis/testdomain/bootstrapping/builtin-requestscoped.list
@@ -16,7 +16,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-org.apache.isis.applib.services.iactn.InteractionContext
+org.apache.isis.applib.services.iactn.InteractionProvider
 org.apache.isis.applib.services.queryresultscache.QueryResultsCacheInternal
 org.apache.isis.applib.services.scratchpad.Scratchpad
 org.apache.isis.core.runtimeservices.changes.ChangedObjectsServiceInternal

--- a/regressiontests/stable-persistence-jdo/src/test/java/org/apache/isis/testdomain/persistence/jdo/JdoExceptionTranslationTest_usingTransactional.java
+++ b/regressiontests/stable-persistence-jdo/src/test/java/org/apache/isis/testdomain/persistence/jdo/JdoExceptionTranslationTest_usingTransactional.java
@@ -42,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.applib.services.repository.RepositoryService;
-import org.apache.isis.commons.functional.Result;
 import org.apache.isis.commons.functional.ThrowingRunnable;
 import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
@@ -54,12 +53,12 @@ import org.apache.isis.testdomain.jdo.entities.JdoInventory;
 import lombok.val;
 
 @SpringBootTest(
-        classes = { 
+        classes = {
                 Configuration_usingJdo.class,
                 JdoInventoryDao.class,
         })
 @TestPropertySources({
-    @TestPropertySource(IsisPresets.UseLog4j2Test)    
+    @TestPropertySource(IsisPresets.UseLog4j2Test)
 })
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class JdoExceptionTranslationTest_usingTransactional
@@ -77,77 +76,77 @@ class JdoExceptionTranslationTest_usingTransactional
         // launch H2Console for troubleshooting ...
         // Util_H2Console.main(null);
     }
-    
-    @Test @Order(1) 
+
+    @Test @Order(1)
     @Transactional @Rollback(false)
     void booksUniqueByIsbn_setupPhase() {
         interactionFactory.runAnonymous(()->{
-            
+
             _TestFixtures.setUp3Books(repositoryService);
-            
+
         });
     }
 
-    @Test @Order(2) 
+    @Test @Order(2)
     void booksUniqueByIsbn_whenViolated_shouldThrowTranslatedException() {
 
         // when adding a book for which one with same ISBN already exists in the database,
         // we expect to see a Spring recognized DataAccessException been thrown
-        
-        final ThrowingRunnable uniqueConstraintViolator = 
+
+        final ThrowingRunnable uniqueConstraintViolator =
                 ()->inventoryDao.get().addBook_havingIsbnA_usingRepositoryService();
-                
+
         assertThrows(DataIntegrityViolationException.class, ()->{
-        
+
             interactionFactory.runAnonymous(()->{
-            
-                Result.ofVoid(uniqueConstraintViolator)
+
+                ThrowingRunnable.resultOf(uniqueConstraintViolator)
                 .ifSuccess(__->fail("expected to fail, but did not"))
                 //.mapFailure(ex->_JdoExceptionTranslator.translate(ex, txManager))
                 .ifFailure(ex->assertTrue(ex instanceof DataIntegrityViolationException))
                 .optionalElseFail();
-            
+
             });
-        
+
         });
-        
-    }    
-    
-    @Test @Order(3) 
+
+    }
+
+    @Test @Order(3)
     @Transactional @Rollback(false)
     void booksUniqueByIsbn_verifyPhase() {
 
         // expected post condition: ONE inventory with 3 books
-        
+
         interactionFactory.runAnonymous(()->{
-            
+
             val inventories = repositoryService.allInstances(JdoInventory.class);
             assertEquals(1, inventories.size());
-            
+
             val inventory = inventories.get(0);
             assertNotNull(inventory);
-            
+
             assertNotNull(inventory);
             assertNotNull(inventory.getProducts());
             assertEquals(3, inventory.getProducts().size());
 
             _TestFixtures.assertInventoryHasBooks(inventory.getProducts(), 1, 2, 3);
-            
+
         });
-        
+
     }
-    
-    @Test @Order(4) 
+
+    @Test @Order(4)
     @Transactional @Rollback(false)
     void booksUniqueByIsbn_cleanupPhase() {
 
         interactionFactory.runAnonymous(()->{
 
             _TestFixtures.cleanUp(repositoryService);
-            
+
         });
-        
+
     }
-    
-    
+
+
 }

--- a/regressiontests/stable-persistence-jdo/src/test/java/org/apache/isis/testdomain/persistence/jdo/JdoExceptionTranslationTest_usingTransactional.java
+++ b/regressiontests/stable-persistence-jdo/src/test/java/org/apache/isis/testdomain/persistence/jdo/JdoExceptionTranslationTest_usingTransactional.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.applib.services.repository.RepositoryService;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.persistence.jdo.spring.integration.JdoTransactionManager;

--- a/regressiontests/stable-persistence-jpa/src/test/java/org/apache/isis/testdomain/persistence/jpa/JpaExceptionTranslationTest_usingTransactional.java
+++ b/regressiontests/stable-persistence-jpa/src/test/java/org/apache/isis/testdomain/persistence/jpa/JpaExceptionTranslationTest_usingTransactional.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.applib.services.repository.RepositoryService;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.testdomain.conf.Configuration_usingJpa;

--- a/regressiontests/stable-persistence-jpa/src/test/java/org/apache/isis/testdomain/persistence/jpa/JpaExceptionTranslationTest_usingTransactional.java
+++ b/regressiontests/stable-persistence-jpa/src/test/java/org/apache/isis/testdomain/persistence/jpa/JpaExceptionTranslationTest_usingTransactional.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.applib.services.repository.RepositoryService;
-import org.apache.isis.commons.functional.Result;
 import org.apache.isis.commons.functional.ThrowingRunnable;
 import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
@@ -54,12 +53,12 @@ import org.apache.isis.testdomain.jpa.entities.JpaInventory;
 import lombok.val;
 
 @SpringBootTest(
-        classes = { 
+        classes = {
                 Configuration_usingJpa.class,
                 JpaInventoryDao.class
         })
 @TestPropertySources({
-    @TestPropertySource(IsisPresets.UseLog4j2Test)    
+    @TestPropertySource(IsisPresets.UseLog4j2Test)
 })
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class JpaExceptionTranslationTest_usingTransactional
@@ -77,66 +76,66 @@ class JpaExceptionTranslationTest_usingTransactional
         // launch H2Console for troubleshooting ...
         // Util_H2Console.main(null);
     }
-    
-    @Test @Order(1) 
+
+    @Test @Order(1)
     @Transactional @Rollback(false)
     void booksUniqueByIsbn_setupPhase() {
         interactionFactory.runAnonymous(()->{
-            
+
             _TestFixtures.setUp3Books(repositoryService);
-            
+
         });
     }
-    
+
     @Test @Order(2)
     void booksUniqueByIsbn_whenViolated_shouldThrowTranslatedException() {
 
         // when adding a book for which one with same ISBN already exists in the database,
-        // we expect to see a Spring recognized DataAccessException been thrown 
-        
-        final ThrowingRunnable uniqueConstraintViolator = 
+        // we expect to see a Spring recognized DataAccessException been thrown
+
+        final ThrowingRunnable uniqueConstraintViolator =
                 ()->inventoryDao.get().addBook_havingIsbnA_usingRepositoryService();
-                
+
         assertThrows(DataIntegrityViolationException.class, ()->{
-        
+
             interactionFactory.runAnonymous(()->{
-                
-                Result.ofVoid(uniqueConstraintViolator)
+
+                ThrowingRunnable.resultOf(uniqueConstraintViolator)
                 .ifSuccess(__->fail("expected to fail, but did not"))
-               // .mapFailure(ex->_JpaExceptionTranslator.translate(ex, txManager)) 
+               // .mapFailure(ex->_JpaExceptionTranslator.translate(ex, txManager))
                 .ifFailure(ex->assertTrue(ex instanceof DataIntegrityViolationException))
                 .optionalElseFail();
-            
+
             });
-        
+
         });
-        
-    }    
-    
+
+    }
+
     @Test @Order(3)
     @Transactional @Rollback(false)
     void booksUniqueByIsbn_verifyPhase() {
 
         // expected post condition: ONE inventory with 3 books
-        
+
         interactionFactory.runAnonymous(()->{
-            
+
             val inventories = repositoryService.allInstances(JpaInventory.class);
             assertEquals(1, inventories.size());
-            
+
             val inventory = inventories.get(0);
             assertNotNull(inventory);
-            
+
             assertNotNull(inventory);
             assertNotNull(inventory.getProducts());
             assertEquals(3, inventory.getProducts().size());
 
             _TestFixtures.assertInventoryHasBooks(inventory.getProducts(), 1, 2, 3);
-            
+
         });
-        
+
     }
-    
+
     @Test @Order(4)
     @Transactional @Rollback(false)
     void booksUniqueByIsbn_cleanupPhase() {
@@ -144,10 +143,10 @@ class JpaExceptionTranslationTest_usingTransactional
         interactionFactory.runAnonymous(()->{
 
             _TestFixtures.cleanUp(repositoryService);
-            
+
         });
-        
+
     }
-    
-    
+
+
 }

--- a/regressiontests/stable-rest/src/test/resources/org/apache/isis/testdomain/bootstrapping/builtin-requestscoped.list
+++ b/regressiontests/stable-rest/src/test/resources/org/apache/isis/testdomain/bootstrapping/builtin-requestscoped.list
@@ -16,7 +16,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-org.apache.isis.applib.services.iactn.InteractionContext
+org.apache.isis.applib.services.iactn.InteractionProvider
 org.apache.isis.applib.services.queryresultscache.QueryResultsCacheInternal
 org.apache.isis.applib.services.scratchpad.Scratchpad
 org.apache.isis.core.runtimeservices.changes.ChangedObjectsServiceInternal

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/applayer/ApplicationLayerTestFactory.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/applayer/ApplicationLayerTestFactory.java
@@ -187,7 +187,7 @@ public class ApplicationLayerTestFactory {
                 return result;
             });
 
-            interactionFactory.closeSessionStack();
+            interactionFactory.closeInteractionLayers();
 
             if(isSuccesfulRun) {
                 verifier.accept(onSuccess);

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/conf/Configuration_headless.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/conf/Configuration_headless.java
@@ -63,7 +63,7 @@ public class Configuration_headless {
     public static class HeadlessCommandSupport
     implements InteractionScopeAware {
 
-//      private final Provider<InteractionContext> interactionContextProvider;
+//      private final Provider<InteractionProvider> interactionContextProvider;
 //      private final CommandDispatcher commandDispatcher;
 
         @Override

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/conf/Configuration_headless.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/conf/Configuration_headless.java
@@ -76,13 +76,13 @@ public class Configuration_headless {
 
         public void setupCommandCreateIfMissing() {
 
-//            val interactionContext = interactionContextProvider.get();
+//            val interactionProvider = interactionProviderProvider.get();
 //            @SuppressWarnings("unused")
 //            final Interaction interaction = Optional.ofNullable(interactionContext.getInteraction())
 //                    .orElseGet(()->{
 //                        val newCommand = new Command();
 //                        val newInteraction = new Interaction(newCommand);
-//                        interactionContext.setInteraction(newInteraction);
+//                        interactionProvider.setInteraction(newInteraction);
 //                        return newInteraction;
 //                    });
         }

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/conf/Configuration_headless.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/conf/Configuration_headless.java
@@ -63,9 +63,6 @@ public class Configuration_headless {
     public static class HeadlessCommandSupport
     implements InteractionScopeAware {
 
-//      private final Provider<InteractionProvider> interactionContextProvider;
-//      private final CommandDispatcher commandDispatcher;
-
         @Override
         public void beforeEnteringTransactionalBoundary(Interaction interaction) {
             _Probe.errOut("Interaction HAS_STARTED conversationId=%s", interaction.getInteractionId());

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/util/interaction/InteractionTestAbstract.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/util/interaction/InteractionTestAbstract.java
@@ -37,7 +37,7 @@ import org.apache.isis.applib.services.wrapper.WrapperFactory;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Sets;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.CollectionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.PropertyInteraction;
@@ -53,7 +53,7 @@ import lombok.val;
 public abstract class InteractionTestAbstract extends IsisIntegrationTestAbstract {
 
     @Inject protected ObjectManager objectManager;
-    @Inject protected InteractionHandler interactionHandler;
+    @Inject protected InteractionService interactionService;
     @Inject protected WrapperFactory wrapper;
     @Inject protected KVStoreForTesting kvStoreForTesting;
     @Inject private javax.inject.Provider<EntityChangeTracker> entityChangeTrackerProvider;

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/util/interaction/InteractionTestAbstract.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/util/interaction/InteractionTestAbstract.java
@@ -37,7 +37,7 @@ import org.apache.isis.applib.services.wrapper.WrapperFactory;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Sets;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.CollectionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.PropertyInteraction;

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/util/interaction/InteractionTestAbstract.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/util/interaction/InteractionTestAbstract.java
@@ -37,7 +37,7 @@ import org.apache.isis.applib.services.wrapper.WrapperFactory;
 import org.apache.isis.commons.internal.base._NullSafe;
 import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Sets;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.CollectionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.PropertyInteraction;
@@ -53,7 +53,7 @@ import lombok.val;
 public abstract class InteractionTestAbstract extends IsisIntegrationTestAbstract {
 
     @Inject protected ObjectManager objectManager;
-    @Inject protected InteractionFactory interactionFactory;
+    @Inject protected InteractionHandler interactionHandler;
     @Inject protected WrapperFactory wrapper;
     @Inject protected KVStoreForTesting kvStoreForTesting;
     @Inject private javax.inject.Provider<EntityChangeTracker> entityChangeTrackerProvider;

--- a/security/keycloak/src/main/java/org/apache/isis/security/keycloak/authentication/AuthenticatorKeycloak.java
+++ b/security/keycloak/src/main/java/org/apache/isis/security/keycloak/authentication/AuthenticatorKeycloak.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Service;
 import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.Authenticator;
 
 /**
@@ -42,7 +42,7 @@ import org.apache.isis.core.security.authentication.Authenticator;
 @Singleton
 public class AuthenticatorKeycloak implements Authenticator {
 
-    @Inject private AuthenticationContext authenticationTracker;
+    @Inject private AuthenticationProvider authenticationTracker;
 
     @Override
     public final boolean canAuthenticate(final Class<? extends AuthenticationRequest> authenticationRequestClass) {

--- a/security/keycloak/src/main/java/org/apache/isis/security/keycloak/authentication/AuthenticatorKeycloak.java
+++ b/security/keycloak/src/main/java/org/apache/isis/security/keycloak/authentication/AuthenticatorKeycloak.java
@@ -42,7 +42,7 @@ import org.apache.isis.core.security.authentication.Authenticator;
 @Singleton
 public class AuthenticatorKeycloak implements Authenticator {
 
-    @Inject private AuthenticationProvider authenticationTracker;
+    @Inject private AuthenticationProvider authenticationProvider;
 
     @Override
     public final boolean canAuthenticate(final Class<? extends AuthenticationRequest> authenticationRequestClass) {
@@ -52,7 +52,7 @@ public class AuthenticatorKeycloak implements Authenticator {
     @Override
     public Authentication authenticate(final AuthenticationRequest request, final String code) {
         // HTTP request filters should already have taken care of Authentication creation
-        return authenticationTracker.currentAuthentication().orElse(null);
+        return authenticationProvider.currentAuthentication().orElse(null);
     }
 
     @Override

--- a/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
+++ b/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.apache.isis.applib.services.user.UserMemento;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
@@ -46,7 +46,7 @@ import lombok.val;
  */
 public class KeycloakFilter implements Filter {
 
-    @Autowired private InteractionHandler interactionHandler;
+    @Autowired private InteractionService interactionService;
 
     @Override
     public void doFilter(
@@ -69,7 +69,7 @@ public class KeycloakFilter implements Filter {
         val authentication = SimpleAuthentication.of(user, subjectHeader);
         authentication.setType(Authentication.Type.EXTERNAL);
 
-        interactionHandler.runAuthenticated(
+        interactionService.runAuthenticated(
                 authentication,
                 ()->{
                         filterChain.doFilter(servletRequest, servletResponse);

--- a/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
+++ b/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
@@ -46,7 +47,7 @@ import lombok.val;
  */
 public class KeycloakFilter implements Filter {
 
-    @Autowired private InteractionService interactionService;
+    @Autowired private InteractionFactory interactionFactory;
 
     @Override
     public void doFilter(
@@ -69,7 +70,7 @@ public class KeycloakFilter implements Filter {
         val authentication = SimpleAuthentication.of(user, subjectHeader);
         authentication.setType(Authentication.Type.EXTERNAL);
 
-        interactionService.runAuthenticated(
+        interactionFactory.runAuthenticated(
                 authentication,
                 ()->{
                         filterChain.doFilter(servletRequest, servletResponse);

--- a/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
+++ b/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.apache.isis.applib.services.user.UserMemento;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 

--- a/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
+++ b/security/keycloak/src/main/java/org/apache/isis/security/keycloak/webmodule/KeycloakFilter.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.apache.isis.applib.services.user.UserMemento;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 
@@ -46,7 +46,7 @@ import lombok.val;
  */
 public class KeycloakFilter implements Filter {
 
-    @Autowired private InteractionFactory isisInteractionFactory;
+    @Autowired private InteractionHandler interactionHandler;
 
     @Override
     public void doFilter(
@@ -69,7 +69,7 @@ public class KeycloakFilter implements Filter {
         val authentication = SimpleAuthentication.of(user, subjectHeader);
         authentication.setType(Authentication.Type.EXTERNAL);
 
-        isisInteractionFactory.runAuthenticated(
+        interactionHandler.runAuthenticated(
                 authentication,
                 ()->{
                         filterChain.doFilter(servletRequest, servletResponse);

--- a/security/spring/src/main/java/org/apache/isis/security/spring/authentication/AuthenticatorSpring.java
+++ b/security/spring/src/main/java/org/apache/isis/security/spring/authentication/AuthenticatorSpring.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 
 import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.core.security.authentication.Authentication;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;
 import org.apache.isis.core.security.authentication.Authenticator;
 
@@ -41,7 +41,7 @@ import org.apache.isis.core.security.authentication.Authenticator;
 @Qualifier("Spring")
 public class AuthenticatorSpring implements Authenticator {
 
-    @Inject private AuthenticationContext authenticationTracker;
+    @Inject private AuthenticationProvider authenticationTracker;
 
     @Override
     public final boolean canAuthenticate(final Class<? extends AuthenticationRequest> authenticationRequestClass) {

--- a/security/spring/src/main/java/org/apache/isis/security/spring/authentication/AuthenticatorSpring.java
+++ b/security/spring/src/main/java/org/apache/isis/security/spring/authentication/AuthenticatorSpring.java
@@ -41,7 +41,7 @@ import org.apache.isis.core.security.authentication.Authenticator;
 @Qualifier("Spring")
 public class AuthenticatorSpring implements Authenticator {
 
-    @Inject private AuthenticationProvider authenticationTracker;
+    @Inject private AuthenticationProvider authenticationProvider;
 
     @Override
     public final boolean canAuthenticate(final Class<? extends AuthenticationRequest> authenticationRequestClass) {
@@ -51,7 +51,7 @@ public class AuthenticatorSpring implements Authenticator {
     @Override
     public Authentication authenticate(final AuthenticationRequest request, final String code) {
         // SpringSecurityFilter should already have taken care of Authentication creation
-        return authenticationTracker.currentAuthentication().orElse(null);
+        return authenticationProvider.currentAuthentication().orElse(null);
     }
 
     @Override

--- a/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
+++ b/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import org.apache.isis.applib.services.user.UserMemento;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 import org.apache.isis.security.spring.authconverters.AuthenticationConverter;
@@ -47,7 +47,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class SpringSecurityFilter implements Filter {
 
-    @Autowired private InteractionFactory isisInteractionFactory;
+    @Autowired private InteractionHandler interactionHandler;
 
     @Override
     public void doFilter(
@@ -86,7 +86,7 @@ public class SpringSecurityFilter implements Filter {
         val authentication = SimpleAuthentication.validOf(userMemento);
         authentication.setType(Authentication.Type.EXTERNAL);
 
-        isisInteractionFactory.runAuthenticated(
+        interactionHandler.runAuthenticated(
                 authentication,
                 ()->{
                         filterChain.doFilter(servletRequest, servletResponse);

--- a/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
+++ b/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import org.apache.isis.applib.services.user.UserMemento;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 import org.apache.isis.security.spring.authconverters.AuthenticationConverter;
@@ -47,7 +47,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class SpringSecurityFilter implements Filter {
 
-    @Autowired private InteractionHandler interactionHandler;
+    @Autowired private InteractionService interactionService;
 
     @Override
     public void doFilter(
@@ -86,7 +86,7 @@ public class SpringSecurityFilter implements Filter {
         val authentication = SimpleAuthentication.validOf(userMemento);
         authentication.setType(Authentication.Type.EXTERNAL);
 
-        interactionHandler.runAuthenticated(
+        interactionService.runAuthenticated(
                 authentication,
                 ()->{
                         filterChain.doFilter(servletRequest, servletResponse);

--- a/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
+++ b/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
@@ -34,6 +34,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import org.apache.isis.applib.services.user.UserMemento;
 import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 import org.apache.isis.security.spring.authconverters.AuthenticationConverter;
@@ -47,7 +48,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class SpringSecurityFilter implements Filter {
 
-    @Autowired private InteractionService interactionService;
+    @Autowired private InteractionFactory interactionFactory;
 
     @Override
     public void doFilter(
@@ -81,12 +82,13 @@ public class SpringSecurityFilter implements Filter {
             return; // unknown principal type, not handled
         }
 
+        // TODO: this should be added by Wicket viewer
         userMemento = userMemento.withRole("org.apache.isis.viewer.wicket.roles.USER");
 
         val authentication = SimpleAuthentication.validOf(userMemento);
         authentication.setType(Authentication.Type.EXTERNAL);
 
-        interactionService.runAuthenticated(
+        interactionFactory.runAuthenticated(
                 authentication,
                 ()->{
                         filterChain.doFilter(servletRequest, servletResponse);

--- a/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
+++ b/security/spring/src/main/java/org/apache/isis/security/spring/webmodule/SpringSecurityFilter.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import org.apache.isis.applib.services.user.UserMemento;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.security.authentication.Authentication;
 import org.apache.isis.core.security.authentication.standard.SimpleAuthentication;
 import org.apache.isis.security.spring.authconverters.AuthenticationConverter;

--- a/testing/fixtures/applib/src/main/java/org/apache/isis/testing/fixtures/applib/services/FixturesLifecycleService.java
+++ b/testing/fixtures/applib/src/main/java/org/apache/isis/testing/fixtures/applib/services/FixturesLifecycleService.java
@@ -33,7 +33,7 @@ import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.config.environment.IsisSystemEnvironment;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.metamodel.events.MetamodelEvent;
 import org.apache.isis.testing.fixtures.applib.clock.clock.Clock;
 import org.apache.isis.testing.fixtures.applib.clock.clock.FixtureClock;

--- a/testing/fixtures/applib/src/main/java/org/apache/isis/testing/fixtures/applib/services/FixturesLifecycleService.java
+++ b/testing/fixtures/applib/src/main/java/org/apache/isis/testing/fixtures/applib/services/FixturesLifecycleService.java
@@ -33,7 +33,7 @@ import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.config.environment.IsisSystemEnvironment;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.metamodel.events.MetamodelEvent;
 import org.apache.isis.testing.fixtures.applib.clock.clock.Clock;
 import org.apache.isis.testing.fixtures.applib.clock.clock.FixtureClock;
@@ -56,7 +56,7 @@ public class FixturesLifecycleService {
     @SuppressWarnings("unused")
 
     @Inject
-    private InteractionFactory isisInteractionFactory; // depends on relationship
+    private InteractionHandler interactionHandler; // depends on relationship
     @Inject
     private IsisSystemEnvironment isisSystemEnvironment;
     @Inject

--- a/testing/fixtures/applib/src/main/java/org/apache/isis/testing/fixtures/applib/services/FixturesLifecycleService.java
+++ b/testing/fixtures/applib/src/main/java/org/apache/isis/testing/fixtures/applib/services/FixturesLifecycleService.java
@@ -33,7 +33,7 @@ import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.core.config.IsisConfiguration;
 import org.apache.isis.core.config.environment.IsisSystemEnvironment;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.metamodel.events.MetamodelEvent;
 import org.apache.isis.testing.fixtures.applib.clock.clock.Clock;
 import org.apache.isis.testing.fixtures.applib.clock.clock.FixtureClock;
@@ -56,7 +56,7 @@ public class FixturesLifecycleService {
     @SuppressWarnings("unused")
 
     @Inject
-    private InteractionHandler interactionHandler; // depends on relationship
+    private InteractionService interactionService; // depends on relationship
     @Inject
     private IsisSystemEnvironment isisSystemEnvironment;
     @Inject

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisIntegrationTestAbstract.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisIntegrationTestAbstract.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 import org.apache.isis.applib.annotation.OrderPrecedence;
 import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.applib.services.factory.FactoryService;
-import org.apache.isis.applib.services.iactn.InteractionContext;
+import org.apache.isis.applib.services.iactn.InteractionProvider;
 import org.apache.isis.applib.services.inject.ServiceInjector;
 import org.apache.isis.applib.services.metamodel.MetaModelService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
@@ -60,7 +60,7 @@ public abstract class IsisIntegrationTestAbstract {
     public static class InteractionSupport {
 
         @SuppressWarnings("unused")
-        private final Provider<InteractionContext> interactionContextProvider;
+        private final Provider<InteractionProvider> interactionContextProvider;
 
     }
 

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisIntegrationTestAbstract.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisIntegrationTestAbstract.java
@@ -60,7 +60,7 @@ public abstract class IsisIntegrationTestAbstract {
     public static class InteractionSupport {
 
         @SuppressWarnings("unused")
-        private final Provider<InteractionProvider> interactionContextProvider;
+        private final Provider<InteractionProvider> interactionProviderProvider;
 
     }
 

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
@@ -32,7 +32,7 @@ public class IsisInteractionHandler implements BeforeEachCallback, AfterEachCall
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
         _Helper.getInteractionFactory(extensionContext)
-        .ifPresent(isisInteractionFactory->isisInteractionFactory.openInteraction());
+        .ifPresent(InteractionService::openInteraction);
     }
 
     @Override

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 
 /**
  * @since 2.0 {@index}

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 
 /**
  * @since 2.0 {@index}
@@ -38,7 +38,7 @@ public class IsisInteractionHandler implements BeforeEachCallback, AfterEachCall
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         _Helper.getInteractionFactory(extensionContext)
-        .ifPresent(InteractionFactory::closeInteractionLayers);
+        .ifPresent(InteractionHandler::closeInteractionLayers);
     }
 
 

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 
 /**
  * @since 2.0 {@index}
@@ -38,7 +38,7 @@ public class IsisInteractionHandler implements BeforeEachCallback, AfterEachCall
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         _Helper.getInteractionFactory(extensionContext)
-        .ifPresent(InteractionHandler::closeInteractionLayers);
+        .ifPresent(InteractionService::closeInteractionLayers);
     }
 
 

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/IsisInteractionHandler.java
@@ -38,7 +38,7 @@ public class IsisInteractionHandler implements BeforeEachCallback, AfterEachCall
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         _Helper.getInteractionFactory(extensionContext)
-        .ifPresent(InteractionFactory::closeSessionStack);
+        .ifPresent(InteractionFactory::closeInteractionLayers);
     }
 
 

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.apache.isis.applib.services.exceprecog.ExceptionRecognizerService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 
 class _Helper {
 
@@ -38,7 +38,7 @@ class _Helper {
 
     // -- SHORTCUTS
 
-    static Optional<InteractionHandler> getInteractionFactory(final ExtensionContext extensionContext) {
+    static Optional<InteractionService> getInteractionFactory(final ExtensionContext extensionContext) {
         return getServiceRegistry(extensionContext)
         .flatMap(serviceRegistry->serviceRegistry.lookupService(InteractionFactory.class));
     }

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
@@ -38,7 +38,7 @@ class _Helper {
 
     // -- SHORTCUTS
 
-    static Optional<InteractionService> getInteractionFactory(final ExtensionContext extensionContext) {
+    static Optional<InteractionFactory> getInteractionFactory(final ExtensionContext extensionContext) {
         return getServiceRegistry(extensionContext)
         .flatMap(serviceRegistry->serviceRegistry.lookupService(InteractionFactory.class));
     }

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.apache.isis.applib.services.exceprecog.ExceptionRecognizerService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 
 class _Helper {
 
@@ -37,7 +38,7 @@ class _Helper {
 
     // -- SHORTCUTS
 
-    static Optional<InteractionFactory> getInteractionFactory(final ExtensionContext extensionContext) {
+    static Optional<InteractionHandler> getInteractionFactory(final ExtensionContext extensionContext) {
         return getServiceRegistry(extensionContext)
         .flatMap(serviceRegistry->serviceRegistry.lookupService(InteractionFactory.class));
     }

--- a/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
+++ b/testing/integtestsupport/applib/src/main/java/org/apache/isis/testing/integtestsupport/applib/_Helper.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.apache.isis.applib.services.exceprecog.ExceptionRecognizerService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 
 class _Helper {
 

--- a/viewers/restfulobjects/rendering/src/main/java/org/apache/isis/viewer/restfulobjects/rendering/IResourceContext.java
+++ b/viewers/restfulobjects/rendering/src/main/java/org/apache/isis/viewer/restfulobjects/rendering/IResourceContext.java
@@ -32,7 +32,7 @@ import org.apache.isis.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.isis.core.metamodel.context.MetaModelContext;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
-import org.apache.isis.core.security.authentication.AuthenticationContext;
+import org.apache.isis.core.security.authentication.AuthenticationProvider;
 import org.apache.isis.viewer.restfulobjects.rendering.domainobjects.DomainObjectReprRenderer;
 import org.apache.isis.viewer.restfulobjects.rendering.domainobjects.ObjectAdapterLinkTo;
 import org.apache.isis.viewer.restfulobjects.rendering.service.RepresentationService;
@@ -96,7 +96,7 @@ public interface IResourceContext {
      */
     RepresentationService.Intent getIntent();
 
-    AuthenticationContext getAuthenticationContext();
+    AuthenticationProvider getAuthenticationContext();
     SpecificationLoader getSpecificationLoader();
     MetaModelContext getMetaModelContext();
     ServiceRegistry getServiceRegistry();

--- a/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
+++ b/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.commons.internal.collections._Maps;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.metamodel._testing.MetaModelContext_forTesting;
@@ -65,7 +65,7 @@ public abstract class ResourceContext_ensureCompatibleAcceptHeader_ContractTest 
     @Mock HttpHeaders mockHttpHeaders;
     @Mock HttpServletRequest mockHttpServletRequest;
     @Mock ServletContext mockServletContext;
-    @Mock InteractionFactory mockIsisInteractionFactory;
+    @Mock InteractionHandler mockInteractionHandler;
     @Mock Interaction mockInteraction;
     @Mock Authentication mockAuthentication;
     @Mock SpecificationLoader mockSpecificationLoader;
@@ -85,7 +85,7 @@ public abstract class ResourceContext_ensureCompatibleAcceptHeader_ContractTest 
                 .authentication(mockAuthentication)
                 .singleton(mockAuthenticationManager)
                 .singleton(mockIsisInteractionTracker)
-                .singleton(mockIsisInteractionFactory)
+                .singleton(mockInteractionHandler)
                 .build();
 
         context.checking(new Expectations() {

--- a/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
+++ b/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.commons.internal.collections._Maps;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.metamodel._testing.MetaModelContext_forTesting;
@@ -65,7 +65,7 @@ public abstract class ResourceContext_ensureCompatibleAcceptHeader_ContractTest 
     @Mock HttpHeaders mockHttpHeaders;
     @Mock HttpServletRequest mockHttpServletRequest;
     @Mock ServletContext mockServletContext;
-    @Mock InteractionService mockInteractionService;
+    @Mock InteractionFactory mockInteractionFactory;
     @Mock Interaction mockInteraction;
     @Mock Authentication mockAuthentication;
     @Mock SpecificationLoader mockSpecificationLoader;
@@ -85,7 +85,7 @@ public abstract class ResourceContext_ensureCompatibleAcceptHeader_ContractTest 
                 .authentication(mockAuthentication)
                 .singleton(mockAuthenticationManager)
                 .singleton(mockIsisInteractionTracker)
-                .singleton(mockInteractionService)
+                .singleton(mockInteractionFactory)
                 .build();
 
         context.checking(new Expectations() {

--- a/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
+++ b/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.commons.internal.collections._Maps;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.metamodel._testing.MetaModelContext_forTesting;
@@ -65,7 +65,7 @@ public abstract class ResourceContext_ensureCompatibleAcceptHeader_ContractTest 
     @Mock HttpHeaders mockHttpHeaders;
     @Mock HttpServletRequest mockHttpServletRequest;
     @Mock ServletContext mockServletContext;
-    @Mock InteractionHandler mockInteractionHandler;
+    @Mock InteractionService mockInteractionService;
     @Mock Interaction mockInteraction;
     @Mock Authentication mockAuthentication;
     @Mock SpecificationLoader mockSpecificationLoader;
@@ -85,7 +85,7 @@ public abstract class ResourceContext_ensureCompatibleAcceptHeader_ContractTest 
                 .authentication(mockAuthentication)
                 .singleton(mockAuthenticationManager)
                 .singleton(mockIsisInteractionTracker)
-                .singleton(mockInteractionHandler)
+                .singleton(mockInteractionService)
                 .build();
 
         context.checking(new Expectations() {

--- a/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
+++ b/viewers/restfulobjects/testing/src/main/java/org/apache/isis/viewer/restfulobjects/testing/ResourceContext_ensureCompatibleAcceptHeader_ContractTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.applib.services.iactn.Interaction;
 import org.apache.isis.commons.internal.collections._Maps;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.metamodel._testing.MetaModelContext_forTesting;

--- a/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
+++ b/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
@@ -48,7 +48,7 @@ import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Lists;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.factory._InstanceUtil;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.metamodel.commons.StringExtensions;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.validator.MetaModelInvalidException;
@@ -157,7 +157,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
         return Pattern.compile(".*\\." + input);
     };
 
-    @Autowired private InteractionHandler interactionHandler;
+    @Autowired private InteractionService interactionService;
     @Autowired private SpecificationLoader specificationLoader;
     @Autowired private TransactionService transactionService;
 
@@ -344,7 +344,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 
-        requires(interactionHandler, "isisInteractionFactory");
+        requires(interactionService, "isisInteractionFactory");
         requires(specificationLoader, "specificationLoader");
 
         ensureMetamodelIsValid(specificationLoader);
@@ -379,7 +379,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
 
                 authStrategy.bind(httpServletRequest, httpServletResponse, authentication);
 
-                interactionHandler.runAuthenticated(
+                interactionService.runAuthenticated(
                         authentication,
                         ()->{
 
@@ -406,7 +406,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
             }
 
         } finally {
-            interactionHandler.closeInteractionLayers();
+            interactionService.closeInteractionLayers();
         }
 
     }

--- a/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
+++ b/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
@@ -48,7 +48,7 @@ import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Lists;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.factory._InstanceUtil;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.metamodel.commons.StringExtensions;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.validator.MetaModelInvalidException;
@@ -157,7 +157,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
         return Pattern.compile(".*\\." + input);
     };
 
-    @Autowired private InteractionService interactionService;
+    @Autowired private InteractionFactory interactionFactory;
     @Autowired private SpecificationLoader specificationLoader;
     @Autowired private TransactionService transactionService;
 
@@ -344,7 +344,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 
-        requires(interactionService, "isisInteractionFactory");
+        requires(interactionFactory, "isisInteractionFactory");
         requires(specificationLoader, "specificationLoader");
 
         ensureMetamodelIsValid(specificationLoader);
@@ -379,7 +379,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
 
                 authStrategy.bind(httpServletRequest, httpServletResponse, authentication);
 
-                interactionService.runAuthenticated(
+                interactionFactory.runAuthenticated(
                         authentication,
                         ()->{
 
@@ -406,7 +406,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
             }
 
         } finally {
-            interactionService.closeInteractionLayers();
+            interactionFactory.closeInteractionLayers();
         }
 
     }

--- a/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
+++ b/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
@@ -406,7 +406,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
             }
 
         } finally {
-            isisInteractionFactory.closeSessionStack();
+            isisInteractionFactory.closeInteractionLayers();
         }
 
     }

--- a/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
+++ b/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
@@ -48,7 +48,7 @@ import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Lists;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.factory._InstanceUtil;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.metamodel.commons.StringExtensions;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.validator.MetaModelInvalidException;
@@ -157,7 +157,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
         return Pattern.compile(".*\\." + input);
     };
 
-    @Autowired private InteractionFactory isisInteractionFactory;
+    @Autowired private InteractionHandler interactionHandler;
     @Autowired private SpecificationLoader specificationLoader;
     @Autowired private TransactionService transactionService;
 
@@ -344,7 +344,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 
-        requires(isisInteractionFactory, "isisInteractionFactory");
+        requires(interactionHandler, "isisInteractionFactory");
         requires(specificationLoader, "specificationLoader");
 
         ensureMetamodelIsValid(specificationLoader);
@@ -379,7 +379,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
 
                 authStrategy.bind(httpServletRequest, httpServletResponse, authentication);
 
-                isisInteractionFactory.runAuthenticated(
+                interactionHandler.runAuthenticated(
                         authentication,
                         ()->{
 
@@ -406,7 +406,7 @@ public class IsisRestfulObjectsInteractionFilter implements Filter {
             }
 
         } finally {
-            isisInteractionFactory.closeInteractionLayers();
+            interactionHandler.closeInteractionLayers();
         }
 
     }

--- a/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
+++ b/viewers/restfulobjects/viewer/src/main/java/org/apache/isis/viewer/restfulobjects/viewer/webmodule/IsisRestfulObjectsInteractionFilter.java
@@ -48,7 +48,7 @@ import org.apache.isis.commons.internal.base._Strings;
 import org.apache.isis.commons.internal.collections._Lists;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.factory._InstanceUtil;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.metamodel.commons.StringExtensions;
 import org.apache.isis.core.metamodel.specloader.SpecificationLoader;
 import org.apache.isis.core.metamodel.specloader.validator.MetaModelInvalidException;

--- a/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
+++ b/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.commons.internal.codec._UrlDecoderUtil;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.interaction.session.IsisInteraction;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
@@ -55,7 +55,7 @@ public class ResourceContext_getArg_Test {
     @Mock private HttpServletRequest mockHttpServletRequest;
     @Mock private ServletContext mockServletContext;
     @Mock private IsisInteraction mockIsisInteraction;
-    @Mock private InteractionHandler mockInteractionHandler;
+    @Mock private InteractionService mockInteractionService;
     @Mock private InteractionTracker mockIsisInteractionTracker;
     @Mock private AuthenticationManager mockAuthenticationManager;
     @Mock private Authentication mockAuthentication;
@@ -72,7 +72,7 @@ public class ResourceContext_getArg_Test {
 
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
-                .singleton(mockInteractionHandler)
+                .singleton(mockInteractionService)
                 .singleton(mockAuthenticationManager)
                 .singleton(mockIsisInteractionTracker)
                 //                .serviceInjector(mockServiceInjector)

--- a/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
+++ b/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.commons.internal.codec._UrlDecoderUtil;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.interaction.session.IsisInteraction;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
@@ -55,7 +55,7 @@ public class ResourceContext_getArg_Test {
     @Mock private HttpServletRequest mockHttpServletRequest;
     @Mock private ServletContext mockServletContext;
     @Mock private IsisInteraction mockIsisInteraction;
-    @Mock private InteractionFactory mockIsisInteractionFactory;
+    @Mock private InteractionHandler mockInteractionHandler;
     @Mock private InteractionTracker mockIsisInteractionTracker;
     @Mock private AuthenticationManager mockAuthenticationManager;
     @Mock private Authentication mockAuthentication;
@@ -72,7 +72,7 @@ public class ResourceContext_getArg_Test {
 
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
-                .singleton(mockIsisInteractionFactory)
+                .singleton(mockInteractionHandler)
                 .singleton(mockAuthenticationManager)
                 .singleton(mockIsisInteractionTracker)
                 //                .serviceInjector(mockServiceInjector)
@@ -84,19 +84,19 @@ public class ResourceContext_getArg_Test {
 
 
         context.checking(new Expectations() {{
-                
+
                 allowing(webApplicationContext).getBean(MetaModelContext.class);
                 will(returnValue(metaModelContext));
-            
+
                 allowing(mockServletContext).getAttribute("org.springframework.web.context.WebApplicationContext.ROOT");
                 will(returnValue(webApplicationContext));
-            
+
                 allowing(mockHttpServletRequest).getServletContext();
                 will(returnValue(mockServletContext));
-                
+
                 allowing(mockHttpServletRequest).getQueryString();
                 will(returnValue(""));
-         
+
         }});
     }
 

--- a/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
+++ b/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.commons.internal.codec._UrlDecoderUtil;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.interaction.session.IsisInteraction;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;

--- a/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
+++ b/viewers/restfulobjects/viewer/src/test/java/org/apache/isis/viewer/restfulobjects/viewer/context/ResourceContext_getArg_Test.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.isis.commons.internal.codec._UrlDecoderUtil;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
+import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.interaction.session.IsisInteraction;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
@@ -55,7 +55,7 @@ public class ResourceContext_getArg_Test {
     @Mock private HttpServletRequest mockHttpServletRequest;
     @Mock private ServletContext mockServletContext;
     @Mock private IsisInteraction mockIsisInteraction;
-    @Mock private InteractionService mockInteractionService;
+    @Mock private InteractionFactory mockInteractionFactory;
     @Mock private InteractionTracker mockIsisInteractionTracker;
     @Mock private AuthenticationManager mockAuthenticationManager;
     @Mock private Authentication mockAuthentication;
@@ -72,7 +72,7 @@ public class ResourceContext_getArg_Test {
 
         metaModelContext = MetaModelContext_forTesting.builder()
                 .specificationLoader(mockSpecificationLoader)
-                .singleton(mockInteractionService)
+                .singleton(mockInteractionFactory)
                 .singleton(mockAuthenticationManager)
                 .singleton(mockIsisInteractionTracker)
                 //                .serviceInjector(mockServiceInjector)

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/themepicker/ThemeChooser.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/themepicker/ThemeChooser.java
@@ -32,7 +32,7 @@ import org.apache.wicket.util.cookies.CookieUtils;
 import org.apache.wicket.util.string.Strings;
 
 import org.apache.isis.core.config.IsisConfiguration;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 
 import lombok.Getter;
 import lombok.val;
@@ -158,5 +158,5 @@ public class ThemeChooser extends Panel {
 
     @Inject @Getter private IsisWicketThemeSupport themeSupport;
     @Inject @Getter private IsisConfiguration configuration;
-    @Inject @Getter private InteractionFactory isisInteractionFactory;
+    @Inject @Getter private InteractionHandler interactionHandler;
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/themepicker/ThemeChooser.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/themepicker/ThemeChooser.java
@@ -32,7 +32,7 @@ import org.apache.wicket.util.cookies.CookieUtils;
 import org.apache.wicket.util.string.Strings;
 
 import org.apache.isis.core.config.IsisConfiguration;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 
 import lombok.Getter;
 import lombok.val;
@@ -158,5 +158,5 @@ public class ThemeChooser extends Panel {
 
     @Inject @Getter private IsisWicketThemeSupport themeSupport;
     @Inject @Getter private IsisConfiguration configuration;
-    @Inject @Getter private InteractionHandler interactionHandler;
+    @Inject @Getter private InteractionService interactionService;
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/themepicker/ThemeChooser.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/components/widgets/themepicker/ThemeChooser.java
@@ -32,7 +32,7 @@ import org.apache.wicket.util.cookies.CookieUtils;
 import org.apache.wicket.util.string.Strings;
 
 import org.apache.isis.core.config.IsisConfiguration;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 
 import lombok.Getter;
 import lombok.val;

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/login/IsisSignInPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/login/IsisSignInPanel.java
@@ -32,7 +32,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.userreg.EmailNotificationService;
 import org.apache.isis.applib.services.userreg.UserRegistrationService;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.viewer.wicket.model.models.PageType;
 import org.apache.isis.viewer.wicket.ui.pages.PageClassRegistry;
 
@@ -50,7 +50,7 @@ public class IsisSignInPanel extends SignInPanel {
 
     private static final long serialVersionUID = 1L;
 
-    @Inject transient InteractionHandler interactionHandler;
+    @Inject transient InteractionService interactionService;
     @Inject transient ServiceInjector serviceInjector;
     @Inject transient ServiceRegistry serviceRegistry;
     @Inject transient private PageClassRegistry pageClassRegistry;

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/login/IsisSignInPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/login/IsisSignInPanel.java
@@ -32,7 +32,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.userreg.EmailNotificationService;
 import org.apache.isis.applib.services.userreg.UserRegistrationService;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.viewer.wicket.model.models.PageType;
 import org.apache.isis.viewer.wicket.ui.pages.PageClassRegistry;
 

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/login/IsisSignInPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/pages/login/IsisSignInPanel.java
@@ -32,7 +32,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.userreg.EmailNotificationService;
 import org.apache.isis.applib.services.userreg.UserRegistrationService;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.viewer.wicket.model.models.PageType;
 import org.apache.isis.viewer.wicket.ui.pages.PageClassRegistry;
 
@@ -50,7 +50,7 @@ public class IsisSignInPanel extends SignInPanel {
 
     private static final long serialVersionUID = 1L;
 
-    @Inject transient InteractionFactory isisInteractionFactory;
+    @Inject transient InteractionHandler interactionHandler;
     @Inject transient ServiceInjector serviceInjector;
     @Inject transient ServiceRegistry serviceRegistry;
     @Inject transient private PageClassRegistry pageClassRegistry;

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
@@ -41,7 +41,7 @@ import org.apache.isis.applib.services.message.MessageService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.commons.internal.collections._Sets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.MessageBroker;
 import org.apache.isis.core.metamodel.facets.actions.redirect.RedirectFacet;
 import org.apache.isis.core.metamodel.facets.properties.renderunchanged.UnchangingFacet;
@@ -430,7 +430,7 @@ implements FormExecutor {
         return getCommonContext().getSpecificationLoader();
     }
 
-    protected InteractionHandler getIsisInteractionFactory() {
+    protected InteractionService getIsisInteractionFactory() {
         return getCommonContext().lookupServiceElseFail(InteractionFactory.class);
     }
 

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
@@ -41,6 +41,7 @@ import org.apache.isis.applib.services.message.MessageService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.commons.internal.collections._Sets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.MessageBroker;
 import org.apache.isis.core.metamodel.facets.actions.redirect.RedirectFacet;
 import org.apache.isis.core.metamodel.facets.properties.renderunchanged.UnchangingFacet;
@@ -429,7 +430,7 @@ implements FormExecutor {
         return getCommonContext().getSpecificationLoader();
     }
 
-    protected InteractionFactory getIsisInteractionFactory() {
+    protected InteractionHandler getIsisInteractionFactory() {
         return getCommonContext().lookupServiceElseFail(InteractionFactory.class);
     }
 

--- a/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/isis/viewer/wicket/ui/panels/FormExecutorDefault.java
@@ -41,7 +41,7 @@ import org.apache.isis.applib.services.message.MessageService;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.commons.internal.collections._Sets;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.MessageBroker;
 import org.apache.isis.core.metamodel.facets.actions.redirect.RedirectFacet;
 import org.apache.isis.core.metamodel.facets.properties.renderunchanged.UnchangingFacet;

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
@@ -32,7 +32,7 @@ import org.apache.isis.applib.services.clock.ClockService;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext.HasCommonContext;
@@ -269,7 +269,7 @@ implements BreadcrumbModelProvider, BookmarkedPagesModelProvider, HasCommonConte
         return commonContext.getServiceRegistry().select(SessionLoggingService.class);
     }
 
-    protected InteractionHandler getIsisInteractionFactory() {
+    protected InteractionService getIsisInteractionFactory() {
         return commonContext.lookupServiceElseFail(InteractionFactory.class);
     }
 

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
@@ -32,7 +32,7 @@ import org.apache.isis.applib.services.clock.ClockService;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext.HasCommonContext;

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
@@ -32,7 +32,6 @@ import org.apache.isis.applib.services.clock.ClockService;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext.HasCommonContext;
@@ -225,18 +224,9 @@ implements BreadcrumbModelProvider, BookmarkedPagesModelProvider, HasCommonConte
         return bookmarkedPagesModel;
     }
 
-
-    // /////////////////////////////////////////////////
-    // Dependencies
-    // /////////////////////////////////////////////////
-
     protected AuthenticationManager getAuthenticationManager() {
         return commonContext.getAuthenticationManager();
     }
-
-    // /////////////////////////////////////////////////
-    // *Provider impl.
-    // /////////////////////////////////////////////////
 
     private void log(
             final SessionLoggingService.Type type,
@@ -244,7 +234,7 @@ implements BreadcrumbModelProvider, BookmarkedPagesModelProvider, HasCommonConte
             final SessionLoggingService.CausedBy causedBy) {
 
 
-        val isisInteractionFactory = getIsisInteractionFactory();
+        val interactionFactory = getInteractionFactory();
         val sessionLoggingServices = getSessionLoggingServices();
 
         final Runnable loggingTask = ()->{
@@ -258,8 +248,8 @@ implements BreadcrumbModelProvider, BookmarkedPagesModelProvider, HasCommonConte
             );
         };
 
-        if(isisInteractionFactory!=null) {
-            isisInteractionFactory.runAnonymous(loggingTask::run);
+        if(interactionFactory!=null) {
+            interactionFactory.runAnonymous(loggingTask::run);
         } else {
             loggingTask.run();
         }
@@ -269,12 +259,8 @@ implements BreadcrumbModelProvider, BookmarkedPagesModelProvider, HasCommonConte
         return commonContext.getServiceRegistry().select(SessionLoggingService.class);
     }
 
-    protected InteractionService getIsisInteractionFactory() {
+    protected InteractionFactory getInteractionFactory() {
         return commonContext.lookupServiceElseFail(InteractionFactory.class);
-    }
-
-    protected InteractionTracker getIsisInteractionTracker() {
-        return commonContext.getInteractionTracker();
     }
 
     private VirtualClock virtualClock() {

--- a/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis.java
@@ -32,6 +32,7 @@ import org.apache.isis.applib.services.clock.ClockService;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext.HasCommonContext;
@@ -268,7 +269,7 @@ implements BreadcrumbModelProvider, BookmarkedPagesModelProvider, HasCommonConte
         return commonContext.getServiceRegistry().select(SessionLoggingService.class);
     }
 
-    protected InteractionFactory getIsisInteractionFactory() {
+    protected InteractionHandler getIsisInteractionFactory() {
         return commonContext.lookupServiceElseFail(InteractionFactory.class);
     }
 

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
@@ -34,7 +34,6 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
@@ -63,7 +62,7 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
     private AuthenticationManager authMgr;
     @Mock protected Authenticator mockAuthenticator;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionService mockInteractionService;
+    @Mock protected InteractionFactory mockInteractionFactory;
     @Mock protected InteractionTracker mockInteractionTracker;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
@@ -85,7 +84,7 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
                 will(returnValue(Can.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionService));
+                will(returnValue(mockInteractionFactory));
 
                 allowing(mockCommonContext).getInteractionTracker();
                 will(returnValue(mockInteractionTracker));
@@ -93,10 +92,10 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
                 allowing(mockInteractionTracker).currentAuthentication();
                 will(returnValue(Optional.of(new SingleUserAuthentication())));
 
-                allowing(mockInteractionService)
+                allowing(mockInteractionFactory)
                 .runAuthenticated(with(new SingleUserAuthentication()), with(any(ThrowingRunnable.class)));
 
-                allowing(mockInteractionService)
+                allowing(mockInteractionFactory)
                 .runAnonymous(with(any(ThrowingRunnable.class)));
 
                 // ignore

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
@@ -34,7 +34,7 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
@@ -34,6 +34,7 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
@@ -62,7 +63,7 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
     private AuthenticationManager authMgr;
     @Mock protected Authenticator mockAuthenticator;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionFactory mockInteractionFactory;
+    @Mock protected InteractionHandler mockInteractionHandler;
     @Mock protected InteractionTracker mockInteractionTracker;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
@@ -84,7 +85,7 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
                 will(returnValue(Can.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionFactory));
+                will(returnValue(mockInteractionHandler));
 
                 allowing(mockCommonContext).getInteractionTracker();
                 will(returnValue(mockInteractionTracker));
@@ -92,10 +93,10 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
                 allowing(mockInteractionTracker).currentAuthentication();
                 will(returnValue(Optional.of(new SingleUserAuthentication())));
 
-                allowing(mockInteractionFactory)
+                allowing(mockInteractionHandler)
                 .runAuthenticated(with(new SingleUserAuthentication()), with(any(ThrowingRunnable.class)));
 
-                allowing(mockInteractionFactory)
+                allowing(mockInteractionHandler)
                 .runAnonymous(with(any(ThrowingRunnable.class)));
 
                 // ignore

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_Authenticate.java
@@ -34,7 +34,7 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.interaction.session.InteractionTracker;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
@@ -63,7 +63,7 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
     private AuthenticationManager authMgr;
     @Mock protected Authenticator mockAuthenticator;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionHandler mockInteractionHandler;
+    @Mock protected InteractionService mockInteractionService;
     @Mock protected InteractionTracker mockInteractionTracker;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
@@ -85,7 +85,7 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
                 will(returnValue(Can.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionHandler));
+                will(returnValue(mockInteractionService));
 
                 allowing(mockCommonContext).getInteractionTracker();
                 will(returnValue(mockInteractionTracker));
@@ -93,10 +93,10 @@ public class AuthenticatedWebSessionForIsis_Authenticate {
                 allowing(mockInteractionTracker).currentAuthentication();
                 will(returnValue(Optional.of(new SingleUserAuthentication())));
 
-                allowing(mockInteractionHandler)
+                allowing(mockInteractionService)
                 .runAuthenticated(with(new SingleUserAuthentication()), with(any(ThrowingRunnable.class)));
 
-                allowing(mockInteractionHandler)
+                allowing(mockInteractionService)
                 .runAnonymous(with(any(ThrowingRunnable.class)));
 
                 // ignore

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
@@ -34,6 +34,7 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;
@@ -58,7 +59,7 @@ public class AuthenticatedWebSessionForIsis_SignIn {
     private AuthenticationManager authMgr;
     @Mock protected Authenticator mockAuthenticator;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionFactory mockInteractionFactory;
+    @Mock protected InteractionHandler mockInteractionHandler;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
     protected AuthenticatedWebSessionForIsis webSession;
@@ -82,12 +83,12 @@ public class AuthenticatedWebSessionForIsis_SignIn {
                 will(returnValue(Can.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionFactory));
+                will(returnValue(mockInteractionHandler));
 
-                allowing(mockInteractionFactory)
+                allowing(mockInteractionHandler)
                 .runAuthenticated(with(new SingleUserAuthentication()), with(any(ThrowingRunnable.class)));
 
-                allowing(mockInteractionFactory)
+                allowing(mockInteractionHandler)
                 .runAnonymous(with(any(ThrowingRunnable.class)));
 
                 // ignore

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
@@ -34,7 +34,7 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
@@ -34,7 +34,6 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;
@@ -59,7 +58,7 @@ public class AuthenticatedWebSessionForIsis_SignIn {
     private AuthenticationManager authMgr;
     @Mock protected Authenticator mockAuthenticator;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionService mockInteractionService;
+    @Mock protected InteractionFactory mockInteractionFactory;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
     protected AuthenticatedWebSessionForIsis webSession;
@@ -83,12 +82,12 @@ public class AuthenticatedWebSessionForIsis_SignIn {
                 will(returnValue(Can.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionService));
+                will(returnValue(mockInteractionFactory));
 
-                allowing(mockInteractionService)
+                allowing(mockInteractionFactory)
                 .runAuthenticated(with(new SingleUserAuthentication()), with(any(ThrowingRunnable.class)));
 
-                allowing(mockInteractionService)
+                allowing(mockInteractionFactory)
                 .runAnonymous(with(any(ThrowingRunnable.class)));
 
                 // ignore

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_SignIn.java
@@ -34,7 +34,7 @@ import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
 import org.apache.isis.core.security.authentication.AuthenticationRequest;
@@ -59,7 +59,7 @@ public class AuthenticatedWebSessionForIsis_SignIn {
     private AuthenticationManager authMgr;
     @Mock protected Authenticator mockAuthenticator;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionHandler mockInteractionHandler;
+    @Mock protected InteractionService mockInteractionService;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
     protected AuthenticatedWebSessionForIsis webSession;
@@ -83,12 +83,12 @@ public class AuthenticatedWebSessionForIsis_SignIn {
                 will(returnValue(Can.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionHandler));
+                will(returnValue(mockInteractionService));
 
-                allowing(mockInteractionHandler)
+                allowing(mockInteractionService)
                 .runAuthenticated(with(new SingleUserAuthentication()), with(any(ThrowingRunnable.class)));
 
-                allowing(mockInteractionHandler)
+                allowing(mockInteractionService)
                 .runAnonymous(with(any(ThrowingRunnable.class)));
 
                 // ignore

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
@@ -31,7 +31,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionHandler;
+import org.apache.isis.core.interaction.session.InteractionService;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2.Mode;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
@@ -46,7 +46,7 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
     @Mock protected Request mockRequest;
     @Mock protected AuthenticationManager mockAuthMgr;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionHandler mockInteractionHandler;
+    @Mock protected InteractionService mockInteractionService;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
     protected AuthenticatedWebSessionForIsis webSession;
@@ -61,9 +61,9 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
                 will(returnValue(Optional.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionHandler));
+                will(returnValue(mockInteractionService));
 
-                allowing(mockInteractionHandler).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
+                allowing(mockInteractionService).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
                 // ignore
 
                 // must provide explicit expectation, since Locale is final.

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
@@ -29,7 +29,7 @@ import org.junit.Rule;
 
 import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
-import org.apache.isis.commons.functional.ThrowingRunnable;
+import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2.Mode;
@@ -39,15 +39,15 @@ import org.apache.isis.core.security.authentication.singleuser.SingleUserAuthent
 
 public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
 
-    @Rule public final JUnitRuleMockery2 context = 
+    @Rule public final JUnitRuleMockery2 context =
             JUnitRuleMockery2.createFor(Mode.INTERFACES_AND_CLASSES);
-    
+
     @Mock protected Request mockRequest;
     @Mock protected AuthenticationManager mockAuthMgr;
     @Mock protected IsisAppCommonContext mockCommonContext;
     @Mock protected InteractionFactory mockIsisInteractionFactory;
     @Mock protected ServiceRegistry mockServiceRegistry;
-    
+
     protected AuthenticatedWebSessionForIsis webSession;
 
     protected void setUp() throws Exception {
@@ -55,16 +55,16 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
             {
                 allowing(mockCommonContext).getServiceRegistry();
                 will(returnValue(mockServiceRegistry));
-                
+
                 allowing(mockServiceRegistry).lookupService(SessionLoggingService.class);
                 will(returnValue(Optional.empty()));
-                
+
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
                 will(returnValue(mockIsisInteractionFactory));
-                
+
                 allowing(mockIsisInteractionFactory).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
                 // ignore
-                
+
                 // must provide explicit expectation, since Locale is final.
                 allowing(mockRequest).getLocale();
                 will(returnValue(Locale.getDefault()));
@@ -79,7 +79,7 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
     protected void setupWebSession() {
         webSession = new AuthenticatedWebSessionForIsis(mockRequest) {
             private static final long serialVersionUID = 1L;
-            
+
             {
                 commonContext = mockCommonContext;
             }
@@ -90,6 +90,6 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
             }
         };
     }
-    
+
 
 }

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
@@ -31,6 +31,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
+import org.apache.isis.core.interaction.session.InteractionHandler;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2.Mode;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
@@ -45,7 +46,7 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
     @Mock protected Request mockRequest;
     @Mock protected AuthenticationManager mockAuthMgr;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionFactory mockIsisInteractionFactory;
+    @Mock protected InteractionHandler mockInteractionHandler;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
     protected AuthenticatedWebSessionForIsis webSession;
@@ -60,9 +61,9 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
                 will(returnValue(Optional.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockIsisInteractionFactory));
+                will(returnValue(mockInteractionHandler));
 
-                allowing(mockIsisInteractionFactory).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
+                allowing(mockInteractionHandler).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
                 // ignore
 
                 // must provide explicit expectation, since Locale is final.

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
@@ -31,7 +31,7 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.core.interaction.session.InteractionService;
+import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2.Mode;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;

--- a/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
+++ b/viewers/wicket/viewer/src/test/java/org/apache/isis/viewer/wicket/viewer/integration/AuthenticatedWebSessionForIsis_TestAbstract.java
@@ -31,7 +31,6 @@ import org.apache.isis.applib.services.registry.ServiceRegistry;
 import org.apache.isis.applib.services.session.SessionLoggingService;
 import org.apache.isis.applib.services.iactnlayer.ThrowingRunnable;
 import org.apache.isis.core.interaction.session.InteractionFactory;
-import org.apache.isis.applib.services.iactnlayer.InteractionService;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.internaltestsupport.jmocking.JUnitRuleMockery2.Mode;
 import org.apache.isis.core.runtime.context.IsisAppCommonContext;
@@ -46,7 +45,7 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
     @Mock protected Request mockRequest;
     @Mock protected AuthenticationManager mockAuthMgr;
     @Mock protected IsisAppCommonContext mockCommonContext;
-    @Mock protected InteractionService mockInteractionService;
+    @Mock protected InteractionFactory mockInteractionFactory;
     @Mock protected ServiceRegistry mockServiceRegistry;
 
     protected AuthenticatedWebSessionForIsis webSession;
@@ -61,9 +60,9 @@ public abstract class AuthenticatedWebSessionForIsis_TestAbstract {
                 will(returnValue(Optional.empty()));
 
                 allowing(mockCommonContext).lookupServiceElseFail(InteractionFactory.class);
-                will(returnValue(mockInteractionService));
+                will(returnValue(mockInteractionFactory));
 
-                allowing(mockInteractionService).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
+                allowing(mockInteractionFactory).runAuthenticated(new SingleUserAuthentication(), with(any(ThrowingRunnable.class)));
                 // ignore
 
                 // must provide explicit expectation, since Locale is final.


### PR DESCRIPTION
This includes bringing in InteractionLayer (renamed from AuthenticationLayer) to the applib as well.  And ThrowingRunnable has gone from commons to applib.

This new interface is implemented by InteractionFactoryDefault.  The main difference is that whereas we used to require an Authentication (even an anonymous one) in order to create a new interaction layer, we can now do this with just InteractionContext (the new name for ExecutionContext as was).  We allow an Authentiation to not get lost by having InteractionContext hold onto an arbitrary map of attributes.