### PR TITLE
Isis 2878

### DIFF
--- a/examples/demo/domain/pom.xml
+++ b/examples/demo/domain/pom.xml
@@ -27,29 +27,63 @@
 	<properties>
 	</properties>
 
-	<build>
-		<resources>
-			<resource>
-				<filtering>true</filtering>
-				<directory>src/main/resources</directory>
-				<includes>
-					<include>application.yml</include>
-				</includes>
-			</resource>
-			<resource>
-				<filtering>false</filtering>
-				<directory>src/main/resources</directory>
-			</resource>
-			<resource>
-				<filtering>false</filtering>
-				<directory>src/main/java</directory>
-				<includes>
-					<!-- we include all .java too, so that we can reference it from the descriptions -->
-					<include>**</include>
-				</includes>
-			</resource>
-		</resources>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>unpack-jar-features</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <echo>Copy jar to source project</echo>
+                                <copy todir="${project.build.directory}/classes">
+                                    <fileset dir="${project.basedir}/../../../incubator/clients/kroviz/build/libs/">
+                                        <include name="*.jar"/>
+                                        <exclude name="*sources.jar"/>
+                                    </fileset>
+                                </copy>
+                                <echo>Unpack jar</echo>echo>
+                                <unzip dest="${project.build.directory}/classes">
+                                    <fileset dir="${project.build.directory}/classes">
+                                        <include name="*.jar"/>
+                                    </fileset>
+                                </unzip>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>application.yml</include>
+                </includes>
+            </resource>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/java</directory>
+                <includes>
+                    <!-- we include all .java too, so that we can reference it from the descriptions -->
+                    <include>**</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
 
 	<dependencies>
 
@@ -106,7 +140,7 @@
             <groupId>org.apache.isis.valuetypes</groupId>
             <artifactId>isis-valuetypes-markdown-applib</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.isis.extensions</groupId>
             <artifactId>isis-extensions-fullcalendar-applib</artifactId>

--- a/examples/demo/domain/pom.xml
+++ b/examples/demo/domain/pom.xml
@@ -28,40 +28,6 @@
 	</properties>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <execution>
-                        <id>unpack-jar-features</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <echo>Copy jar to source project</echo>
-                                <copy todir="${project.build.directory}/classes">
-                                    <fileset dir="${project.basedir}/../../../incubator/clients/kroviz/build/libs/">
-                                        <include name="*.jar"/>
-                                        <exclude name="*sources.jar"/>
-                                    </fileset>
-                                </copy>
-                                <echo>Unpack jar</echo>echo>
-                                <unzip dest="${project.build.directory}/classes">
-                                    <fileset dir="${project.build.directory}/classes">
-                                        <include name="*.jar"/>
-                                    </fileset>
-                                </unzip>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -88,6 +54,12 @@
 	<dependencies>
 
 		<!-- EXTENSIONS -->
+
+		<dependency>
+			<groupId>org.apache.isis.incubator.clients</groupId>
+			<artifactId>isis-client-kroviz</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.isis.extensions</groupId>

--- a/examples/demo/domain/src/main/resources/static/index.html
+++ b/examples/demo/domain/src/main/resources/static/index.html
@@ -66,7 +66,7 @@
                 </li>
                 <li>
                     <p>
-                        <b><a href="kroviz/">EXPERIMENTAL: Generic UI client, based on the Restful Objects Viewer</a></b>
+                        <b><a href="kroviz/index.html">EXPERIMENTAL: Generic UI client, based on the Restful Objects Viewer</a></b>
                     </p>
                     <p>
                         provides access to a generic UI client for end-users.

--- a/examples/demo/domain/src/main/resources/static/index.html
+++ b/examples/demo/domain/src/main/resources/static/index.html
@@ -64,6 +64,17 @@
                         <a href="http://restfulobjects.org"  target="_blank">Restful Objects</a> spec.
                     </p>
                 </li>
+                <li>
+                    <p>
+                        <b><a href="kroviz/">EXPERIMENTAL: Generic UI client, based on the Restful Objects Viewer</a></b>
+                    </p>
+                    <p>
+                        provides access to a generic UI client for end-users.
+                        This viewer is written in Kotlin/JS and built on top of
+                        <a href="https://kvision.gitbook.io/kvision-guide/" target="_blank">KVision</a>&trade;.
+                        This viewer is still in the Apache Isis Incubator - use at your own risk and please report bugs.
+                    </p>
+                </li>
             </ul>
 
             <p>

--- a/examples/demo/pom.xml
+++ b/examples/demo/pom.xml
@@ -212,6 +212,11 @@
 			<groupId>org.apache.isis.extensions</groupId>
 			<artifactId>isis-extensions-secman-shiro-realm</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.isis.incubator.clients</groupId>
+			<artifactId>isis-client-kroviz</artifactId>
+			<version>2.0.0-SNAPSHOT</version>
+		</dependency>
 
 		<!-- OTHER DEPENDENCIES -->
 
@@ -238,12 +243,12 @@
 			</activation>
 			<modules>
 				<module>domain</module>
-				<module>javafx</module>
+				<!--module>javafx</module-->
 				<module>web</module>
 				<module>wicket/common</module>
 				<module>wicket/jdo</module>
 				<module>wicket/jpa</module>
-				<module>vaadin</module>
+				<!--module>vaadin</module-->
 			</modules>
 		</profile>
 

--- a/examples/demo/pom.xml
+++ b/examples/demo/pom.xml
@@ -243,12 +243,12 @@
 			</activation>
 			<modules>
 				<module>domain</module>
-				<!--module>javafx</module-->
+				<module>javafx</module>
 				<module>web</module>
 				<module>wicket/common</module>
 				<module>wicket/jdo</module>
 				<module>wicket/jpa</module>
-				<!--module>vaadin</module-->
+				<module>vaadin</module>
 			</modules>
 		</profile>
 

--- a/incubator/clients/kroviz/build.gradle.kts
+++ b/incubator/clients/kroviz/build.gradle.kts
@@ -128,9 +128,9 @@ afterEvaluate {
                 ).destinationDirectory
             from(distribution) {
                 include("**/*.*")
-                into("/static/kroviz/")
+                into("/public/kroviz/")
             }
-            from(webDir) { into("/static/kroviz/") }
+            from(webDir) { into("/public/kroviz/") }
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             inputs.files(distribution, webDir)
             outputs.file(archiveFile)

--- a/incubator/clients/kroviz/build.gradle.kts
+++ b/incubator/clients/kroviz/build.gradle.kts
@@ -127,10 +127,10 @@ afterEvaluate {
                     KotlinWebpack::class
                 ).destinationDirectory
             from(distribution) {
-                include("*.*")
-                into("/resources/static/")
+                include("**/*.*")
+                into("/static/kroviz/")
             }
-            from(webDir) { into("/resources/static/") }
+            from(webDir) { into("/static/kroviz/") }
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             inputs.files(distribution, webDir)
             outputs.file(archiveFile)

--- a/incubator/clients/kroviz/build.gradle.kts
+++ b/incubator/clients/kroviz/build.gradle.kts
@@ -117,7 +117,7 @@ kotlin {
 
 afterEvaluate {
     tasks {
-        create("jar", Zip::class) {
+        create("jar", Jar::class) {
             dependsOn("browserProductionWebpack")
             group = "package"
             destinationDirectory.set(file("$buildDir/libs"))
@@ -128,8 +128,9 @@ afterEvaluate {
                 ).destinationDirectory
             from(distribution) {
                 include("*.*")
+                into("/resources/static/")
             }
-            from(webDir)
+            from(webDir) { into("/resources/static/") }
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             inputs.files(distribution, webDir)
             outputs.file(archiveFile)

--- a/incubator/clients/kroviz/pom.xml
+++ b/incubator/clients/kroviz/pom.xml
@@ -105,6 +105,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>gradle-build-jar</id>

--- a/incubator/clients/kroviz/pom.xml
+++ b/incubator/clients/kroviz/pom.xml
@@ -109,10 +109,14 @@
                     <execution>
                         <id>gradle-build-jar</id>
                         <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
                         <configuration>
                             <executable>${gradle.executable}</executable>
                             <arguments>
                                 <argument>clean</argument>
+                                <argument>build</argument>
                                 <argument>jar</argument>
                                 <argument>-Pgroup=${project.groupId}</argument>
                                 <argument>-Pversion=${project.version}</argument>
@@ -121,23 +125,35 @@
                                 <argument>${gradle.skipBrowserTests}</argument>
                             </arguments>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-jar</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
-                    </execution>
-                    <execution>
-                        <id>copy-and-rename-jar</id>
-                        <phase>package</phase>
                         <configuration>
                             <executable>cp</executable>
                             <arguments>
                                 <argument>${project.basedir}/build/libs/*.jar</argument>
-                                <argument>${project.build.directory}/${project.artifactId}-${project.version}.jar</argument>
+                                <argument>${project.build.directory}</argument>
                             </arguments>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <id>rename-jar</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
+                        <configuration>
+                            <executable>mv</executable>
+                            <arguments>
+                                <argument>${project.build.directory}/kroviz-${project.version}.jar</argument>
+                                <argument>${project.build.directory}/${project.artifactId}-${project.version}.jar
+                                </argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/incubator/clients/kroviz/pom.xml
+++ b/incubator/clients/kroviz/pom.xml
@@ -38,8 +38,8 @@
 
     <!-- see: http://andresalmiray.com/running-gradle-inside-maven/ -->
     <profiles>
-    
-    	<!-- GRADLE WRAPPER SCRIPT AUTO SELECT -->
+
+        <!-- GRADLE WRAPPER SCRIPT AUTO SELECT -->
         <profile>
             <id>windows</id>
             <activation>
@@ -62,58 +62,58 @@
                 <gradle.executable>./gradlew.sh</gradle.executable>
             </properties>
         </profile>
-        
+
         <!-- GRADLE BUILD TASK SELECTIVE SKIPPING -->
         <profile>
-        	<id>skipTests</id>
-			<activation>
-				<property>
-					<name>skipTests</name>
-				</property>
-			</activation>
-			<properties>
+            <id>skipTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                </property>
+            </activation>
+            <properties>
                 <gradle.skipTests>-xtest</gradle.skipTests>
                 <gradle.skipBrowserTests>-xbrowserTest</gradle.skipBrowserTests>
             </properties>
         </profile>
         <profile>
-        	<id>skipBrowserTests</id>
-			<activation>
-				<property>
-					<name>!browserTests</name>
-				</property>
-			</activation>
-			<properties>
+            <id>skipBrowserTests</id>
+            <activation>
+                <property>
+                    <name>!browserTests</name>
+                </property>
+            </activation>
+            <properties>
                 <gradle.skipBrowserTests>-xbrowserTest</gradle.skipBrowserTests>
             </properties>
         </profile>
-        
+
     </profiles>
 
     <build>
-    
-    	<resources>
-    		<resource>
-    			<filtering>false</filtering>
-    			<directory>**</directory>
-    		</resource>
-    	</resources>
-    
+
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>**</directory>
+            </resource>
+        </resources>
+
         <plugins>
-        
+
             <!-- execute Gradle command -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>gradle</id>
-                        <phase>prepare-package</phase>
+                        <id>gradle-build-jar</id>
+                        <phase>process-resources</phase>
                         <configuration>
                             <executable>${gradle.executable}</executable>
                             <arguments>
-                                <argument>clean</argument>
-                                <argument>build</argument>
+                                <!--argument>clean</argument>
+                                <argument>build</argument-->
                                 <argument>jar</argument>
                                 <argument>-Pgroup=${project.groupId}</argument>
                                 <argument>-Pversion=${project.version}</argument>
@@ -126,8 +126,23 @@
                             <goal>exec</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>copy-and-rename-jar</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <executable>cp</executable>
+                            <arguments>
+                                <argument>${project.basedir}/build/libs/*.jar</argument>
+                                <argument>${project.build.directory}/${project.artifactId}-${project.version}.jar</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
+
         </plugins>
     </build>
 

--- a/incubator/clients/kroviz/pom.xml
+++ b/incubator/clients/kroviz/pom.xml
@@ -114,6 +114,7 @@
                             <arguments>
                                 <argument>clean</argument>
                                 <argument>build</argument>
+                                <argument>jar</argument>
                                 <argument>-Pgroup=${project.groupId}</argument>
                                 <argument>-Pversion=${project.version}</argument>
                                 <argument>-S</argument>

--- a/incubator/clients/kroviz/pom.xml
+++ b/incubator/clients/kroviz/pom.xml
@@ -136,7 +136,7 @@
                         <configuration>
                             <executable>cp</executable>
                             <arguments>
-                                <argument>${project.basedir}/build/libs/*.jar</argument>
+                                <argument>${project.basedir}/build/libs/kroviz-${project.version}.jar</argument>
                                 <argument>${project.build.directory}</argument>
                             </arguments>
                         </configuration>

--- a/incubator/clients/kroviz/pom.xml
+++ b/incubator/clients/kroviz/pom.xml
@@ -24,9 +24,9 @@
 
     <groupId>org.apache.isis.incubator.clients</groupId>
     <artifactId>isis-client-kroviz</artifactId>
-    <name>Apache Isis Inc - Client kroViz</name>
+    <name>Apache Isis Incubator - Client kroViz</name>
     <description>
-        Initial sketches
+        Web client based on RESTful API
     </description>
 
     <properties>
@@ -112,8 +112,7 @@
                         <configuration>
                             <executable>${gradle.executable}</executable>
                             <arguments>
-                                <!--argument>clean</argument>
-                                <argument>build</argument-->
+                                <argument>clean</argument>
                                 <argument>jar</argument>
                                 <argument>-Pgroup=${project.groupId}</argument>
                                 <argument>-Pversion=${project.version}</argument>

--- a/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/core/event/LogEntry.kt
+++ b/incubator/clients/kroviz/src/main/kotlin/org/apache/isis/client/kroviz/core/event/LogEntry.kt
@@ -58,9 +58,10 @@ data class LogEntry(
     val request: String = "",
     @Contextual val createdAt: Date = Date()
 ) {
-    val url: String = rs.url
-
-    val subType = rs.subType
+    val url: String = rs?.url
+        //?. is required, otherwise Tabulator.js/EventLogTable shows no entries
+    val subType = rs?.subType
+    //?. is required, otherwise Tabulator.js/EventLogTable shows no entries
     var state = EventState.INITIAL
     var title: String = ""
     var requestLength: Int = 0 // must be accessible (public) for LogEntryTable

--- a/incubator/pom.xml
+++ b/incubator/pom.xml
@@ -184,7 +184,7 @@
 	</dependencies>
 
 	<modules>
-<!-- 		<module>clients/kroviz</module> -->
+ 		<module>clients/kroviz</module>
 		<module>viewers/vaadin</module>
 		<module>viewers/javafx</module>
 		<module>../valuetypes/prism/vaadin</module>


### PR DESCRIPTION
The kroviz jar created via `mvn clean install -DskipTests ` is not the same as the one created via `gradle jar`.
Eventually the use of maven-antrun-plugin could be omitted all together (or replaced by maven-dependency-plugin).

The most elegant way to integrate would be a simple addition of 
```
<dependency>
    <groupId>org.apache.isis.incubator.clients</groupId>
     <artifactId>isis-client-kroviz</artifactId>
     <version>${project.version}</version>
</dependency>
```
to demo/domain/pom.xml - once the jar is in the classpath, resources under /public should be available.