### PR TITLE
ISIS-3249: adds note on logging in to Jira for contribution

### DIFF
--- a/antora/components/conguide/modules/ROOT/pages/contributing.adoc
+++ b/antora/components/conguide/modules/ROOT/pages/contributing.adoc
@@ -31,7 +31,7 @@ That is:
 . you set the https://github.com/apache/isis.git[github.com/apache/isis] as your upstream branch; this will allow you to keep your local clone up-to-date with new commits
 * note the asymmetry here: the `upstream` repo (the Apache GitHub repo) is *not* the same as the `origin` repo (your fork).
 . you work on your changes locally; when done, you push them to your GitHub fork
-. to contribute back a change, raise a https://issues.apache.org/jira/browse/ISIS[JIRA] ticket, and ensure your commit message is in the form: `ISIS-nnnn: ...` so that changes can be tracked (more discussion on this point below).
+. to contribute back a change, raise a https://issues.apache.org/jira/browse/ISIS[JIRA] ticket (you will need to log in or create a new account first), and ensure your commit message is in the form: `ISIS-nnnn: ...` so that changes can be tracked (more discussion on this point below).
 In any case, before you decide to start hacking with Apache Isis, it's always worth creating a ticket in JIRA and then have a discussion about it on the xref:docs:support:mailing-list.adoc[mailing lists].
 . Use GitHub to raise a https://help.github.com/articles/using-pull-requests/[pull request] for your feature
 . An Apache Isis committer will review your change, and apply it if suitable.


### PR DESCRIPTION
A proposal to extend the contributing doc to have a note for new contributors that they need to create an account and log in to Jira first before being able to create an issue for their contributions. 

This was from my personal experience when I first started contributing here, and as not all open-source projects have Jira set up as part of the contribution flow it might prove to be a potential source of confusion for others as well.

The text I've put in here for the PR is just a draft starting point - happy to amend it as required.