### PR TITLE
ISIS-2785: filters out inherited ObjectNamedFacet ...

### DIFF
--- a/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/all/i18n/SynthesizeObjectNamingPostProcessor.java
+++ b/core/metamodel/src/main/java/org/apache/isis/core/metamodel/postprocessors/all/i18n/SynthesizeObjectNamingPostProcessor.java
@@ -58,6 +58,7 @@ extends ObjectSpecificationPostProcessorAbstract {
 
         val topRank = objectSpecification
         .lookupFacet(ObjectNamedFacet.class)
+        .filter(x -> x.getFacetHolder() == objectSpecification) // insist is for this objectSpec (not a superclass')
         .flatMap(Facet::getSharedFacetRanking)
         .map(facetRanking->facetRanking.getTopRank(ObjectNamedFacet.class))
         .orElse(Can.empty())


### PR DESCRIPTION
... when insatlling an ObjectNamedFacetSynthesized.  Otherwise we see that the name comes (or can come from) the superclass' ObjectNamedFacets