### PR TITLE
ISIS-3328: HTML Documentation Service based on the domain model

### DIFF
--- a/api/applib/src/main/java/module-info.java
+++ b/api/applib/src/main/java/module-info.java
@@ -64,6 +64,7 @@ module org.apache.causeway.applib {
     exports org.apache.causeway.applib.services.commanddto;
     exports org.apache.causeway.applib.services.confview;
     exports org.apache.causeway.applib.services.conmap;
+    exports org.apache.causeway.applib.services.documentation;
     exports org.apache.causeway.applib.services.email;
     exports org.apache.causeway.applib.services.error;
     exports org.apache.causeway.applib.services.eventbus;

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/documentation/DocumentationService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/documentation/DocumentationService.java
@@ -1,0 +1,30 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.applib.services.documentation;
+
+/**
+ * Provides a documentation based on the menu bar layout.
+ *
+ * @since 2.x {@index}
+ */
+public interface DocumentationService {
+
+    String toDocumentationHtml();
+
+}

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/documentation/DocumentationServiceMenu.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/documentation/DocumentationServiceMenu.java
@@ -1,0 +1,78 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.applib.services.documentation;
+
+import javax.inject.Named;
+
+import org.apache.causeway.applib.CausewayModuleApplib;
+import org.apache.causeway.applib.annotation.Action;
+import org.apache.causeway.applib.annotation.ActionLayout;
+import org.apache.causeway.applib.annotation.DomainService;
+import org.apache.causeway.applib.annotation.DomainServiceLayout;
+import org.apache.causeway.applib.annotation.MemberSupport;
+import org.apache.causeway.applib.annotation.PriorityPrecedence;
+import org.apache.causeway.applib.annotation.RestrictTo;
+import org.apache.causeway.applib.annotation.SemanticsOf;
+import org.apache.causeway.applib.value.Markup;
+
+/**
+ * Simply provides a UI to for the generation of a documentation (obtained from {@link DocumentationService}).
+ *
+ * @since 2.x {@index}
+ */
+@Named(DocumentationServiceMenu.LOGICAL_TYPE_NAME)
+@DomainService()
+@DomainServiceLayout(
+        named = "Prototyping",
+        menuBar = DomainServiceLayout.MenuBar.SECONDARY
+)
+@javax.annotation.Priority(PriorityPrecedence.EARLY)
+public class DocumentationServiceMenu {
+
+    public static final String LOGICAL_TYPE_NAME = CausewayModuleApplib.NAMESPACE + ".DocumentationServiceMenu";
+
+    public static abstract class ActionDomainEvent<T> extends CausewayModuleApplib.ActionDomainEvent<T> {}
+
+    private final DocumentationService documentationService;
+
+    public DocumentationServiceMenu(final DocumentationService DocumentationService) {
+        this.documentationService = DocumentationService;
+    }
+
+    @Action(
+            domainEvent = downloadDocumentation.ActionDomainEvent.class,
+            semantics = SemanticsOf.NON_IDEMPOTENT, //disable client-side caching
+            restrictTo = RestrictTo.PROTOTYPING
+            )
+    @ActionLayout(
+            cssClassFa = "fa-download",
+            named = "The application-level help & documentation",
+            sequence="500.450.2")
+    public class downloadDocumentation{
+
+        public class ActionDomainEvent extends DocumentationServiceMenu.ActionDomainEvent<downloadDocumentation> {}
+
+        @MemberSupport public Markup act() {
+            final String html = documentationService.toDocumentationHtml();
+            return new Markup(html);
+        }
+
+    }
+
+}

--- a/core/metamodel/src/main/java/module-info.java
+++ b/core/metamodel/src/main/java/module-info.java
@@ -50,6 +50,7 @@ open module org.apache.causeway.core.metamodel {
     exports org.apache.causeway.core.metamodel.facets.object.domainservice;
     exports org.apache.causeway.core.metamodel.facets.object.domainservicelayout;
     exports org.apache.causeway.core.metamodel.facets.object.entity;
+    exports org.apache.causeway.core.metamodel.facets.object.grid;
     exports org.apache.causeway.core.metamodel.facets.object.icon;
     exports org.apache.causeway.core.metamodel.facets.object.mixin;
     exports org.apache.causeway.core.metamodel.facets.object.objectvalidprops;

--- a/core/runtimeservices/src/main/java/module-info.java
+++ b/core/runtimeservices/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module org.apache.causeway.core.runtimeservices {
     exports org.apache.causeway.core.runtimeservices;
     exports org.apache.causeway.core.runtimeservices.bookmarks;
     exports org.apache.causeway.core.runtimeservices.command;
+    exports org.apache.causeway.core.runtimeservices.documentation;
     exports org.apache.causeway.core.runtimeservices.email;
     exports org.apache.causeway.core.runtimeservices.eventbus;
     exports org.apache.causeway.core.runtimeservices.executor;

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/documentation/DocumentationServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/documentation/DocumentationServiceDefault.java
@@ -1,0 +1,269 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.core.runtimeservices.documentation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.causeway.applib.annotation.DomainObject;
+import org.apache.causeway.applib.annotation.PriorityPrecedence;
+import org.apache.causeway.applib.layout.component.ActionLayoutData;
+import org.apache.causeway.applib.layout.component.CollectionLayoutData;
+import org.apache.causeway.applib.layout.component.FieldSet;
+import org.apache.causeway.applib.layout.component.PropertyLayoutData;
+import org.apache.causeway.applib.layout.component.ServiceActionLayoutData;
+import org.apache.causeway.applib.layout.grid.Grid;
+import org.apache.causeway.applib.layout.menubars.MenuBars;
+import org.apache.causeway.applib.layout.menubars.bootstrap.BSMenuBars;
+import org.apache.causeway.applib.services.documentation.DocumentationService;
+import org.apache.causeway.applib.services.homepage.HomePageResolverService;
+import org.apache.causeway.applib.services.i18n.TranslationContext;
+import org.apache.causeway.applib.services.i18n.TranslationService;
+import org.apache.causeway.applib.services.menu.MenuBarsService;
+import org.apache.causeway.commons.internal.base._NullSafe;
+import org.apache.causeway.commons.internal.base._Strings;
+import org.apache.causeway.core.metamodel.facets.all.described.MemberDescribedFacet;
+import org.apache.causeway.core.metamodel.facets.all.i8n.staatic.HasStaticText;
+import org.apache.causeway.core.metamodel.facets.object.grid.GridFacet;
+import org.apache.causeway.core.metamodel.spec.ActionScope;
+import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
+import org.apache.causeway.core.metamodel.spec.feature.ObjectAction;
+import org.apache.causeway.core.metamodel.specloader.SpecificationLoader;
+import org.apache.causeway.core.runtimeservices.CausewayModuleCoreRuntimeServices;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Named(CausewayModuleCoreRuntimeServices.NAMESPACE + ".DocumentationServiceDefault")
+@Priority(PriorityPrecedence.MIDPOINT)
+@Qualifier("Default")
+@RequiredArgsConstructor(onConstructor_ = {@Inject})
+//@Log4j2
+public class DocumentationServiceDefault implements DocumentationService {
+
+    private final SpecificationLoader specificationLoader;
+    private final MenuBarsService menuBarsService;
+    private final HomePageResolverService homePageResolverService;
+    private final TranslationService translationService;
+
+    @Override
+    public String toDocumentationHtml() {
+        final StringBuilder html = new StringBuilder();
+        Object homePage = homePageResolverService.getHomePage();
+        if (homePage != null) {
+            specificationLoader.specForType(homePage.getClass()).ifPresent(homeSpec -> {
+                html.append(String.format("<i>%s</i>\n", homeSpec.getDescription()));
+                html.append("</br><i>").append(translationService.translate(TranslationContext.empty(), "To know more about full terminology"));
+                html.append(" <a href='#allObjectSpecs'>").append(translationService.translate(TranslationContext.empty(), "click here")).append("</a></i>\n");
+                html.append("<hr></hr>");
+                html.append("<h3>").append(translationService.translate(TranslationContext.empty(), "Application Home Page")).append("</h3>");
+                html.append(documentationForObjectType(homeSpec));
+                html.append("<hr></hr>");
+            });
+        }
+        html.append("<h3>").append(translationService.translate(TranslationContext.empty(), "Menu Actions")).append("</h3>");
+
+        Map<String, ObjectSpecification> domainObjects = new HashMap<>();
+
+        MenuBars menuBars = menuBarsService.menuBars(MenuBarsService.Type.DEFAULT);
+        html.append("<ol>");
+        menuBars.visit(BSMenuBars.VisitorAdapter.visitingMenus(menu -> {
+            String menuName = menu.getNamed();
+            if (_Strings.isNotEmpty(menuName)) {
+
+                html.append(String.format("<li><h4>%s</h4></li>\n", menuName));
+
+                html.append("<ol>");
+                _NullSafe.stream(menu.getSections())
+                        .forEach(menuSection -> {
+                            String sectionName = menuSection.getNamed();
+                            if (_Strings.isNotEmpty(sectionName)) {
+                                html.append(String.format("<li><h5>%s</h5></li>\n", sectionName));
+
+                                html.append("<ul>");
+                                _NullSafe.stream(menuSection.getServiceActions())
+                                        .map(this::lookupAction)
+                                        .flatMap(Optional::stream)
+                                        .forEach(menuAction -> {
+                                            html.append(String.format("<li>%s: ", menuAction.getCanonicalFriendlyName()));
+                                            menuAction.getCanonicalDescription()
+                                                    .ifPresent(describedAs -> {
+                                                        html.append(String.format("<b>%s</b>.", describedAs));
+                                                    });
+                                            ObjectSpecification actionReturnType = menuAction.getReturnType();
+                                            ObjectSpecification actionElementType = menuAction.getElementType();
+
+                                            if (actionElementType.getCorrespondingClass() == void.class) {
+                                                html.append("<i></i>"); //WARNING : NOTHING
+                                            } else if (actionReturnType.isPlural()) {
+                                                domainObjects.put(actionElementType.getLogicalTypeName(), actionElementType);
+                                                html.append(String.format(" <i> %s: <a href='#%s'>%s</a>\n</i>"
+                                                        , translationService.translate(TranslationContext.empty(), "See"), actionElementType.getLogicalTypeName(), actionElementType.getSingularName()));
+                                            } else {
+                                                domainObjects.put(actionReturnType.getLogicalTypeName(), actionReturnType);
+                                                html.append(String.format(" <i> %s: <a href='#%s'>%s</a>\n</i>"
+                                                        , translationService.translate(TranslationContext.empty(), "See"), actionElementType.getLogicalTypeName(), actionElementType.getSingularName()));
+                                            }
+                                            html.append("</li>");
+                                        });
+                                html.append("</ul>");
+                            }
+                        });
+                html.append("</ol>");
+            }
+        }));
+        html.append("</ol>");
+
+        html.append("<hr></hr>");
+        html.append("<h2 id='allObjectSpecs'>").append(translationService.translate(TranslationContext.empty(), "Terminology")).append("</h2>");
+        html.append("<ol>");
+        for (ObjectSpecification objectSpec : domainObjects.values()) {
+            if (objectSpec != null) {
+                html.append(String.format("<li id='%s'><h3>%s</h3></li>\n",
+                        objectSpec.getLogicalTypeName(), objectSpec.getSingularName()));
+                html.append(objectSpec.getDescription());
+                html.append(".");
+                html.append(String.format("%s\n", documentationForObjectType(objectSpec)));
+            }
+        }
+        html.append("</ol>");
+        return html.toString();
+    }
+
+    // -- HELPER
+
+    private StringBuffer documentationForObjectType(ObjectSpecification objectSpec) {
+        StringBuffer html = new StringBuffer();
+
+        Grid grid = toGrid(objectSpec.getCorrespondingClass());
+        html.append("<ul>");
+        {
+            html.append("<ul>");
+            {
+                for (ActionLayoutData layout : grid.getAllActionsById().values()) {
+                    objectSpec.getAction(layout.getId(), ActionScope.PRODUCTION_ONLY)
+                            .ifPresent(member -> {
+                                if (!"clearHints".equals(member.getId()) && !member.isAlwaysHidden()) {
+                                    String describedAs = member.getCanonicalDescription()
+                                            .map(desc -> String.format("%s", desc))
+                                            .orElse("");
+                                    html.append(String.format("<li><i class='%s'></i><b>%s</b>: %s.</li>\n",
+                                            _Strings.isNotEmpty(layout.getCssClassFa()) ? layout.getCssClassFa() : "fa fa-faw fa-location-arrow",
+                                            member.getCanonicalFriendlyName(),
+                                            describedAs));
+                                }
+                            });
+                }
+            }
+            html.append("</ul>");
+            html.append("<ul>");
+            {
+                for (CollectionLayoutData layout : grid.getAllCollectionsById().values()) {
+                    objectSpec.getCollection(layout.getId())
+                            .ifPresent(member -> {
+                                if (!member.isAlwaysHidden()) {
+                                    String description = null;
+                                    if (member.containsFacet(MemberDescribedFacet.class)) {
+                                        description = member.getFacet(MemberDescribedFacet.class).getSpecialization()
+                                                .left().map(HasStaticText::text).orElse(null);
+                                    }
+                                    if (_Strings.isNotEmpty(description)) {
+                                        description = layout.getDescribedAs();
+                                    }
+                                    html.append(String.format("<li><i class='%s'></i><b>%s</b>: %s.</li>\n",
+                                            "fa fa-fw fa-list",
+                                            member.getCanonicalFriendlyName(),
+                                            description != null ? description : ""));
+                                    // FIXME[ISIS-2883] also visit associated actions
+                                    // ... collection.streamAssociatedActions()
+                                    html.append("<ul>");
+                                    member.streamAssociatedActions().forEach(action -> {
+                                        html.append(String.format("<li><i class='%s'></i> <b>%s</b>: %s.</li>\n",
+                                                "fa fa-faw fa-location-arrow",
+                                                action.getCanonicalFriendlyName(),
+                                                action.getCanonicalDescription().orElse("")));
+                                    });
+                                    html.append("</ul>");
+                                }
+                            });
+                }
+            }
+            html.append("</ul>");
+            html.append("<ul>");
+            {
+                grid.visit(new Grid.VisitorAdapter() {
+                    @Override
+                    public void visit(final FieldSet fieldSet) {
+                        if (_NullSafe.isEmpty(fieldSet.getProperties())) {
+                            return;
+                        } else {
+                            html.append(String.format("<li>%s</li>\n", fieldSet.getName()));
+                            html.append("<ul>");
+                            for (PropertyLayoutData layout : fieldSet.getProperties()) {
+                                objectSpec.getProperty(layout.getId())
+                                        .ifPresent(member -> {
+                                            if (!member.isAlwaysHidden()) {
+                                                String describedAs = member.getCanonicalDescription()
+                                                        .map(desc -> String.format("%s", desc))
+                                                        .orElse("");
+                                                html.append(String.format("<li><b>%s</b>: %s.",
+                                                        member.getCanonicalFriendlyName(),
+                                                        describedAs));
+                                                if (member.getElementType().getLogicalType().getCorrespondingClass().isAnnotationPresent(DomainObject.class)) {
+                                                    html.append(String.format(" <i> See: <a href='#%s'>%s</a></i>",
+                                                            member.getElementType().getLogicalTypeName(),
+                                                            member.getElementType().getSingularName()));
+                                                } else {
+                                                    //none
+                                                }
+                                                html.append("</li>\n");
+                                            }
+                                        });
+                            }
+                            html.append("</ul>");
+                        }
+                    }
+                });
+            }
+            html.append("</ul>");
+        }
+        html.append("</ul>");
+        return html;
+    }
+
+    private Optional<ObjectAction> lookupAction(final ServiceActionLayoutData actionLayout) {
+        return specificationLoader
+                .specForLogicalTypeName(actionLayout.getLogicalTypeName())
+                .map(typeSpec -> typeSpec.getAction(actionLayout.getId(), ActionScope.PRODUCTION_ONLY).orElse(null));
+    }
+
+    private Grid toGrid(final Class<?> domainClass) {
+        return specificationLoader.specForType(domainClass)
+                .flatMap(spec -> spec.lookupFacet(GridFacet.class))
+                .map(gridFacet -> gridFacet.getGrid(null))
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
We have created new documentation service which creates the HTML documentation based on the menu and the domain model. Very similar to the sitemap, but in HTML, so the end user can directly show it together with autogenerated description.

I've migrated it into the latest version, I've just hasn't been able to test it. At least it worked fine in ISIS M7.