### PR TITLE
ISIS-2875 ArchitectureJdoRules should only check root entities which …

### DIFF
--- a/testing/archtestsupport/applib/src/main/java/org/apache/isis/testing/archtestsupport/applib/classrules/ArchitectureJdoRules.java
+++ b/testing/archtestsupport/applib/src/main/java/org/apache/isis/testing/archtestsupport/applib/classrules/ArchitectureJdoRules.java
@@ -170,10 +170,16 @@ public class ArchitectureJdoRules {
      * This is so that entities will have an alternative business key in addition to the system-defined surrogate
      * key.
      * </p>
+     *
+     * <p>
+     *     The rule does <i>not</i> apply to any entities that are subtype entities where there
+     *     is a supertype entity.
+     * </p>
      */
     public static ArchRule every_jdo_PersistenceCapable_with_DATASTORE_identityType_must_be_annotated_as_DataStoreIdentity() {
         return classes()
                 .that().areAnnotatedWith(PersistenceCapable_with_DATASTORE_identityType())
+                .and(not(areSubtypeEntities()))
                 .should().beAnnotatedWith(javax.jdo.annotations.DatastoreIdentity.class);
     }
 

--- a/testing/archtestsupport/applib/src/test/java/org/apache/isis/testing/archtestsupport/applib/entity/jdo/dom/JdoEntity2.java
+++ b/testing/archtestsupport/applib/src/test/java/org/apache/isis/testing/archtestsupport/applib/entity/jdo/dom/JdoEntity2.java
@@ -20,16 +20,15 @@ package org.apache.isis.testing.archtestsupport.applib.entity.jdo.dom;
 
 import java.util.Comparator;
 
-import javax.jdo.annotations.PersistenceCapable;
-import javax.jdo.annotations.Unique;
-import javax.jdo.annotations.Version;
+import javax.jdo.annotations.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Nature;
 import org.apache.isis.applib.jaxb.PersistentEntityAdapter;
 
-@PersistenceCapable(schema = "jdo")
+@PersistenceCapable(schema = "jdo", identityType = IdentityType.DATASTORE)
+@DatastoreIdentity
 @Unique(name = "name", members = {"name"})
 @Version
 @DomainObject(nature = Nature.ENTITY)

--- a/testing/archtestsupport/applib/src/test/java/org/apache/isis/testing/archtestsupport/applib/entity/jdo/dom/JdoEntitySubtype.java
+++ b/testing/archtestsupport/applib/src/test/java/org/apache/isis/testing/archtestsupport/applib/entity/jdo/dom/JdoEntitySubtype.java
@@ -18,6 +18,7 @@
  */
 package org.apache.isis.testing.archtestsupport.applib.entity.jdo.dom;
 
+import javax.jdo.annotations.IdentityType;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
@@ -25,7 +26,7 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Nature;
 import org.apache.isis.applib.jaxb.PersistentEntityAdapter;
 
-@PersistenceCapable(schema = "jdo")
+@PersistenceCapable(schema = "jdo", identityType = IdentityType.DATASTORE)
 @DomainObject(nature = Nature.ENTITY)
 @XmlJavaTypeAdapter(PersistentEntityAdapter.class)
 public class JdoEntitySubtype extends JdoEntity2<JdoEntitySubtype> {


### PR DESCRIPTION
…have identityType defined in their @PersistenceCapable annotation and not subclasses of that entity!