### PR TITLE
ISIS-2209: fix broken contributing link

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,3 +1,3 @@
 = Contributing
 
-You can find full details of how to contribute back to Isis at our https://isis.apache.org/conguide/2.0.0-M4/contributing.html[main website].
+You can find full details of how to contribute back to Isis at our https://isis.apache.org/conguide/2.0.0-M7/contributing.html[main website].


### PR DESCRIPTION
This fixes the broken contribution info link for Apache Isis.