### PR TITLE
Added @ComponentScan to IsisModuleSubdomainsDocxApplib

### DIFF
--- a/subdomains/docx/applib/src/main/java/org/apache/isis/subdomains/docx/applib/IsisModuleSubdomainsDocxApplib.java
+++ b/subdomains/docx/applib/src/main/java/org/apache/isis/subdomains/docx/applib/IsisModuleSubdomainsDocxApplib.java
@@ -18,9 +18,11 @@
  */
 package org.apache.isis.subdomains.docx.applib;
 
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ComponentScan
 public class IsisModuleSubdomainsDocxApplib {
 
 }


### PR DESCRIPTION
so Docx beans are actually registered in the Spring application context