### PR TITLE
ISIS-2826: Lightweight JPA Property Change Publishing

### DIFF
--- a/api/applib/src/main/java/org/apache/isis/applib/Identifier.java
+++ b/api/applib/src/main/java/org/apache/isis/applib/Identifier.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.isis.applib.id.HasLogicalType;
 import org.apache.isis.applib.id.LogicalType;
+import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.applib.services.i18n.HasTranslationContext;
 import org.apache.isis.applib.services.i18n.TranslationContext;
 import org.apache.isis.applib.services.i18n.TranslationService;
@@ -154,6 +155,11 @@ implements
                 + memberNameAndParameterClassNamesIdentityString;
     }
 
+    public boolean matchesCommand(final @NonNull Command command) {
+        return (getLogicalTypeName() + "#" + memberLogicalName)
+                .equals(command.getLogicalMemberIdentifier());
+    }
+
     // -- NATURAL NAMES
 
     public String getClassNaturalName() {
@@ -263,6 +269,7 @@ implements
     private static Can<String> naturalNames(final Can<String> names) {
         return names.map(Identifier::naturalName);
     }
+
 
 }
 

--- a/commons/src/main/java/org/apache/isis/commons/collections/Can.java
+++ b/commons/src/main/java/org/apache/isis/commons/collections/Can.java
@@ -161,7 +161,7 @@ extends Iterable<T>, Comparable<Can<T>>, Serializable {
      * @return whether this Can contains given {@code element}, that is, at least one contained element
      * passes the {@link Objects#equals(Object, Object)} test with respect to the given element.
      */
-    boolean contains(T element);
+    boolean contains(@Nullable T element);
 
     // -- FACTORIES
 
@@ -490,21 +490,21 @@ extends Iterable<T>, Comparable<Can<T>>, Serializable {
 
     // -- MANIPULATION
 
-    Can<T> add(T element);
+    Can<T> add(@Nullable T element);
 
     /**
      * Adds the specified element to the list if it is not already present.
      * @param element
      * @return same or new instance
      */
-    default Can<T> addUnique(@NonNull final T element) {
+    default Can<T> addUnique(final @Nullable T element) {
         if(contains(element)) {
             return this;
         }
         return add(element);
     }
 
-    Can<T> addAll(Can<T> other);
+    Can<T> addAll(@Nullable Can<T> other);
 
     /**
      * Inserts the specified element at the specified position in this list
@@ -523,9 +523,9 @@ extends Iterable<T>, Comparable<Can<T>>, Serializable {
      * @throws IndexOutOfBoundsException if the index is out of range
      *         (<tt>index &lt; 0 || index &gt; size()</tt>)
      */
-    Can<T> add(int index, T element);
+    Can<T> add(int index, @Nullable T element);
 
-    Can<T> replace(int index, T element);
+    Can<T> replace(int index, @Nullable T element);
 
     /**
      * Removes the element at the specified position in this list (optional
@@ -540,7 +540,7 @@ extends Iterable<T>, Comparable<Can<T>>, Serializable {
      */
     Can<T> remove(int index);
 
-    Can<T> remove(T element);
+    Can<T> remove(@Nullable T element);
 
     /**
      * Given <i>n</i> indices, returns an equivalent of
@@ -572,11 +572,8 @@ extends Iterable<T>, Comparable<Can<T>>, Serializable {
      * @throws ClassCastException if the type of the specified element
      *         is incompatible with this list
      *         (<a href="Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified element is null and this
-     *         list does not permit null elements
-     *         (<a href="Collection.html#optional-restrictions">optional</a>)
      */
-    int indexOf(T element);
+    int indexOf(@Nullable T element);
 
     // -- EQUALITY
 

--- a/commons/src/main/java/org/apache/isis/commons/collections/Can_Empty.java
+++ b/commons/src/main/java/org/apache/isis/commons/collections/Can_Empty.java
@@ -86,7 +86,7 @@ final class Can_Empty<T> implements Can<T> {
     }
 
     @Override
-    public boolean contains(final T element) {
+    public boolean contains(final @Nullable T element) {
         return false;
     }
 
@@ -120,7 +120,7 @@ final class Can_Empty<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> filter(@Nullable final Predicate<? super T> predicate) {
+    public Can<T> filter(final @Nullable Predicate<? super T> predicate) {
         return this; // identity
     }
 
@@ -135,31 +135,35 @@ final class Can_Empty<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> add(@NonNull final T element) {
-        return Can.ofSingleton(element);
+    public Can<T> add(final @Nullable T element) {
+        return element != null
+                ? Can.ofSingleton(element)
+                : this;
     }
 
     @Override
-    public Can<T> addUnique(@NonNull final T element) {
-        return Can.ofSingleton(element);
+    public Can<T> addUnique(final @Nullable T element) {
+        return add(element);
     }
 
     @Override
-    public Can<T> addAll(@NonNull final Can<T> other) {
-        return other;
+    public Can<T> addAll(final @Nullable Can<T> other) {
+        return other != null
+                ? other
+                : this;
     }
 
     @Override
-    public Can<T> add(final int index, @NonNull final T element) {
+    public Can<T> add(final int index, final @Nullable T element) {
         if(index!=0) {
             throw new IndexOutOfBoundsException(
                     "cannot add to empty can with index other than 0; got " + index);
         }
-        return Can.ofSingleton(element);
+        return add(element);
     }
 
     @Override
-    public Can<T> replace(final int index, final T element) {
+    public Can<T> replace(final int index, final @Nullable T element) {
         throw _Exceptions.unsupportedOperation("cannot replace an element in an empty Can");
     }
 
@@ -169,7 +173,7 @@ final class Can_Empty<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> remove(final T element) {
+    public Can<T> remove(final @Nullable T element) {
         return this; // on an empty can this is a no-op
     }
 
@@ -179,7 +183,7 @@ final class Can_Empty<T> implements Can<T> {
     }
 
     @Override
-    public int indexOf(final T element) {
+    public int indexOf(final @Nullable T element) {
         return -1;
     }
 

--- a/commons/src/main/java/org/apache/isis/commons/collections/Can_Multiple.java
+++ b/commons/src/main/java/org/apache/isis/commons/collections/Can_Multiple.java
@@ -89,9 +89,9 @@ final class Can_Multiple<T> implements Can<T> {
     }
 
     @Override
-    public boolean contains(final T element) {
+    public boolean contains(final @Nullable T element) {
         if(element==null) {
-            return false; // an optimization: Can's dont't contain null
+            return false; // Can's dont't contain null
         }
         return elements.contains(element);
     }
@@ -183,14 +183,16 @@ final class Can_Multiple<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> add(@NonNull final T element) {
-        val elementStream = Stream.concat(elements.stream(), Stream.of(element)); // append
-        return Can.ofStream(elementStream);
+    public Can<T> add(final @Nullable T element) {
+        return element!=null
+                ? Can.ofStream(Stream.concat(elements.stream(), Stream.of(element))) // append
+                : this;
     }
 
     @Override
-    public Can<T> addAll(@NonNull final Can<T> other) {
-        if(other.isEmpty()) {
+    public Can<T> addAll(final @Nullable Can<T> other) {
+        if(other==null
+                || other.isEmpty()) {
             return this;
         }
         val newElements = new ArrayList<T>(this.size() + other.size());
@@ -200,14 +202,20 @@ final class Can_Multiple<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> add(final int index, @NonNull final T element) {
+    public Can<T> add(final int index, final @Nullable T element) {
+        if(element==null) {
+            return this; // identity
+        }
         val newElements = new ArrayList<T>(elements);
         newElements.add(index, element);
         return Can.ofCollection(newElements);
     }
 
     @Override
-    public Can<T> replace(final int index, final T element) {
+    public Can<T> replace(final int index, final @Nullable T element) {
+        if(element==null) {
+            return remove(index);
+        }
         val newElements = new ArrayList<T>(elements);
         newElements.set(index, element);
         return Can.ofCollection(newElements);
@@ -221,7 +229,10 @@ final class Can_Multiple<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> remove(final T element) {
+    public Can<T> remove(final @Nullable T element) {
+        if(element==null) {
+            return this; // identity
+        }
         val newElements = new ArrayList<T>(elements);
         newElements.remove(element);
         return Can.ofCollection(newElements);
@@ -245,7 +256,7 @@ final class Can_Multiple<T> implements Can<T> {
     }
 
     @Override
-    public int indexOf(@NonNull final T element) {
+    public int indexOf(final @Nullable T element) {
         return this.elements.indexOf(element);
     }
 

--- a/commons/src/main/java/org/apache/isis/commons/collections/Can_Singleton.java
+++ b/commons/src/main/java/org/apache/isis/commons/collections/Can_Singleton.java
@@ -92,7 +92,7 @@ final class Can_Singleton<T> implements Can<T> {
     }
 
     @Override
-    public boolean contains(final T element) {
+    public boolean contains(final @Nullable T element) {
         return Objects.equals(this.element, element);
     }
 
@@ -142,13 +142,16 @@ final class Can_Singleton<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> add(@NonNull final T element) {
-        return Can.ofStream(Stream.of(this.element, element)); // append
+    public Can<T> add(final @Nullable T element) {
+        return element!=null
+                ? Can.ofStream(Stream.of(this.element, element)) // append
+                : this;
     }
 
     @Override
-    public Can<T> addAll(@NonNull final Can<T> other) {
-        if(other.isEmpty()) {
+    public Can<T> addAll(final @Nullable Can<T> other) {
+        if(other==null
+                || other.isEmpty()) {
             return this;
         }
         if(other.isCardinalityOne()) {
@@ -161,7 +164,10 @@ final class Can_Singleton<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> add(final int index, @NonNull final T element) {
+    public Can<T> add(final int index, final @Nullable T element) {
+        if(element==null) {
+            return this; // no-op
+        }
         if(index==0) {
             return Can.ofStream(Stream.of(element, this.element)); // insert before
         }
@@ -173,12 +179,14 @@ final class Can_Singleton<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> replace(final int index, final T element) {
-        if(index==0) {
-            return Can.ofSingleton(element);
-        }
-        throw new IndexOutOfBoundsException(
+    public Can<T> replace(final int index, final @Nullable T element) {
+        if(index!=0) {
+            throw new IndexOutOfBoundsException(
                 "cannot replace on singleton with index other than 0; got " + index);
+        }
+        return element!=null
+                ? Can.ofSingleton(element)
+                : Can.empty();
     }
 
     @Override
@@ -191,7 +199,7 @@ final class Can_Singleton<T> implements Can<T> {
     }
 
     @Override
-    public Can<T> remove(final T element) {
+    public Can<T> remove(final @Nullable T element) {
         if(this.element.equals(element)) {
             return Can.empty();
         }
@@ -224,7 +232,7 @@ final class Can_Singleton<T> implements Can<T> {
     }
 
     @Override
-    public int indexOf(@NonNull final T element) {
+    public int indexOf(final @Nullable T element) {
         return this.element.equals(element) ? 0 : -1;
     }
 

--- a/commons/src/main/java/org/apache/isis/commons/internal/base/_With.java
+++ b/commons/src/main/java/org/apache/isis/commons/internal/base/_With.java
@@ -215,7 +215,8 @@ public final class _With<T> {
      * @param paramName to use for the exception message, when the non-null-check fails
      * @return {@code obj!=null ? obj : throw NullPointerException}
      * @throws NullPointerException if {@code obj} is {@code null}
-     * @deprecated use {@code @lombok.NonNull} on the parameter instead
+     * @deprecated instead use {@code @lombok.NonNull} on parameters
+     * or {@link java.util.Objects#requireNonNull(Object, String)} on fields
      */
     @Deprecated
     public static <T> T requires(@Nullable final T obj, final String paramName) {

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/executor/MemberExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/executor/MemberExecutorServiceDefault.java
@@ -33,7 +33,6 @@ import org.springframework.stereotype.Service;
 import org.apache.isis.applib.annotation.PriorityPrecedence;
 import org.apache.isis.applib.services.clock.ClockService;
 import org.apache.isis.applib.services.command.Command;
-import org.apache.isis.applib.services.command.Command.CommandPublishingPhase;
 import org.apache.isis.applib.services.iactn.ActionInvocation;
 import org.apache.isis.applib.services.iactn.Execution;
 import org.apache.isis.applib.services.iactn.PropertyEdit;
@@ -113,8 +112,7 @@ implements MemberExecutorService {
         val interaction = getInteractionElseFail();
         val command = interaction.getCommand();
 
-        CommandPublishingFacet.ifPublishingEnabledForCommand(
-                command, owningAction, facetHolder, ()->command.updater().setPublishingPhase(CommandPublishingPhase.READY));
+        CommandPublishingFacet.prepareCommandForPublishing(command, owningAction, facetHolder);
 
         val xrayHandle = _Xray.enterActionInvocation(interactionLayerTracker, interaction, owningAction, head, argumentAdapters);
 
@@ -191,8 +189,7 @@ implements MemberExecutorService {
             return head.getTarget();
         }
 
-        CommandPublishingFacet.ifPublishingEnabledForCommand(
-                command, owningProperty, facetHolder, ()->command.updater().setPublishingPhase(CommandPublishingPhase.READY));
+        CommandPublishingFacet.prepareCommandForPublishing(command, owningProperty, facetHolder);
 
         val xrayHandle = _Xray.enterPropertyEdit(interactionLayerTracker, interaction, owningProperty, head, newValueAdapter);
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/executor/MemberExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/executor/MemberExecutorServiceDefault.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 import org.apache.isis.applib.annotation.PriorityPrecedence;
 import org.apache.isis.applib.services.clock.ClockService;
 import org.apache.isis.applib.services.command.Command;
+import org.apache.isis.applib.services.command.Command.CommandPublishingPhase;
 import org.apache.isis.applib.services.iactn.ActionInvocation;
 import org.apache.isis.applib.services.iactn.Execution;
 import org.apache.isis.applib.services.iactn.PropertyEdit;
@@ -113,7 +114,7 @@ implements MemberExecutorService {
         val command = interaction.getCommand();
 
         CommandPublishingFacet.ifPublishingEnabledForCommand(
-                command, owningAction, facetHolder, ()->command.updater().setPublishingEnabled(true));
+                command, owningAction, facetHolder, ()->command.updater().setPublishingPhase(CommandPublishingPhase.READY));
 
         val xrayHandle = _Xray.enterActionInvocation(interactionLayerTracker, interaction, owningAction, head, argumentAdapters);
 
@@ -191,7 +192,7 @@ implements MemberExecutorService {
         }
 
         CommandPublishingFacet.ifPublishingEnabledForCommand(
-                command, owningProperty, facetHolder, ()->command.updater().setPublishingEnabled(true));
+                command, owningProperty, facetHolder, ()->command.updater().setPublishingPhase(CommandPublishingPhase.READY));
 
         val xrayHandle = _Xray.enterPropertyEdit(interactionLayerTracker, interaction, owningProperty, head, newValueAdapter);
 

--- a/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/isis/core/runtimeservices/session/InteractionServiceDefault.java
@@ -28,6 +28,8 @@ import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import static java.util.Objects.requireNonNull;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.Priority;
 import javax.inject.Inject;
@@ -69,12 +71,10 @@ import org.apache.isis.core.runtime.events.MetamodelEventService;
 import org.apache.isis.core.security.authentication.InteractionContextFactory;
 import org.apache.isis.core.security.authentication.manager.AuthenticationManager;
 
-import static org.apache.isis.commons.internal.base._With.requires;
-
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import lombok.extern.log4j.Log4j2;
 import lombok.val;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Is the factory of {@link Interaction}s.
@@ -116,7 +116,7 @@ implements
     @EventListener
     public void init(final ContextRefreshedEvent event) {
 
-        requires(authenticationManager, "authenticationManager");
+        requireNonNull(authenticationManager, "authenticationManager");
 
         log.info("Initialising Isis System");
         log.info("working directory: {}", new File(".").getAbsolutePath());

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/IsisModuleCoreTransaction.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/IsisModuleCoreTransaction.java
@@ -21,14 +21,13 @@ package org.apache.isis.core.transaction;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import org.apache.isis.core.transaction.changetracking.EntityChangeTrackerDefault;
 import org.apache.isis.core.transaction.changetracking.events.TimestampService;
 
 @Configuration
 @Import({
         // @Service's
         TimestampService.class,
-        EntityChangeTrackerDefault.class,
+
 })
 public class IsisModuleCoreTransaction {
 

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PersistenceCallbackHandlerAbstract.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PersistenceCallbackHandlerAbstract.java
@@ -1,0 +1,61 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.isis.core.transaction.changetracking;
+
+import org.apache.isis.applib.events.lifecycle.AbstractLifecycleEvent;
+import org.apache.isis.applib.services.eventbus.EventBusService;
+import org.apache.isis.commons.internal.factory._InstanceUtil;
+import org.apache.isis.core.metamodel.facets.object.callbacks.LifecycleEventFacet;
+import org.apache.isis.core.metamodel.spec.ManagedObject;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class PersistenceCallbackHandlerAbstract {
+
+    protected final EventBusService eventBusService;
+
+    //  -- HELPER
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    protected void postLifecycleEventIfRequired(
+            final ManagedObject adapter,
+            final Class<? extends LifecycleEventFacet> lifecycleEventFacetClass) {
+
+        val lifecycleEventFacet = adapter.getSpecification().getFacet(lifecycleEventFacetClass);
+        if(lifecycleEventFacet == null) {
+            return;
+        }
+        val eventInstance = (AbstractLifecycleEvent) _InstanceUtil
+                .createInstance(lifecycleEventFacet.getEventType());
+        val pojo = adapter.getPojo();
+        postEvent(eventInstance, pojo);
+
+    }
+
+    protected void postEvent(final AbstractLifecycleEvent<Object> event, final Object pojo) {
+        if(eventBusService!=null) {
+            event.initSource(pojo);
+            eventBusService.post(event);
+        }
+    }
+
+}

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PreAndPostValue.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PreAndPostValue.java
@@ -24,7 +24,7 @@ import org.apache.isis.core.transaction.changetracking.events.IsisTransactionPla
 
 import lombok.Getter;
 
-final class _PreAndPostValue {
+public final class PreAndPostValue {
 
     /**
      * The object that was referenced before this object was changed.
@@ -44,26 +44,26 @@ final class _PreAndPostValue {
     @Getter private final Object post;
     @Getter private final String postString;
 
-    public static _PreAndPostValue pre(final Object preValue) {
-        return new _PreAndPostValue(preValue);
+    public static PreAndPostValue pre(final Object preValue) {
+        return new PreAndPostValue(preValue);
     }
 
-    private _PreAndPostValue(final Object pre) {
+    private PreAndPostValue(final Object pre) {
         this.pre = pre;
         this.preString = asString(pre);
         this.post = null;
         this.postString = null;
     }
 
-    private _PreAndPostValue(final _PreAndPostValue pre, final Object post) {
+    private PreAndPostValue(final PreAndPostValue pre, final Object post) {
         this.pre = pre.getPre();
         this.preString = pre.getPreString();
         this.post = post;
         this.postString = asString(post);
     }
 
-    public _PreAndPostValue withPost(final Object post) {
-        return new _PreAndPostValue(this, post);
+    public PreAndPostValue withPost(final Object post) {
+        return new PreAndPostValue(this, post);
     }
 
     @Override
@@ -88,7 +88,7 @@ final class _PreAndPostValue {
 
     // -- HELPER
 
-    private static String asString(Object object) {
+    private static String asString(final Object object) {
         return object != null
                 ? object.toString()
                 : null;

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangePublisher.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangePublisher.java
@@ -18,26 +18,38 @@
  */
 package org.apache.isis.core.transaction.changetracking;
 
+import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
 
 /**
- * @since 2 {@index}
+ * Responsible for collecting then immediately publishing changes to domain objects
+ * within a transaction, that is, notify publishing subscribers and call the various
+ * persistence call-back facets.
+ *
+ * @since 2.0 {index}
+ * @apiNote Introduced for JPA (EclipseLink implementation). More lightweight than
+ * {@link EntityChangeTracker}
  */
-public interface EntityChangeTrackerWithPreValue extends EntityChangeTracker {
+public interface PropertyChangePublisher {
 
     /**
-     * An override of {@link EntityChangeTracker#enlistUpdating(ManagedObject)}
+     * TODO update ... An override of {@link EntityChangeTracker#enlistUpdating(ManagedObject)}
      * where the caller already knows the old value (and so the
      * {@link EntityChangeTracker} does not need to capture the old value itself.
      *
-     * <p>
-     *     Introduced for JPA (EclipseLink implementation).
-     * </p>
-     *
      * @param entity - being enlisted
-     * @param propertyIdIfAny - the entity property id (its simple name); if non-null, indicates that the pre value is known
-     * @param preValue - the pre-value (could be null); only relevant if propertyNameIfAny is provided (non-null).
+     * @param preValue - the pre-value (could be null)
      */
-    void enlistUpdating(ManagedObject entity, String propertyIdIfAny, Object preValue);
-}
+    void onPreUpdate(ManagedObject entity, Can<PropertyChangeRecord> changeRecords);
 
+    void onPrePersist(ManagedObject entity);
+
+    void onPreRemove(ManagedObject entity);
+
+    void onPostPersist(ManagedObject entity);
+
+    void onPostUpdate(ManagedObject entity);
+
+    void onPostRemove(ManagedObject entity);
+
+}

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangeRecord.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangeRecord.java
@@ -32,47 +32,59 @@ import lombok.NonNull;
 import lombok.ToString;
 import lombok.val;
 
-
 @EqualsAndHashCode(of = {"bookmarkStr", "propertyId"})
 @ToString(of = {"bookmarkStr", "propertyId"})
-final class _PropertyChangeRecord {
+public final class PropertyChangeRecord {
 
     @Getter private final ManagedObject entity;
     @Getter private final ObjectAssociation property;
     @Getter private final Bookmark bookmark;
     @Getter private final String propertyId;
-    @Getter private _PreAndPostValue preAndPostValue;
+    @Getter private PreAndPostValue preAndPostValue;
 
     private final String bookmarkStr;
 
-    public static _PropertyChangeRecord of(
+    public static PropertyChangeRecord of(
             final @NonNull ManagedObject entity,
             final @NonNull ObjectAssociation property) {
-        return new _PropertyChangeRecord(entity, property);
+        return new PropertyChangeRecord(entity, property, null);
     }
 
-    private _PropertyChangeRecord(final ManagedObject entity, final ObjectAssociation property) {
+    public static PropertyChangeRecord of(
+            final @NonNull ManagedObject entity,
+            final @NonNull ObjectAssociation property,
+            final @NonNull PreAndPostValue preAndPostValue) {
+        return new PropertyChangeRecord(entity, property, preAndPostValue);
+    }
+
+    private PropertyChangeRecord(
+            final ManagedObject entity,
+            final ObjectAssociation property,
+            final PreAndPostValue preAndPostValue) {
         this.entity = entity;
         this.property = property;
         this.propertyId = property.getId();
 
         this.bookmark = ManagedObjects.bookmarkElseFail(entity);
         this.bookmarkStr = bookmark.toString();
+
+        this.preAndPostValue = preAndPostValue;
     }
 
     public String getMemberId() {
         return property.getFeatureIdentifier().getFullIdentityString();
     }
 
-    void setPreValue(final Object pre) {
-        preAndPostValue = _PreAndPostValue.pre(pre);
+    public void setPreValue(final Object pre) {
+        preAndPostValue = PreAndPostValue.pre(pre);
     }
 
-    void updatePreValue() {
+    public void updatePreValue() {
         setPreValue(getPropertyValue());
     }
 
-    void updatePostValue(/*final boolean isEntityDeleted*/) {
+    @Deprecated // unreliable logic, instead the caller should know if this originates from a delete event
+    public void updatePostValue() {
         preAndPostValue = EntityUtil.isDetachedOrRemoved(entity) //TODO[ISIS-2573] when detached, logic is wrong
                 ? preAndPostValue.withPost(IsisTransactionPlaceholder.DELETED)
                 : preAndPostValue.withPost(getPropertyValue());

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangeTracker.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangeTracker.java
@@ -38,7 +38,7 @@ import lombok.NonNull;
  * @apiNote Introduced for JPA (EclipseLink implementation). More lightweight than
  * {@link EntityChangeTracker}
  */
-public interface PropertyChangePublisher {
+public interface PropertyChangeTracker {
 
     void onPreUpdate(ManagedObject entity, Can<PropertyChangeRecord> changeRecords);
 

--- a/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangeTracker.java
+++ b/core/transaction/src/main/java/org/apache/isis/core/transaction/changetracking/PropertyChangeTracker.java
@@ -77,7 +77,7 @@ public interface PropertyChangeTracker {
                             property,
                             PreAndPostValue
                                 .pre(IsisTransactionPlaceholder.NEW)
-                                .withPost(property.get(entity)))
+                                .withPost(property.get(entity).getPojo()))
                     .toEntityPropertyChange(
                             timestamp,
                             user,
@@ -113,7 +113,7 @@ public interface PropertyChangeTracker {
                             entity,
                             property,
                             PreAndPostValue
-                                .pre(property.get(entity))
+                                .pre(property.get(entity).getPojo())
                                 .withPost(IsisTransactionPlaceholder.DELETED))
                     .toEntityPropertyChange(
                             timestamp,

--- a/core/transaction/src/test/java/org/apache/isis/core/transaction/changetracking/PreAndPostValues_shouldAudit_Test.java
+++ b/core/transaction/src/test/java/org/apache/isis/core/transaction/changetracking/PreAndPostValues_shouldAudit_Test.java
@@ -32,35 +32,35 @@ public class PreAndPostValues_shouldAudit_Test {
 
     @Test
     public void just_created() {
-        val preAndPostValue = _PreAndPostValue.pre(IsisTransactionPlaceholder.NEW)
+        val preAndPostValue = PreAndPostValue.pre(IsisTransactionPlaceholder.NEW)
                 .withPost("Foo");
 
         assertTrue(preAndPostValue.shouldPublish());
     }
     @Test
     public void just_deleted() {
-        val preAndPostValue = _PreAndPostValue.pre("Foo")
+        val preAndPostValue = PreAndPostValue.pre("Foo")
                 .withPost(IsisTransactionPlaceholder.DELETED);
 
         assertTrue(preAndPostValue.shouldPublish());
     }
     @Test
     public void changed() {
-        val preAndPostValue = _PreAndPostValue.pre("Foo")
+        val preAndPostValue = PreAndPostValue.pre("Foo")
                 .withPost("Bar");
 
         assertTrue(preAndPostValue.shouldPublish());
     }
     @Test
     public void unchanged() {
-        val preAndPostValue = _PreAndPostValue.pre("Foo")
+        val preAndPostValue = PreAndPostValue.pre("Foo")
                 .withPost("Foo");
 
         assertFalse(preAndPostValue.shouldPublish());
     }
     @Test
     public void created_and_then_deleted() {
-        val preAndPostValue = _PreAndPostValue.pre(IsisTransactionPlaceholder.NEW)
+        val preAndPostValue = PreAndPostValue.pre(IsisTransactionPlaceholder.NEW)
                 .withPost(IsisTransactionPlaceholder.DELETED);
 
         assertFalse(preAndPostValue.shouldPublish());

--- a/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/IsisModuleJdoIntegration.java
+++ b/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/IsisModuleJdoIntegration.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Import;
 
 import org.apache.isis.core.runtime.IsisModuleCoreRuntime;
 import org.apache.isis.persistence.jdo.applib.IsisModulePersistenceJdoApplib;
+import org.apache.isis.persistence.jdo.integration.changetracking.EntityChangeTrackerJdo;
 import org.apache.isis.persistence.jdo.metamodel.IsisModuleJdoMetamodel;
 
 @Configuration
@@ -32,9 +33,9 @@ import org.apache.isis.persistence.jdo.metamodel.IsisModuleJdoMetamodel;
         IsisModulePersistenceJdoApplib.class,
         IsisModuleJdoMetamodel.class,
 
+        // services
+        EntityChangeTrackerJdo.class,
 })
 public class IsisModuleJdoIntegration {
-
-
 
 }

--- a/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_ChangingEntitiesFactory.java
+++ b/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_ChangingEntitiesFactory.java
@@ -16,7 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.core.transaction.changetracking;
+package org.apache.isis.persistence.jdo.integration.changetracking;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +40,7 @@ final class _ChangingEntitiesFactory {
     public static Optional<EntityChanges> createChangingEntities(
             final java.sql.Timestamp completedAt,
             final String userName,
-            final EntityChangeTrackerDefault entityChangeTracker) {
+            final EntityChangeTrackerJdo entityChangeTracker) {
 
         if(entityChangeTracker.getChangeKindByEnlistedAdapter().isEmpty()) {
             return Optional.empty();

--- a/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_EntityPropertyChangeFactory.java
+++ b/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_EntityPropertyChangeFactory.java
@@ -16,7 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.core.transaction.changetracking;
+package org.apache.isis.persistence.jdo.integration.changetracking;
 
 import java.util.UUID;
 
@@ -24,6 +24,7 @@ import org.apache.isis.applib.services.bookmark.Bookmark;
 import org.apache.isis.applib.services.publishing.spi.EntityPropertyChange;
 import org.apache.isis.applib.services.xactn.TransactionId;
 import org.apache.isis.core.metamodel.facets.actions.action.invocation.CommandUtil;
+import org.apache.isis.core.transaction.changetracking.PropertyChangeRecord;
 
 import lombok.val;
 
@@ -33,7 +34,7 @@ final class _EntityPropertyChangeFactory {
             final java.sql.Timestamp timestamp,
             final String user,
             final TransactionId txId,
-            final _PropertyChangeRecord propertyChangeRecord) {
+            final PropertyChangeRecord propertyChangeRecord) {
 
         val spec = propertyChangeRecord.getEntity().getSpecification();
 

--- a/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_SimpleChangingEntities.java
+++ b/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_SimpleChangingEntities.java
@@ -17,7 +17,7 @@
  *  under the License.
  */
 
-package org.apache.isis.core.transaction.changetracking;
+package org.apache.isis.persistence.jdo.integration.changetracking;
 
 import java.sql.Timestamp;
 import java.util.UUID;

--- a/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_Xray.java
+++ b/persistence/jdo/integration/src/main/java/org/apache/isis/persistence/jdo/integration/changetracking/_Xray.java
@@ -16,7 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.isis.core.transaction.changetracking;
+package org.apache.isis.persistence.jdo.integration.changetracking;
 
 import java.awt.Color;
 
@@ -33,7 +33,7 @@ import lombok.val;
 final class _Xray {
 
     public static void publish(
-            final EntityChangeTrackerDefault entityChangeTrackerDefault,
+            final EntityChangeTrackerJdo entityChangeTrackerDefault,
             final Provider<InteractionProvider> interactionProviderProvider) {
 
         if(!XrayUi.isXrayEnabled()) {

--- a/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
+++ b/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
@@ -91,21 +91,18 @@ public class IsisEntityListener {
             .map(DirectToFieldChangeRecord.class::cast)
             .map(changeRecord -> {
                 val propertyName = changeRecord.getAttribute();
-                val property = entity.getSpecification().getProperty(propertyName)
+                return entity
+                        .getSpecification()
+                        .getProperty(propertyName)
                         .filter(property->!property.isMixedIn())
                         .filter(property->!property.isNotPersisted())
-                        .orElse(null);
-
-                if(property==null) {
-                    return null; // ignore
-                }
-
-                return PropertyChangeRecord.of(
-                        entity,
-                        property,
-                        PreAndPostValue
-                            .pre(changeRecord.getOldValue())
-                            .withPost(changeRecord.getNewValue()));
+                        .map(property->PropertyChangeRecord.of(
+                                entity,
+                                property,
+                                PreAndPostValue
+                                    .pre(changeRecord.getOldValue())
+                                    .withPost(changeRecord.getNewValue())))
+                        .orElse(null); // ignore
             })
             .collect(Can.toCan()); // a Can<T> only collects non-null elements
 

--- a/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
+++ b/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
@@ -36,8 +36,8 @@ import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
 import org.apache.isis.core.transaction.changetracking.EntityChangeTracker;
 import org.apache.isis.core.transaction.changetracking.PreAndPostValue;
-import org.apache.isis.core.transaction.changetracking.PropertyChangePublisher;
 import org.apache.isis.core.transaction.changetracking.PropertyChangeRecord;
+import org.apache.isis.core.transaction.changetracking.PropertyChangeTracker;
 import org.apache.isis.persistence.jpa.applib.services.JpaSupportService;
 
 import lombok.val;
@@ -63,7 +63,7 @@ public class IsisEntityListener {
 
     // not managed by Spring (directly)
     @Inject private ServiceInjector serviceInjector;
-    @Inject private PropertyChangePublisher propertyChangePublisher;
+    @Inject private PropertyChangeTracker propertyChangePublisher;
     @Inject private Provider<JpaSupportService> jpaSupportServiceProvider;
     @Inject private ObjectManager objectManager;
 
@@ -83,6 +83,9 @@ public class IsisEntityListener {
             val unwrap = em.unwrap(UnitOfWork.class);
             val changes = unwrap.getCurrentChanges();
             val objectChanges = changes.getObjectChangeSetForClone(entityPojo);
+            if(objectChanges==null) {
+                return;
+            }
 
             final Can<PropertyChangeRecord> propertyChangeRecords =
             objectChanges
@@ -139,6 +142,5 @@ public class IsisEntityListener {
         log.debug("onPostLoad: {}", entityPojo);
         serviceInjector.injectServicesInto(entityPojo);
     }
-
 
 }

--- a/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
+++ b/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
@@ -84,7 +84,8 @@ public class IsisEntityListener {
             val changes = unwrap.getCurrentChanges();
             val objectChanges = changes.getObjectChangeSetForClone(entityPojo);
 
-            final Can<PropertyChangeRecord> payload = objectChanges
+            final Can<PropertyChangeRecord> propertyChangeRecords =
+            objectChanges
             .getChanges()
             .stream()
             .filter(DirectToFieldChangeRecord.class::isInstance)
@@ -106,7 +107,7 @@ public class IsisEntityListener {
             })
             .collect(Can.toCan()); // a Can<T> only collects non-null elements
 
-            propertyChangePublisher.onPreUpdate(entity, payload);
+            propertyChangePublisher.onPreUpdate(entity, propertyChangeRecords);
 
         });
     }
@@ -137,8 +138,6 @@ public class IsisEntityListener {
     @PostLoad void onPostLoad(final Object entityPojo) {
         log.debug("onPostLoad: {}", entityPojo);
         serviceInjector.injectServicesInto(entityPojo);
-        val entity = objectManager.adapt(entityPojo);
-        propertyChangePublisher.onPostRemove(entity);
     }
 
 

--- a/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
+++ b/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/IsisEntityListener.java
@@ -29,15 +29,19 @@ import javax.persistence.PreRemove;
 import javax.persistence.PreUpdate;
 
 import org.eclipse.persistence.sessions.UnitOfWork;
+import org.eclipse.persistence.sessions.changesets.DirectToFieldChangeRecord;
 
 import org.apache.isis.applib.services.inject.ServiceInjector;
+import org.apache.isis.commons.collections.Can;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
 import org.apache.isis.core.transaction.changetracking.EntityChangeTracker;
-import org.apache.isis.core.transaction.changetracking.EntityChangeTrackerWithPreValue;
+import org.apache.isis.core.transaction.changetracking.PreAndPostValue;
+import org.apache.isis.core.transaction.changetracking.PropertyChangePublisher;
+import org.apache.isis.core.transaction.changetracking.PropertyChangeRecord;
 import org.apache.isis.persistence.jpa.applib.services.JpaSupportService;
 
-import lombok.extern.log4j.Log4j2;
 import lombok.val;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * EntityListener class for listing with the {@link javax.persistence.EntityListeners} annotation, to
@@ -59,70 +63,86 @@ public class IsisEntityListener {
 
     // not managed by Spring (directly)
     @Inject private ServiceInjector serviceInjector;
-    @Inject private Provider<EntityChangeTrackerWithPreValue> entityChangeTrackerProvider;
+    @Inject private PropertyChangePublisher propertyChangePublisher;
     @Inject private Provider<JpaSupportService> jpaSupportServiceProvider;
     @Inject private ObjectManager objectManager;
 
-
-    @PrePersist void onPrePersist(Object entityPojo) {
+    @PrePersist void onPrePersist(final Object entityPojo) {
         log.debug("onPrePersist: {}", entityPojo);
         serviceInjector.injectServicesInto(entityPojo);
         val entity = objectManager.adapt(entityPojo);
-        val entityChangeTracker = entityChangeTrackerProvider.get();
-        entityChangeTracker.recognizePersisting(entity);
+        propertyChangePublisher.onPrePersist(entity);
     }
 
-    @PreUpdate void onPreUpdate(Object entityPojo) {
+    @PreUpdate void onPreUpdate(final Object entityPojo) {
         log.debug("onPreUpdate: {}", entityPojo);
         serviceInjector.injectServicesInto(entityPojo);
         val entity = objectManager.adapt(entityPojo);
-        val entityChangeTracker = entityChangeTrackerProvider.get();
         val entityManagerResult = jpaSupportServiceProvider.get().getEntityManager(entityPojo.getClass());
         entityManagerResult.getValue().ifPresent(em -> {  // https://wiki.eclipse.org/EclipseLink/FAQ/JPA#How_to_access_what_changed_in_an_object_or_transaction.3F
             val unwrap = em.unwrap(UnitOfWork.class);
             val changes = unwrap.getCurrentChanges();
             val objectChanges = changes.getObjectChangeSetForClone(entityPojo);
-            val changeRecords = objectChanges.getChanges();
-            changeRecords.forEach(changeRecord -> {
+
+            final Can<PropertyChangeRecord> payload = objectChanges
+            .getChanges()
+            .stream()
+            .filter(DirectToFieldChangeRecord.class::isInstance)
+            .map(DirectToFieldChangeRecord.class::cast)
+            .map(changeRecord -> {
                 val propertyName = changeRecord.getAttribute();
-                val oldValue = changeRecord.getOldValue();
-                entityChangeTracker.enlistUpdating(entity, propertyName, oldValue);
-            });
+                val property = entity.getSpecification().getProperty(propertyName)
+                        .filter(property->!property.isMixedIn())
+                        .filter(property->!property.isNotPersisted())
+                        .orElse(null);
+
+                if(property==null) {
+                    return null; // ignore
+                }
+
+                return PropertyChangeRecord.of(
+                        entity,
+                        property,
+                        PreAndPostValue
+                            .pre(changeRecord.getOldValue())
+                            .withPost(changeRecord.getNewValue()));
+            })
+            .collect(Can.toCan()); // a Can<T> only collects non-null elements
+
+            propertyChangePublisher.onPreUpdate(entity, payload);
+
         });
     }
 
-    @PreRemove void onPreRemove(Object entityPojo) {
+    @PreRemove void onPreRemove(final Object entityPojo) {
         log.debug("onAnyRemove: {}", entityPojo);
         serviceInjector.injectServicesInto(entityPojo);
         val entity = objectManager.adapt(entityPojo);
-        val entityChangeTracker = entityChangeTrackerProvider.get();
-        entityChangeTracker.enlistDeleting(entity);
+        propertyChangePublisher.onPreRemove(entity);
     }
 
-    @PostPersist void onPostPersist(Object entityPojo) {
+    @PostPersist void onPostPersist(final Object entityPojo) {
         log.debug("onPostPersist: {}", entityPojo);
         val entity = objectManager.adapt(entityPojo);
-        val entityChangeTracker = entityChangeTrackerProvider.get();
-        entityChangeTracker.enlistCreated(entity);
+        propertyChangePublisher.onPostPersist(entity);
     }
 
-    @PostUpdate void onPostUpdate(Object entityPojo) {
+    @PostUpdate void onPostUpdate(final Object entityPojo) {
         log.debug("onPostUpdate: {}", entityPojo);
         val entity = objectManager.adapt(entityPojo);
-        val entityChangeTracker = entityChangeTrackerProvider.get();
-        entityChangeTracker.recognizeUpdating(entity);
+        propertyChangePublisher.onPostUpdate(entity);
     }
 
-    @PostRemove void onPostRemove(Object entityPojo) {
+    @PostRemove void onPostRemove(final Object entityPojo) {
         log.debug("onPostRemove: {}", entityPojo);
     }
 
-    @PostLoad void onPostLoad(Object entityPojo) {
+    @PostLoad void onPostLoad(final Object entityPojo) {
         log.debug("onPostLoad: {}", entityPojo);
         serviceInjector.injectServicesInto(entityPojo);
         val entity = objectManager.adapt(entityPojo);
-        val entityChangeTracker = entityChangeTrackerProvider.get();
-        entityChangeTracker.recognizeLoaded(entity);
+        propertyChangePublisher.onPostRemove(entity);
     }
+
 
 }

--- a/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/JpaEntityInjectionPointResolver.java
+++ b/persistence/jpa/applib/src/main/java/org/apache/isis/persistence/jpa/applib/integration/JpaEntityInjectionPointResolver.java
@@ -26,50 +26,52 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreRemove;
 import javax.persistence.PreUpdate;
 
-import org.eclipse.persistence.sessions.UnitOfWork;
-
-import lombok.extern.log4j.Log4j2;
-import lombok.val;
-
 /**
  * Use {@link IsisEntityListener} instead.
  */
 @Deprecated
-@Log4j2
+//@Log4j2
 public class JpaEntityInjectionPointResolver extends IsisEntityListener {
 
+    @Override
     @PrePersist
-    void onPrePersist(Object entityPojo) {
+    void onPrePersist(final Object entityPojo) {
         super.onPrePersist(entityPojo);
     }
 
+    @Override
     @PreUpdate
-    void onPreUpdate(Object entityPojo) {
+    void onPreUpdate(final Object entityPojo) {
         super.onPreUpdate(entityPojo);
     }
 
+    @Override
     @PreRemove
-    void onPreRemove(Object entityPojo) {
+    void onPreRemove(final Object entityPojo) {
         super.onPreRemove(entityPojo);
     }
 
+    @Override
     @PostPersist
-    void onPostPersist(Object entityPojo) {
+    void onPostPersist(final Object entityPojo) {
         super.onPostPersist(entityPojo);
     }
 
+    @Override
     @PostUpdate
-    void onPostUpdate(Object entityPojo) {
+    void onPostUpdate(final Object entityPojo) {
         super.onPostUpdate(entityPojo);
     }
 
+    @Override
     @PostRemove
-    void onPostRemove(Object entityPojo) {
+    void onPostRemove(final Object entityPojo) {
         super.onPostRemove(entityPojo);
     }
 
+    @Override
     @PostLoad
-    void onPostLoad(Object entityPojo) {
+    void onPostLoad(final Object entityPojo) {
         super.onPostLoad(entityPojo);
     }
 

--- a/persistence/jpa/integration/src/main/java/org/apache/isis/persistence/jpa/integration/IsisModuleJpaIntegration.java
+++ b/persistence/jpa/integration/src/main/java/org/apache/isis/persistence/jpa/integration/IsisModuleJpaIntegration.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import org.apache.isis.core.runtime.IsisModuleCoreRuntime;
+import org.apache.isis.persistence.jpa.integration.changetracking.PropertyChangePublisherJpa;
 import org.apache.isis.persistence.jpa.integration.metamodel.JpaProgrammingModel;
 import org.apache.isis.persistence.jpa.integration.services.JpaSupportServiceUsingSpring;
 import org.apache.isis.persistence.jpa.integration.typeconverters.JavaAwtBufferedImageByteArrayConverter;
@@ -38,6 +39,7 @@ import org.apache.isis.persistence.jpa.integration.typeconverters.JavaAwtBuffere
 
         // @Service's
         JpaSupportServiceUsingSpring.class,
+        PropertyChangePublisherJpa.class,
 
 //        DataNucleusSettings.class,
 //        ExceptionRecognizerForSQLIntegrityConstraintViolationUniqueOrIndexException.class,

--- a/persistence/jpa/integration/src/main/java/org/apache/isis/persistence/jpa/integration/changetracking/PropertyChangePublisherJpa.java
+++ b/persistence/jpa/integration/src/main/java/org/apache/isis/persistence/jpa/integration/changetracking/PropertyChangePublisherJpa.java
@@ -1,8 +1,5 @@
 package org.apache.isis.persistence.jpa.integration.changetracking;
 
-import java.sql.Timestamp;
-import java.util.UUID;
-
 import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -11,13 +8,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import org.apache.isis.applib.annotation.PriorityPrecedence;
-import org.apache.isis.applib.services.bookmark.Bookmark;
 import org.apache.isis.applib.services.eventbus.EventBusService;
 import org.apache.isis.applib.services.metrics.MetricsService;
-import org.apache.isis.applib.services.publishing.spi.EntityPropertyChange;
-import org.apache.isis.applib.services.xactn.TransactionId;
 import org.apache.isis.commons.collections.Can;
-import org.apache.isis.core.metamodel.facets.actions.action.invocation.CommandUtil;
 import org.apache.isis.core.metamodel.facets.object.callbacks.CallbackFacet;
 import org.apache.isis.core.metamodel.facets.object.callbacks.PersistedCallbackFacet;
 import org.apache.isis.core.metamodel.facets.object.callbacks.PersistedLifecycleEventFacet;
@@ -30,18 +23,10 @@ import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatedLifecycleEv
 import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatingCallbackFacet;
 import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatingLifecycleEventFacet;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
-import org.apache.isis.core.metamodel.spec.ManagedObjects;
-import org.apache.isis.core.metamodel.spec.feature.MixedIn;
 import org.apache.isis.core.transaction.changetracking.EntityPropertyChangePublisher;
-import org.apache.isis.core.transaction.changetracking.HasEnlistedEntityPropertyChanges;
 import org.apache.isis.core.transaction.changetracking.PersistenceCallbackHandlerAbstract;
-import org.apache.isis.core.transaction.changetracking.PreAndPostValue;
-import org.apache.isis.core.transaction.changetracking.PropertyChangePublisher;
 import org.apache.isis.core.transaction.changetracking.PropertyChangeRecord;
-import org.apache.isis.core.transaction.changetracking.events.IsisTransactionPlaceholder;
-
-import lombok.val;
-import lombok.extern.log4j.Log4j2;
+import org.apache.isis.core.transaction.changetracking.PropertyChangeTracker;
 
 /**
  * @since 2.0 {@index}
@@ -50,12 +35,12 @@ import lombok.extern.log4j.Log4j2;
 @Named("isis.transaction.PropertyChangePublisherJpa")
 @Priority(PriorityPrecedence.EARLY)
 @Qualifier("jpa")
-@Log4j2
+//@Log4j2
 public class PropertyChangePublisherJpa
 extends PersistenceCallbackHandlerAbstract
 implements
     MetricsService,
-    PropertyChangePublisher {
+    PropertyChangeTracker {
 
     private final EntityPropertyChangePublisher entityPropertyChangePublisher;
 
@@ -86,7 +71,7 @@ implements
         postLifecycleEventIfRequired(entity, UpdatingLifecycleEventFacet.class);
 
         entityPropertyChangePublisher.publishChangedProperties(
-                PropertyChangePublisher
+                PropertyChangeTracker
                 .publishingPayloadForUpdate(entity, changeRecords));
 
     }
@@ -97,7 +82,7 @@ implements
         postLifecycleEventIfRequired(entity, RemovingLifecycleEventFacet.class);
 
         entityPropertyChangePublisher.publishChangedProperties(
-                PropertyChangePublisher
+                PropertyChangeTracker
                 .publishingPayloadForDeletion(entity));
     }
 
@@ -107,7 +92,7 @@ implements
         postLifecycleEventIfRequired(entity, PersistedLifecycleEventFacet.class);
 
         entityPropertyChangePublisher.publishChangedProperties(
-                PropertyChangePublisher
+                PropertyChangeTracker
                 .publishingPayloadForCreation(entity));
     }
 

--- a/persistence/jpa/integration/src/main/java/org/apache/isis/persistence/jpa/integration/changetracking/PropertyChangePublisherJpa.java
+++ b/persistence/jpa/integration/src/main/java/org/apache/isis/persistence/jpa/integration/changetracking/PropertyChangePublisherJpa.java
@@ -1,0 +1,262 @@
+package org.apache.isis.persistence.jpa.integration.changetracking;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import org.apache.isis.applib.annotation.PriorityPrecedence;
+import org.apache.isis.applib.services.bookmark.Bookmark;
+import org.apache.isis.applib.services.eventbus.EventBusService;
+import org.apache.isis.applib.services.metrics.MetricsService;
+import org.apache.isis.applib.services.publishing.spi.EntityPropertyChange;
+import org.apache.isis.applib.services.xactn.TransactionId;
+import org.apache.isis.commons.collections.Can;
+import org.apache.isis.core.metamodel.facets.actions.action.invocation.CommandUtil;
+import org.apache.isis.core.metamodel.facets.object.callbacks.CallbackFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.PersistedCallbackFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.PersistedLifecycleEventFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.PersistingCallbackFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.PersistingLifecycleEventFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.RemovingCallbackFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.RemovingLifecycleEventFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatedCallbackFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatedLifecycleEventFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatingCallbackFacet;
+import org.apache.isis.core.metamodel.facets.object.callbacks.UpdatingLifecycleEventFacet;
+import org.apache.isis.core.metamodel.spec.ManagedObject;
+import org.apache.isis.core.metamodel.spec.ManagedObjects;
+import org.apache.isis.core.metamodel.spec.feature.MixedIn;
+import org.apache.isis.core.transaction.changetracking.EntityPropertyChangePublisher;
+import org.apache.isis.core.transaction.changetracking.HasEnlistedEntityPropertyChanges;
+import org.apache.isis.core.transaction.changetracking.PersistenceCallbackHandlerAbstract;
+import org.apache.isis.core.transaction.changetracking.PreAndPostValue;
+import org.apache.isis.core.transaction.changetracking.PropertyChangePublisher;
+import org.apache.isis.core.transaction.changetracking.PropertyChangeRecord;
+import org.apache.isis.core.transaction.changetracking.events.IsisTransactionPlaceholder;
+
+import lombok.val;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * @since 2.0 {@index}
+ */
+@Service
+@Named("isis.transaction.PropertyChangePublisherJpa")
+@Priority(PriorityPrecedence.EARLY)
+@Qualifier("jpa")
+@Log4j2
+public class PropertyChangePublisherJpa
+extends PersistenceCallbackHandlerAbstract
+implements
+    MetricsService,
+    PropertyChangePublisher {
+
+    private final EntityPropertyChangePublisher entityPropertyChangePublisher;
+
+    @Inject
+    public PropertyChangePublisherJpa(
+            final EventBusService eventBusService,
+            final EntityPropertyChangePublisher entityPropertyChangePublisher) {
+        super(eventBusService);
+        this.entityPropertyChangePublisher = entityPropertyChangePublisher;
+    }
+
+    @Override
+    public void onPrePersist(final ManagedObject entity) {
+        CallbackFacet.callCallback(entity, PersistingCallbackFacet.class);
+        postLifecycleEventIfRequired(entity, PersistingLifecycleEventFacet.class);
+    }
+
+    @Override
+    public void onPreUpdate(
+            final ManagedObject entity,
+            final Can<PropertyChangeRecord> changeRecords) {
+
+        if(changeRecords.isEmpty()) {
+            return;
+        }
+
+        val payload = new HasEnlistedEntityPropertyChanges() {
+
+            @Override
+            public Can<EntityPropertyChange> getPropertyChanges(
+                    final Timestamp timestamp,
+                    final String user,
+                    final TransactionId txId) {
+
+                return changeRecords
+                .map(changeRecord->{
+
+                    log.debug("publish property change {} value '{}' -> '{}'",
+                            entity.getSpecification().getLogicalTypeName(),
+                            changeRecord.getPropertyId(),
+                            changeRecord.getPreAndPostValue().getPre(),
+                            changeRecord.getPreAndPostValue().getPost());
+
+                    return toPropertyChange(changeRecord,
+                            timestamp,
+                            user,
+                            txId);
+                });
+
+            }
+
+        };
+
+        CallbackFacet.callCallback(entity, UpdatingCallbackFacet.class);
+        postLifecycleEventIfRequired(entity, UpdatingLifecycleEventFacet.class);
+
+        entityPropertyChangePublisher.publishChangedProperties(payload);
+    }
+
+    @Override
+    public void onPreRemove(final ManagedObject entity) {
+        CallbackFacet.callCallback(entity, RemovingCallbackFacet.class);
+        postLifecycleEventIfRequired(entity, RemovingLifecycleEventFacet.class);
+
+
+        val payload = new HasEnlistedEntityPropertyChanges() {
+
+            @Override
+            public Can<EntityPropertyChange> getPropertyChanges(
+                    final Timestamp timestamp,
+                    final String user,
+                    final TransactionId txId) {
+
+                return entity
+                .getSpecification()
+                .streamProperties(MixedIn.EXCLUDED)
+                .filter(property->!property.isMixedIn())
+                .filter(property->!property.isNotPersisted())
+                .map(property->PropertyChangeRecord.of(
+                            entity,
+                            property,
+                            PreAndPostValue
+                                .pre(property.get(entity))
+                                .withPost(IsisTransactionPlaceholder.DELETED))
+                )
+                .map(changeRecord->{
+
+                    log.debug("publish property change {} value '{}' -> '{}'",
+                            entity.getSpecification().getLogicalTypeName(),
+                            changeRecord.getPropertyId(),
+                            changeRecord.getPreAndPostValue().getPre(),
+                            changeRecord.getPreAndPostValue().getPost());
+
+                    return toPropertyChange(changeRecord,
+                            timestamp,
+                            user,
+                            txId);
+                })
+                .collect(Can.toCan());
+
+            }
+
+        };
+
+        entityPropertyChangePublisher.publishChangedProperties(payload);
+    }
+
+    @Override
+    public void onPostPersist(final ManagedObject entity) {
+        CallbackFacet.callCallback(entity, PersistedCallbackFacet.class);
+        postLifecycleEventIfRequired(entity, PersistedLifecycleEventFacet.class);
+
+        val payload = new HasEnlistedEntityPropertyChanges() {
+
+            @Override
+            public Can<EntityPropertyChange> getPropertyChanges(
+                    final Timestamp timestamp,
+                    final String user,
+                    final TransactionId txId) {
+
+                return entity
+                .getSpecification()
+                .streamProperties(MixedIn.EXCLUDED)
+                .filter(property->!property.isMixedIn())
+                .filter(property->!property.isNotPersisted())
+                .map(property->PropertyChangeRecord.of(
+                            entity,
+                            property,
+                            PreAndPostValue
+                                .pre(IsisTransactionPlaceholder.NEW)
+                                .withPost(property.get(entity)))
+                )
+                .map(changeRecord->{
+
+                    log.debug("publish property change {} value '{}' -> '{}'",
+                            entity.getSpecification().getLogicalTypeName(),
+                            changeRecord.getPropertyId(),
+                            changeRecord.getPreAndPostValue().getPre(),
+                            changeRecord.getPreAndPostValue().getPost());
+
+                    return toPropertyChange(changeRecord,
+                            timestamp,
+                            user,
+                            txId);
+                })
+                .collect(Can.toCan());
+
+            }
+
+        };
+
+        entityPropertyChangePublisher.publishChangedProperties(payload);
+    }
+
+    @Override
+    public void onPostUpdate(final ManagedObject entity) {
+        CallbackFacet.callCallback(entity, UpdatedCallbackFacet.class);
+        postLifecycleEventIfRequired(entity, UpdatedLifecycleEventFacet.class);
+    }
+
+    @Override
+    public void onPostRemove(final ManagedObject entity) {
+        // not used
+    }
+
+    @Override
+    public int numberEntitiesLoaded() {
+        return -1; // n/a
+    }
+
+    @Override
+    public int numberEntitiesDirtied() {
+        return -1; // n/a
+    }
+
+    // -- HELPER
+
+    private EntityPropertyChange toPropertyChange(
+            final PropertyChangeRecord record,
+            final Timestamp timestamp,
+            final String user,
+            final TransactionId txId) {
+
+        val entity = record.getEntity();
+        val spec = entity.getSpecification();
+        val property = record.getProperty();
+
+        final Bookmark target = ManagedObjects.bookmarkElseFail(entity);
+        final String propertyId = property.getId();
+        final String memberId = property.getFeatureIdentifier().getFullIdentityString();
+        final String preValueStr = record.getPreAndPostValue().getPreString();
+        final String postValueStr = record.getPreAndPostValue().getPostString();
+        final String targetClass = CommandUtil.targetClassNameFor(spec);
+
+        final UUID transactionId = txId.getInteractionId();
+        final int sequence = txId.getSequence();
+
+
+        return EntityPropertyChange.of(
+                transactionId, sequence, targetClass, target,
+                memberId, propertyId, preValueStr, postValueStr, user, timestamp);
+    }
+
+}

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/CommandPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/CommandPublishingTestAbstract.java
@@ -29,6 +29,7 @@ import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.commons.collections.Can;
 import org.apache.isis.schema.cmd.v2.CommandDto;
 import org.apache.isis.schema.cmd.v2.PropertyDto;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.VerificationStage;
 import org.apache.isis.testdomain.publishing.subscriber.CommandSubscriberForTesting;
 import org.apache.isis.testdomain.util.CollectionAssertions;
@@ -45,7 +46,9 @@ implements HasPersistenceStandard {
         CommandSubscriberForTesting.clearPublishedCommands(kvStore);
     }
 
-    protected void verify(final VerificationStage verificationStage) {
+    protected void verify(
+            final ChangeScenario changeScenario,
+            final VerificationStage verificationStage) {
         switch(verificationStage) {
 
         case FAILURE_CASE:

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/CommandPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/CommandPublishingTestAbstract.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.applib.services.command.Command;
 import org.apache.isis.commons.collections.Can;
+import org.apache.isis.commons.internal.exceptions._Exceptions;
+import org.apache.isis.schema.cmd.v2.ActionDto;
 import org.apache.isis.schema.cmd.v2.CommandDto;
 import org.apache.isis.schema.cmd.v2.PropertyDto;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
@@ -59,26 +61,37 @@ implements HasPersistenceStandard {
             break;
         case POST_COMMIT:
 
-
-//            Interaction interaction = null;
-//            String propertyId = "org.apache.isis.testdomain.jdo.entities.JdoBook#name";
-//            Object target = null;
-//            Object argValue = "Book #2";
-//            String targetMemberName = "name???";
-//            String targetClass = "org.apache.isis.testdomain.jdo.entities.JdoBook";
-
-            val propertyDto = new PropertyDto();
-            propertyDto.setLogicalMemberIdentifier(
-                    formatPersistenceStandardSpecificLowerCase("testdomain.%s.Book#name"));
-
             val command = new Command(UUID.randomUUID());
             val commandDto = new CommandDto();
             commandDto.setInteractionId(command.getInteractionId().toString());
-            commandDto.setMember(propertyDto);
 
-            command.updater().setCommandDto(commandDto);
+            switch(changeScenario) {
+            case PROPERTY_UPDATE:
 
-            assertHasCommandEntries(Can.of(command));
+                val propertyDto = new PropertyDto();
+                propertyDto.setLogicalMemberIdentifier(
+                        formatPersistenceStandardSpecificLowerCase("testdomain.%s.Book#name"));
+
+                commandDto.setMember(propertyDto);
+                command.updater().setCommandDto(commandDto);
+
+                assertHasCommandEntries(Can.of(command));
+                break;
+            case ACTION_EXECUTION:
+
+                val actionDto = new ActionDto();
+                actionDto.setLogicalMemberIdentifier(
+                        formatPersistenceStandardSpecificLowerCase("testdomain.%s.Book#doubleThePrice"));
+
+                commandDto.setMember(actionDto);
+                command.updater().setCommandDto(commandDto);
+
+                assertHasCommandEntries(Can.of(command));
+                break;
+            default:
+                throw _Exceptions.unmatchedCase(changeScenario);
+            }
+
             break;
         default:
             // if hitting this, the caller is requesting a verification stage, we are providing no case for

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/EntityPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/EntityPublishingTestAbstract.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.VerificationStage;
 import org.apache.isis.testdomain.util.kv.KVStoreForTesting;
 
@@ -42,7 +43,9 @@ implements HasPersistenceStandard {
         clearPublishedEntries(kvStore);
     }
 
-    protected void verify(final VerificationStage verificationStage) {
+    protected void verify(
+            final ChangeScenario changeScenario,
+            final VerificationStage verificationStage) {
         switch(verificationStage) {
         case FAILURE_CASE:
             assertEquals(0, getCreated(kvStore));

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/ExecutionPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/ExecutionPublishingTestAbstract.java
@@ -34,6 +34,7 @@ import org.apache.isis.commons.collections.Can;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.testdomain.jdo.entities.JdoBook;
 import org.apache.isis.testdomain.jpa.entities.JpaBook;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.VerificationStage;
 import org.apache.isis.testdomain.publishing.subscriber.ExecutionSubscriberForTesting;
 import org.apache.isis.testdomain.util.CollectionAssertions;
@@ -50,7 +51,9 @@ implements HasPersistenceStandard {
         ExecutionSubscriberForTesting.clearPublishedEntries(kvStore);
     }
 
-    protected void verify(final VerificationStage verificationStage) {
+    protected void verify(
+            final ChangeScenario changeScenario,
+            final VerificationStage verificationStage) {
         switch(verificationStage) {
 
         case FAILURE_CASE:

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/ExecutionPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/ExecutionPublishingTestAbstract.java
@@ -18,6 +18,7 @@
  */
 package org.apache.isis.testdomain.publishing;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -63,18 +64,39 @@ implements HasPersistenceStandard {
         case POST_INTERACTION:
             break;
         case POST_COMMIT:
-            val bookClass = bookClass();
-            Interaction interaction = null;
-            Identifier propertyId = Identifier.propertyOrCollectionIdentifier(
-                    LogicalType.fqcn(bookClass), "name");
-            Object target = null;
-            Object argValue = "Book #2";
-            String targetMemberName = "name???";
-            String targetClass = bookClass.getName();
 
-            assertHasExecutionEntries(Can.of(
-                    new PropertyEdit(interaction, propertyId, target, argValue, targetMemberName, targetClass)
-                    ));
+            val bookClass = bookClass();
+            final Interaction interaction = null;
+            val targetMemberName = "name???";
+            final Object target = null;
+            val targetClass = bookClass.getName();
+
+            switch(changeScenario) {
+            case PROPERTY_UPDATE: {
+                Identifier propertyId = Identifier.propertyOrCollectionIdentifier(
+                        LogicalType.fqcn(bookClass), "name");
+                Object argValue = "Book #2";
+
+                assertHasExecutionEntries(Can.of(
+                        new PropertyEdit(interaction, propertyId, target, argValue, targetMemberName, targetClass)
+                        ));
+            }
+                break;
+            case ACTION_EXECUTION: {
+                Identifier actionId = Identifier.actionIdentifier(
+                        LogicalType.fqcn(bookClass), "doubleThePrice");
+                val args = Collections.<Object>emptyList();
+
+                assertHasExecutionEntries(Can.of(
+                        new ActionInvocation(interaction, actionId, target, args, targetMemberName, targetClass)
+                        ));
+            }
+
+                break;
+            default:
+                throw _Exceptions.unmatchedCase(changeScenario);
+            }
+
             break;
         default:
             // if hitting this, the caller is requesting a verification stage, we are providing no case for

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/PropertyPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/PropertyPublishingTestAbstract.java
@@ -58,9 +58,13 @@ implements HasPersistenceStandard {
                 assertContainsPropertyChangeEntries(Can.of(
                         formatPersistenceStandardSpecificCapitalize("%s Book/name: '[NEW]' -> 'Sample Book'")));
                 break;
-            case ENTITY_UPDATE:
+            case PROPERTY_UPDATE:
                 assertHasPropertyChangeEntries(Can.of(
                         formatPersistenceStandardSpecificCapitalize("%s Book/name: 'Sample Book' -> 'Book #2'")));
+                break;
+            case ACTION_EXECUTION:
+                assertHasPropertyChangeEntries(Can.of(
+                        formatPersistenceStandardSpecificCapitalize("%s Book/price: '99.0' -> '198.0'")));
                 break;
             case ENTITY_REMOVAL:
                 assertContainsPropertyChangeEntries(Can.of(

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/PropertyPublishingTestAbstract.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/PropertyPublishingTestAbstract.java
@@ -20,9 +20,11 @@ package org.apache.isis.testdomain.publishing;
 
 import javax.inject.Inject;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.isis.commons.collections.Can;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.VerificationStage;
 import org.apache.isis.testdomain.publishing.subscriber.EntityPropertyChangeSubscriberForTesting;
 import org.apache.isis.testdomain.util.CollectionAssertions;
@@ -39,7 +41,9 @@ implements HasPersistenceStandard {
         EntityPropertyChangeSubscriberForTesting.clearPropertyChangeEntries(kvStore);
     }
 
-    protected void verify(final VerificationStage verificationStage) {
+    protected void verify(
+            final ChangeScenario changeScenario,
+            final VerificationStage verificationStage) {
         switch(verificationStage) {
         case FAILURE_CASE:
             assertHasPropertyChangeEntries(Can.empty());
@@ -48,8 +52,22 @@ implements HasPersistenceStandard {
         case POST_INTERACTION:
             break;
         case POST_COMMIT:
-            assertHasPropertyChangeEntries(Can.of(
-                    formatPersistenceStandardSpecificCapitalize("%s Book/name: 'Sample Book' -> 'Book #2'")));
+
+            switch(changeScenario) {
+            case ENTITY_CREATION:
+                assertContainsPropertyChangeEntries(Can.of(
+                        formatPersistenceStandardSpecificCapitalize("%s Book/name: '[NEW]' -> 'Sample Book'")));
+                break;
+            case ENTITY_UPDATE:
+                assertHasPropertyChangeEntries(Can.of(
+                        formatPersistenceStandardSpecificCapitalize("%s Book/name: 'Sample Book' -> 'Book #2'")));
+                break;
+            case ENTITY_REMOVAL:
+                assertContainsPropertyChangeEntries(Can.of(
+                        formatPersistenceStandardSpecificCapitalize("%s Book/name: 'Sample Book' -> '[DELETED]'")));
+                break;
+            }
+
             break;
         default:
             // if hitting this, the caller is requesting a verification stage, we are providing no case for
@@ -58,6 +76,15 @@ implements HasPersistenceStandard {
     }
 
     // -- HELPER
+
+    private void assertContainsPropertyChangeEntries(final Can<String> expectedAuditEntries) {
+        val actualAuditEntries = EntityPropertyChangeSubscriberForTesting.getPropertyChangeEntries(kvStore);
+        expectedAuditEntries.forEach(expectedAuditEntry->{
+            assertTrue(actualAuditEntries.contains(expectedAuditEntry),
+                    ()->String.format("expectedAuditEntry (%s) not found in %s", expectedAuditEntry, actualAuditEntries));
+        });
+
+    }
 
     private void assertHasPropertyChangeEntries(final Can<String> expectedAuditEntries) {
         val actualAuditEntries = EntityPropertyChangeSubscriberForTesting.getPropertyChangeEntries(kvStore);

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoCommandPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoCommandPublishingTest.java
@@ -69,10 +69,16 @@ implements HasPersistenceStandardJdo {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTests(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTests(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoCommandPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoCommandPublishingTest.java
@@ -32,6 +32,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJdo;
 import org.apache.isis.testdomain.publishing.CommandPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJdo;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingCommandPublishing;
 
 @SpringBootTest(
@@ -56,9 +57,22 @@ implements HasPersistenceStandardJdo {
 
     @Inject private PublishingTestFactoryJdo testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTests(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoEntityPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoEntityPublishingTest.java
@@ -70,10 +70,16 @@ implements HasPersistenceStandardJdo {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTestsIncludeProgrammatic(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoEntityPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoEntityPublishingTest.java
@@ -32,6 +32,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJdo;
 import org.apache.isis.testdomain.publishing.EntityPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJdo;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingEntityChangesPublishing;
 
 @SpringBootTest(
@@ -57,9 +58,22 @@ implements HasPersistenceStandardJdo {
 
     @Inject private PublishingTestFactoryJdo testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTestsIncludeProgrammatic(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoExecutionPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoExecutionPublishingTest.java
@@ -32,6 +32,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJdo;
 import org.apache.isis.testdomain.publishing.ExecutionPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJdo;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingExecutionPublishing;
 
 @SpringBootTest(
@@ -56,9 +57,22 @@ implements HasPersistenceStandardJdo {
 
     @Inject private PublishingTestFactoryJdo testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTests(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoExecutionPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoExecutionPublishingTest.java
@@ -69,10 +69,16 @@ implements HasPersistenceStandardJdo {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTests(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTests(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoPropertyPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoPropertyPublishingTest.java
@@ -72,10 +72,16 @@ implements HasPersistenceStandardJdo {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTestsIncludeProgrammatic(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoPropertyPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jdo/JdoPropertyPublishingTest.java
@@ -34,6 +34,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJdo;
 import org.apache.isis.testdomain.publishing.PropertyPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJdo;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingEntityPropertyChangePublishing;
 
 @SpringBootTest(
@@ -59,9 +60,22 @@ implements HasPersistenceStandardJdo {
 
     @Inject private PublishingTestFactoryJdo testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTestsIncludeProgrammatic(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaCommandPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaCommandPublishingTest.java
@@ -32,6 +32,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJpa;
 import org.apache.isis.testdomain.publishing.CommandPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJpa;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingCommandPublishing;
 
 @SpringBootTest(
@@ -56,9 +57,23 @@ implements HasPersistenceStandardJpa {
 
     @Inject private PublishingTestFactoryJpa testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTests(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
     }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+    }
+
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaCommandPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaCommandPublishingTest.java
@@ -69,10 +69,16 @@ implements HasPersistenceStandardJpa {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTests(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTests(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaEntityPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaEntityPublishingTest.java
@@ -58,24 +58,31 @@ implements HasPersistenceStandardJpa {
     @Inject private PublishingTestFactoryJpa testFactory;
 
     @Disabled("'Entity Changes Tracking' currently not supported for JPA")
-    @TestFactory @DisplayName("Entity Creation")
+    @TestFactory @DisplayName("Entity Creation - n/a")
     List<DynamicTest> generateTestsForCreation() {
         return testFactory.generateTestsIncludeProgrammatic(
                 ChangeScenario.ENTITY_CREATION, this::given, this::verify);
     }
 
     @Disabled("'Entity Changes Tracking' currently not supported for JPA")
-    @TestFactory @DisplayName("Entity Removal")
+    @TestFactory @DisplayName("Entity Removal - n/a")
     List<DynamicTest> generateTestsForRemoval() {
         return testFactory.generateTestsIncludeProgrammatic(
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
     @Disabled("'Entity Changes Tracking' currently not supported for JPA")
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update - n/a")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTestsIncludeProgrammatic(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @Disabled("'Entity Changes Tracking' currently not supported for JPA")
+    @TestFactory @DisplayName("Action Execution - n/a")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaEntityPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaEntityPublishingTest.java
@@ -33,6 +33,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJpa;
 import org.apache.isis.testdomain.publishing.EntityPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJpa;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingEntityChangesPublishing;
 
 @SpringBootTest(
@@ -57,9 +58,24 @@ implements HasPersistenceStandardJpa {
     @Inject private PublishingTestFactoryJpa testFactory;
 
     @Disabled("'Entity Changes Tracking' currently not supported for JPA")
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTestsIncludeProgrammatic(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @Disabled("'Entity Changes Tracking' currently not supported for JPA")
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @Disabled("'Entity Changes Tracking' currently not supported for JPA")
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaEntityPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaEntityPublishingTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -55,6 +56,7 @@ implements HasPersistenceStandardJpa {
 
     @Inject private PublishingTestFactoryJpa testFactory;
 
+    @Disabled("'Entity Changes Tracking' currently not supported for JPA")
     @TestFactory @DisplayName("Execution Scenario")
     List<DynamicTest> generateTests() {
         return testFactory.generateTestsIncludeProgrammatic(this::given, this::verify);

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaExecutionPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaExecutionPublishingTest.java
@@ -32,6 +32,7 @@ import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJpa;
 import org.apache.isis.testdomain.publishing.ExecutionPublishingTestAbstract;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJpa;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingExecutionPublishing;
 
 @SpringBootTest(
@@ -56,9 +57,22 @@ implements HasPersistenceStandardJpa {
 
     @Inject private PublishingTestFactoryJpa testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTests(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTests(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaExecutionPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaExecutionPublishingTest.java
@@ -69,10 +69,16 @@ implements HasPersistenceStandardJpa {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTests(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTests(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaPropertyPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaPropertyPublishingTest.java
@@ -72,10 +72,16 @@ implements HasPersistenceStandardJpa {
                 ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
     }
 
-    @TestFactory @DisplayName("Entity Update")
+    @TestFactory @DisplayName("Property Update")
     List<DynamicTest> generateTestsForUpdate() {
         return testFactory.generateTestsIncludeProgrammatic(
-                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
+                ChangeScenario.PROPERTY_UPDATE, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Action Execution")
+    List<DynamicTest> generateTestsForAction() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ACTION_EXECUTION, this::given, this::verify);
     }
 
 }

--- a/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaPropertyPublishingTest.java
+++ b/regressiontests/incubating/src/test/java/org/apache/isis/testdomain/publishing/jpa/JpaPropertyPublishingTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.apache.isis.core.config.presets.IsisPresets;
 import org.apache.isis.testdomain.conf.Configuration_usingJpa;
 import org.apache.isis.testdomain.publishing.PropertyPublishingTestAbstract;
+import org.apache.isis.testdomain.publishing.PublishingTestFactoryAbstract.ChangeScenario;
 import org.apache.isis.testdomain.publishing.PublishingTestFactoryJpa;
 import org.apache.isis.testdomain.publishing.conf.Configuration_usingEntityPropertyChangePublishing;
 
@@ -59,9 +60,22 @@ implements HasPersistenceStandardJpa {
 
     @Inject private PublishingTestFactoryJpa testFactory;
 
-    @TestFactory @DisplayName("Execution Scenario")
-    List<DynamicTest> generateTests() {
-        return testFactory.generateTestsIncludeProgrammatic(this::given, this::verify);
+    @TestFactory @DisplayName("Entity Creation")
+    List<DynamicTest> generateTestsForCreation() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_CREATION, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Removal")
+    List<DynamicTest> generateTestsForRemoval() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_REMOVAL, this::given, this::verify);
+    }
+
+    @TestFactory @DisplayName("Entity Update")
+    List<DynamicTest> generateTestsForUpdate() {
+        return testFactory.generateTestsIncludeProgrammatic(
+                ChangeScenario.ENTITY_UPDATE, this::given, this::verify);
     }
 
 }

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jdo/entities/JdoBook.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jdo/entities/JdoBook.java
@@ -69,7 +69,7 @@ public class JdoBook extends JdoProduct {
     // -- ENTITY SERVICE INJECTION TEST
     private MyService myService;
     @Inject
-    public void setMyService(MyService myService) {
+    public void setMyService(final MyService myService) {
         val count = kvStore.incrementCounter(JdoBook.class, "injection-count");
         log.debug("INJECTION " + count);
         this.myService = myService;
@@ -86,12 +86,12 @@ public class JdoBook extends JdoProduct {
     }
 
     public static JdoBook of(
-            String name,
-            String description,
-            double price,
-            String author,
-            String isbn,
-            String publisher) {
+            final String name,
+            final String description,
+            final double price,
+            final String author,
+            final String isbn,
+            final String publisher) {
 
         return new JdoBook(name, description, price, author, isbn, publisher);
     }
@@ -111,16 +111,17 @@ public class JdoBook extends JdoProduct {
     // -- CONSTRUCTOR
 
     private JdoBook(
-            String name,
-            String description,
-            double price,
-            String author,
-            String isbn,
-            String publisher) {
+            final String name,
+            final String description,
+            final double price,
+            final String author,
+            final String isbn,
+            final String publisher) {
 
         super(name, description, price, /*comments*/null);
         this.author = author;
         this.isbn = isbn;
         this.publisher = publisher;
     }
+
 }

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jdo/entities/JdoProduct.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jdo/entities/JdoProduct.java
@@ -30,9 +30,11 @@ import javax.jdo.annotations.InheritanceStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 
+import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.Collection;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
+import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.commons.internal.base._Strings;
@@ -87,8 +89,20 @@ public class JdoProduct implements Comparable<JdoProduct> {
     @Getter @Setter
     private List<JdoProductComment> comments;
 
+    @Action(
+            commandPublishing = Publishing.ENABLED,
+            executionPublishing = Publishing.ENABLED)
+    public void doubleThePrice() {
+        this.setPrice(2.*getPrice());
+    }
+
+    @MemberSupport
+    public String disableDoubleThePrice() {
+        return "always disabled for testing purposes";
+    }
+
     @Override
-    public int compareTo(JdoProduct other) {
+    public int compareTo(final JdoProduct other) {
         return _Strings.compareNullsFirst(this.getName(), other==null ? null : other.getName());
     }
 

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaBook.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaBook.java
@@ -28,7 +28,7 @@ import javax.persistence.Transient;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.Publishing;
-import org.apache.isis.persistence.jpa.applib.integration.JpaEntityInjectionPointResolver;
+import org.apache.isis.persistence.jpa.applib.integration.IsisEntityListener;
 import org.apache.isis.testdomain.model.stereotypes.MyService;
 import org.apache.isis.testdomain.util.kv.KVStoreForTesting;
 
@@ -41,7 +41,7 @@ import lombok.val;
 import lombok.extern.log4j.Log4j2;
 
 @Entity
-@EntityListeners(JpaEntityInjectionPointResolver.class)
+@EntityListeners(IsisEntityListener.class)
 @DiscriminatorValue("Book")
 @DomainObject(
         logicalTypeName = "testdomain.jpa.Book",
@@ -56,7 +56,7 @@ public class JpaBook extends JpaProduct {
     // -- ENTITY SERVICE INJECTION TEST
     @Transient private MyService myService;
     @Inject
-    public void setMyService(MyService myService) {
+    public void setMyService(final MyService myService) {
         val count = kvStore.incrementCounter(JpaBook.class, "injection-count");
         log.debug("INJECTION " + count);
         this.myService = myService;
@@ -73,12 +73,12 @@ public class JpaBook extends JpaProduct {
     }
 
     public static JpaBook of(
-            String name,
-            String description,
-            double price,
-            String author,
-            String isbn,
-            String publisher) {
+            final String name,
+            final String description,
+            final double price,
+            final String author,
+            final String isbn,
+            final String publisher) {
 
         return new JpaBook(name, description, price, author, isbn, publisher);
     }
@@ -98,12 +98,12 @@ public class JpaBook extends JpaProduct {
     // -- CONSTRUCTOR
 
     private JpaBook(
-            String name,
-            String description,
-            double price,
-            String author,
-            String isbn,
-            String publisher) {
+            final String name,
+            final String description,
+            final double price,
+            final String author,
+            final String isbn,
+            final String publisher) {
 
         super(/*id*/ null, name, description, price, /*comments*/null);
         this.author = author;

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaProduct.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaProduct.java
@@ -33,9 +33,11 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 
+import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.Collection;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
+import org.apache.isis.applib.annotation.MemberSupport;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.commons.internal.base._Strings;
@@ -70,15 +72,11 @@ public class JpaProduct implements Comparable<JpaProduct> {
     private @Getter @Setter Long id;
 
     @Property(
-            editing = Editing.DISABLED, // used for an async rule check test
+            editing = Editing.DISABLED, // used for an wrapper rule check test
             commandPublishing = Publishing.ENABLED,
             executionPublishing = Publishing.ENABLED)
     @Column(nullable = true)
     private @Getter @Setter String name;
-//    public void setName(String name) {
-//        System.err.println("!!! setting name " + name);
-//        this.name = name;
-//    }
 
     @Property
     @Column(nullable = true)
@@ -92,6 +90,18 @@ public class JpaProduct implements Comparable<JpaProduct> {
     @Collection
     @OneToMany(mappedBy = "product") @JoinColumn(nullable = true)
     private @Getter @Setter List<JpaProductComment> comments;
+
+    @Action(
+            commandPublishing = Publishing.ENABLED,
+            executionPublishing = Publishing.ENABLED)
+    public void doubleThePrice() {
+        this.setPrice(2.*getPrice());
+    }
+
+    @MemberSupport
+    public String disableDoubleThePrice() {
+        return "always disabled for testing purposes";
+    }
 
     @Override
     public int compareTo(final JpaProduct other) {

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaProduct.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaProduct.java
@@ -69,7 +69,10 @@ public class JpaProduct implements Comparable<JpaProduct> {
     @Column(name = "id")
     private @Getter @Setter Long id;
 
-    @Property(editing = Editing.DISABLED, commandPublishing = Publishing.ENABLED) // used for an async rule check test
+    @Property(
+            editing = Editing.DISABLED, // used for an async rule check test
+            commandPublishing = Publishing.ENABLED,
+            executionPublishing = Publishing.ENABLED)
     @Column(nullable = true)
     private @Getter @Setter String name;
 //    public void setName(String name) {

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaProduct.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/jpa/entities/JpaProduct.java
@@ -37,6 +37,7 @@ import org.apache.isis.applib.annotation.Collection;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Property;
+import org.apache.isis.applib.annotation.Publishing;
 import org.apache.isis.commons.internal.base._Strings;
 
 import lombok.AccessLevel;
@@ -68,7 +69,7 @@ public class JpaProduct implements Comparable<JpaProduct> {
     @Column(name = "id")
     private @Getter @Setter Long id;
 
-    @Property(editing = Editing.DISABLED) // used for an async rule check test
+    @Property(editing = Editing.DISABLED, commandPublishing = Publishing.ENABLED) // used for an async rule check test
     @Column(nullable = true)
     private @Getter @Setter String name;
 //    public void setName(String name) {
@@ -90,7 +91,7 @@ public class JpaProduct implements Comparable<JpaProduct> {
     private @Getter @Setter List<JpaProductComment> comments;
 
     @Override
-    public int compareTo(JpaProduct other) {
+    public int compareTo(final JpaProduct other) {
         return _Strings.compareNullsFirst(this.getName(), other==null ? null : other.getName());
     }
 

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryAbstract.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryAbstract.java
@@ -218,12 +218,12 @@ public abstract class PublishingTestFactoryAbstract {
                         PublishingTestContext.of("Wrapper Sync w/ Rules (expected to fail w/ DisabledException)",
                                 given, verifier, VerificationStage.FAILURE_CASE),
                         VerificationStage.POST_INTERACTION,
-                        this::wrapperSyncExecutionWithFailure),
-                publishingTest(
-                        PublishingTestContext.of("Wrapper Async w/ Rules (expected to fail w/ DisabledException)",
-                                given, verifier, VerificationStage.FAILURE_CASE),
-                        VerificationStage.POST_INTERACTION,
-                        this::wrapperAsyncExecutionWithFailure)
+                        this::wrapperSyncExecutionWithFailure)
+//                publishingTest(
+//                        PublishingTestContext.of("Wrapper Async w/ Rules (expected to fail w/ DisabledException)",
+//                                given, verifier, VerificationStage.FAILURE_CASE),
+//                        VerificationStage.POST_INTERACTION,
+//                        this::wrapperAsyncExecutionWithFailure)
                 );
 
         if(includeProgrammatic) {

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryAbstract.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryAbstract.java
@@ -66,7 +66,8 @@ public abstract class PublishingTestFactoryAbstract {
     @RequiredArgsConstructor @Getter
     public static enum ChangeScenario {
         ENTITY_CREATION("creation"),
-        ENTITY_UPDATE("update"),
+        PROPERTY_UPDATE("property update"),
+        ACTION_EXECUTION("action execution"),
         ENTITY_REMOVAL("removal");
         final String displayName;
     }
@@ -124,6 +125,12 @@ public abstract class PublishingTestFactoryAbstract {
             traceLog.log("2.3 about to change book's name");
             runnable.run();
             traceLog.log("2.4 book's name has changed");
+        }
+
+        public void executeAction(final Runnable runnable) {
+            traceLog.log("2.3 about to double book's price");
+            runnable.run();
+            traceLog.log("2.4 book's price has been doubled");
         }
 
         public void runPostCommitVerify() {
@@ -224,7 +231,8 @@ public abstract class PublishingTestFactoryAbstract {
         }
 
 
-        if(changeScenario == ChangeScenario.ENTITY_UPDATE) {
+        if(changeScenario == ChangeScenario.PROPERTY_UPDATE
+                || changeScenario == ChangeScenario.ACTION_EXECUTION) {
 
             dynamicTests = dynamicTests
                 .add(publishingTest(

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryJpa.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryJpa.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -39,9 +38,11 @@ import org.apache.isis.applib.services.wrapper.DisabledException;
 import org.apache.isis.applib.services.wrapper.WrapperFactory;
 import org.apache.isis.applib.services.wrapper.control.SyncControl;
 import org.apache.isis.applib.services.xactn.TransactionService;
+import org.apache.isis.commons.collections.Can;
 import org.apache.isis.commons.internal.debug._Probe;
 import org.apache.isis.commons.internal.exceptions._Exceptions;
 import org.apache.isis.commons.internal.functions._Functions.CheckedConsumer;
+import org.apache.isis.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.isis.core.metamodel.interactions.managed.PropertyInteraction;
 import org.apache.isis.core.metamodel.objectmanager.ObjectManager;
 import org.apache.isis.core.metamodel.spec.ManagedObject;
@@ -93,7 +94,8 @@ extends PublishingTestFactoryAbstract {
             fixtureScripts.runPersona(JpaTestDomainPersona.PurgeAll);
             break;
 
-        case ENTITY_UPDATE:
+        case PROPERTY_UPDATE:
+        case ACTION_EXECUTION:
         case ENTITY_REMOVAL:
 
             // given
@@ -120,7 +122,7 @@ extends PublishingTestFactoryAbstract {
             setupBookForJpa();
             break;
 
-        case ENTITY_UPDATE:
+        case PROPERTY_UPDATE:
 
             withBookDo(book->{
 
@@ -128,6 +130,20 @@ extends PublishingTestFactoryAbstract {
 
                 // when - direct change (circumventing the framework)
                 context.changeProperty(()->book.setName("Book #2"));
+
+                repository.persistAndFlush(book);
+
+            });
+
+            break;
+        case ACTION_EXECUTION:
+
+            withBookDo(book->{
+
+                context.runGiven();
+
+                // when - direct action method invocation (circumventing the framework)
+                context.executeAction(()->book.doubleThePrice());
 
                 repository.persistAndFlush(book);
 
@@ -155,30 +171,57 @@ extends PublishingTestFactoryAbstract {
     protected boolean interactionApiExecution(
             final PublishingTestContext context) {
 
-        assertEquals(ChangeScenario.ENTITY_UPDATE, context.getScenario(),
-                "interactionApiExecution does only support 'update' scenario");
-
         context.bind(commitListener);
 
-        // when
-        withBookDo(book->{
+        switch(context.getScenario()) {
 
-            context.runGiven();
+        case PROPERTY_UPDATE:
 
             // when
-            context.changeProperty(()->{
+            withBookDo(book->{
 
-                val bookAdapter = objectManager.adapt(book);
-                val propertyInteraction = PropertyInteraction.start(bookAdapter, "name", Where.OBJECT_FORMS);
-                val managedProperty = propertyInteraction.getManagedPropertyElseThrow(__->_Exceptions.noSuchElement());
-                val propertyModel = managedProperty.startNegotiation();
-                val propertySpec = managedProperty.getSpecification();
-                propertyModel.getValue().setValue(ManagedObject.of(propertySpec, "Book #2"));
-                propertyModel.submit();
+                context.runGiven();
+
+                // when
+                context.changeProperty(()->{
+
+                    val bookAdapter = objectManager.adapt(book);
+                    val propertyInteraction = PropertyInteraction.start(bookAdapter, "name", Where.OBJECT_FORMS);
+                    val managedProperty = propertyInteraction.getManagedPropertyElseThrow(__->_Exceptions.noSuchElement());
+                    val propertyModel = managedProperty.startNegotiation();
+                    val propertySpec = managedProperty.getSpecification();
+                    propertyModel.getValue().setValue(ManagedObject.of(propertySpec, "Book #2"));
+                    propertyModel.submit();
+
+                });
 
             });
 
-        });
+            break;
+        case ACTION_EXECUTION:
+
+            // when
+            withBookDo(book->{
+
+                context.runGiven();
+
+                // when
+                context.executeAction(()->{
+
+                    val bookAdapter = objectManager.adapt(book);
+
+                    val actionInteraction = ActionInteraction.start(bookAdapter, "doubleThePrice", Where.OBJECT_FORMS);
+                    val managedAction = actionInteraction.getManagedActionElseThrow(__->_Exceptions.noSuchElement());
+                    // this test action is always disabled, so don't enforce rules here, just invoke
+                    managedAction.invoke(Can.empty()); // no-arg action
+                });
+
+            });
+
+            break;
+        default:
+            throw _Exceptions.unmatchedCase(context.getScenario());
+        }
 
         return true;
     }
@@ -189,21 +232,41 @@ extends PublishingTestFactoryAbstract {
     protected boolean wrapperSyncExecutionNoRules(
             final PublishingTestContext context) {
 
-        assertEquals(ChangeScenario.ENTITY_UPDATE, context.getScenario(),
-                "wrapperSyncExecutionNoRules does only support 'update' scenario");
-
         context.bind(commitListener);
 
-        // when
-        withBookDo(book->{
+        switch(context.getScenario()) {
 
-            context.runGiven();
+        case PROPERTY_UPDATE:
 
-            // when - running synchronous
-            val syncControl = SyncControl.control().withSkipRules(); // don't enforce rules
-            context.changeProperty(()->wrapper.wrap(book, syncControl).setName("Book #2"));
+            // when
+            withBookDo(book->{
 
-        });
+                context.runGiven();
+
+                // when - running synchronous
+                val syncControl = SyncControl.control().withSkipRules(); // don't enforce rules
+                context.changeProperty(()->wrapper.wrap(book, syncControl).setName("Book #2"));
+
+            });
+
+            break;
+        case ACTION_EXECUTION:
+
+            // when
+            withBookDo(book->{
+
+                context.runGiven();
+
+                // when - running synchronous
+                val syncControl = SyncControl.control().withSkipRules(); // don't enforce rules
+                context.executeAction(()->wrapper.wrap(book, syncControl).doubleThePrice());
+
+            });
+
+            break;
+        default:
+            throw _Exceptions.unmatchedCase(context.getScenario());
+        }
 
         return true;
     }
@@ -212,24 +275,47 @@ extends PublishingTestFactoryAbstract {
     protected boolean wrapperSyncExecutionWithFailure(
             final PublishingTestContext context) {
 
-        assertEquals(ChangeScenario.ENTITY_UPDATE, context.getScenario(),
-                "wrapperSyncExecutionWithFailure does only support 'update' scenario");
-
         context.bind(commitListener);
 
-        // when
-        withBookDo(book->{
+        switch(context.getScenario()) {
 
-            context.runGiven();
+        case PROPERTY_UPDATE:
 
-            // when - running synchronous
-            val syncControl = SyncControl.control().withCheckRules(); // enforce rules
+            // when
+            withBookDo(book->{
 
-            assertThrows(DisabledException.class, ()->{
-                wrapper.wrap(book, syncControl).setName("Book #2"); // should fail with DisabledException
+                context.runGiven();
+
+                // when - running synchronous
+                val syncControl = SyncControl.control().withCheckRules(); // enforce rules
+
+                assertThrows(DisabledException.class, ()->{
+                    wrapper.wrap(book, syncControl).setName("Book #2"); // should fail with DisabledException
+                });
+
             });
 
-        });
+            break;
+        case ACTION_EXECUTION:
+
+            // when
+            withBookDo(book->{
+
+                context.runGiven();
+
+                // when - running synchronous
+                val syncControl = SyncControl.control().withCheckRules(); // enforce rules
+
+                assertThrows(DisabledException.class, ()->{
+                    wrapper.wrap(book, syncControl).doubleThePrice(); // should fail with DisabledException
+                });
+
+            });
+
+            break;
+        default:
+            throw _Exceptions.unmatchedCase(context.getScenario());
+        }
 
         return false;
     }

--- a/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryJpa.java
+++ b/regressiontests/stable/src/main/java/org/apache/isis/testdomain/publishing/PublishingTestFactoryJpa.java
@@ -86,7 +86,6 @@ extends PublishingTestFactoryAbstract {
 
     @Override
     protected void setupEntity(final PublishingTestContext context) {
-
         switch(context.getScenario()) {
         case ENTITY_CREATION:
 
@@ -101,7 +100,6 @@ extends PublishingTestFactoryAbstract {
             setupBookForJpa();
             break;
         }
-
     }
 
     // -- TESTS - PROGRAMMATIC


### PR DESCRIPTION
- [x] property change publishing for PrePersist (implement)
- [x] property change publishing for PrePersist (tests)
- [x] property change publishing for PreUpdate (implement)
- [x] property change publishing for PreUpdate (tests)
- [x] property change publishing for PreRemove (implement)
- [x] property change publishing for PreRemove (tests)
- [x] command publishing tests (property chances)
- [x] command publishing tests (actions)
- [x] execution publishing tests (property chances)
- [x] execution publishing tests (actions)