### PR TITLE
Add explicit workflow permissions for weekly build job

### DIFF
--- a/.github/workflows/ci-build-artifacts-push-maven.yml
+++ b/.github/workflows/ci-build-artifacts-push-maven.yml
@@ -6,6 +6,10 @@ on:
     # daily 02:00 (UTC) on Sunday morning
     - cron: '0 2 * * 0'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: build-local-push
@@ -107,4 +111,3 @@ jobs:
 #     env:
 #       MATRIX_CONTEXT: ${{ toJson(matrix) }}
 #     run: echo "$MATRIX_CONTEXT"
-


### PR DESCRIPTION
## Summary
- Add an explicit `permissions` block to `.github/workflows/ci-build-artifacts-push-maven.yml`.
- Scope token access to `contents: read` and `packages: write` for the deploy workflow.

## Why
Declaring explicit workflow token permissions follows least-privilege defaults and makes required access clear for scheduled automation.