### PR TITLE
CAUSEWAY-3997: [Layout] In-memory Patching of Table Column Order (Round 2)

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/services/appfeat/ApplicationFeatureRepository.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/appfeat/ApplicationFeatureRepository.java
@@ -20,12 +20,8 @@ package org.apache.causeway.applib.services.appfeat;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.SortedSet;
 
-import org.jspecify.annotations.Nullable;
-
-import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.id.LogicalType;
 
 /**
@@ -57,5 +53,4 @@ public interface ApplicationFeatureRepository  {
 
     SortedSet<ApplicationFeatureId> propertyIdsFor(LogicalType logicalType);
 
-    Optional<Identifier> asIdentifier(@Nullable ApplicationFeatureId applicationFeatureId);
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/columnorder/Object_patchColumnOrder.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/columnorder/Object_patchColumnOrder.java
@@ -40,8 +40,6 @@ import org.apache.causeway.applib.annotation.Publishing;
 import org.apache.causeway.applib.annotation.RestrictTo;
 import org.apache.causeway.applib.annotation.SemanticsOf;
 import org.apache.causeway.applib.layout.LayoutConstants;
-import org.apache.causeway.applib.services.appfeat.ApplicationFeatureId;
-import org.apache.causeway.applib.services.appfeat.ApplicationFeatureRepository;
 import org.apache.causeway.applib.services.metamodel.MetaModelService;
 import org.apache.causeway.applib.services.metamodel.MetaModelService.AssociationsLookup;
 import org.apache.causeway.applib.util.Listing;
@@ -80,7 +78,6 @@ public class Object_patchColumnOrder {
 	extends org.apache.causeway.applib.CausewayModuleApplib.ActionDomainEvent<Object_patchColumnOrder> {}
 
 	@Inject MetaModelService metaModelService;
-	@Inject ApplicationFeatureRepository applicationFeatureRepository;
 
     private final Object mixee;
 
@@ -95,7 +92,7 @@ public class Object_patchColumnOrder {
                     + "represents the domain-type itself or one of the domain-type's super types. "
                     + "The Apache Causeway Programming Model also supports {parent-type, element-type} scoped "
                     + "column order definitions, which are not covered by patching yet.")
-    		final ApplicationFeatureId featureId,
+    		final Identifier featureId,
 
     		@Parameter(precedingParamsPolicy = PrecedingParamsPolicy.RESET)
             @ParameterLayout(multiLine = 20, describedAs = "Automaticly filled in are all currently enabled and available "
@@ -103,45 +100,37 @@ public class Object_patchColumnOrder {
             		+ "Reorder or remove column-ids as desired.")
             final String columnListing) {
 
-    	var identifier = applicationFeatureRepository.asIdentifier(featureId)
-                .orElseThrow(); // not found -> unexpected
-
     	var listing = listingHandler().parseListing(columnListing);
     	var columns = Can.ofStream(listing.streamEnabled());
 
-    	metaModelService.patchColumnOrder(identifier, columns);
+    	metaModelService.patchColumnOrder(featureId, columns);
         return mixee;
     }
 
-    @MemberSupport public List<ApplicationFeatureId> choicesFeatureId() {
+    @MemberSupport public List<Identifier> choicesFeatureId() {
         return Stream.concat(
-                metaModelService.streamTypeHierarchy(mixee.getClass())
-                    .map(ApplicationFeatureId::fromIdentifier),
-                metaModelService.streamCollections(mixee.getClass())
-                    .map(ApplicationFeatureId::fromIdentifier))
+                metaModelService.streamTypeHierarchy(mixee.getClass()),
+                metaModelService.streamCollections(mixee.getClass()))
             .toList();
     }
 
-    @MemberSupport public String defaultColumnListing(final @Nullable ApplicationFeatureId featureId) {
+    @MemberSupport public String defaultColumnListing(final @Nullable Identifier featureId) {
         if(featureId==null)
             return "# no feature selected";
 
-        var identifier = applicationFeatureRepository.asIdentifier(featureId)
-                .orElseThrow(); // not found -> unexpected
-
-        if(identifier.type().isCollection())
+        if(featureId.type().isCollection())
             return listing(
-	                metaModelService.parentedAssociationsForColumnRendering(mixee, identifier, AssociationsLookup.AVAILABLE),
-	                metaModelService.parentedAssociationsForColumnRendering(mixee, identifier, AssociationsLookup.ENABLED))
+	                metaModelService.parentedAssociationsForColumnRendering(mixee, featureId, AssociationsLookup.AVAILABLE),
+	                metaModelService.parentedAssociationsForColumnRendering(mixee, featureId, AssociationsLookup.ENABLED))
         		.toString();
 
-        if(identifier.type().isClass())
+        if(featureId.type().isClass())
             return listing(
-	                metaModelService.standaloneAssociationsForColumnRendering(identifier.logicalType(), AssociationsLookup.AVAILABLE),
-	                metaModelService.standaloneAssociationsForColumnRendering(identifier.logicalType(), AssociationsLookup.ENABLED))
+	                metaModelService.standaloneAssociationsForColumnRendering(featureId.logicalType(), AssociationsLookup.AVAILABLE),
+	                metaModelService.standaloneAssociationsForColumnRendering(featureId.logicalType(), AssociationsLookup.ENABLED))
         		.toString();
 
-        throw _Exceptions.illegalArgument("unsupported feature type %s", identifier.type());
+        throw _Exceptions.illegalArgument("unsupported feature type %s", featureId.type());
     }
 
     // -- HELPER

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/CausewayModuleCoreMetamodel.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/CausewayModuleCoreMetamodel.java
@@ -90,6 +90,7 @@ import org.apache.causeway.core.metamodel.valuesemantics.ClobValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.CommandDtoValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.DoubleValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.FloatValueSemantics;
+import org.apache.causeway.core.metamodel.valuesemantics.IdentifierValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.IntValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.InteractionDtoValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.LocalResourcePathValueSemantics;
@@ -180,6 +181,7 @@ import org.apache.causeway.core.security.CausewayModuleCoreSecurity;
         JavaUtilDateValueSemantics.class,
         // Value Semantics (meta-model)
         ApplicationFeatureIdValueSemantics.class,
+        IdentifierValueSemantics.class,
 
         // @Service's
         ColumnOrderTxtFileServiceDefault.class,

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/services/appfeat/ApplicationFeatureRepositoryDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/services/appfeat/ApplicationFeatureRepositoryDefault.java
@@ -38,7 +38,6 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.stereotype.Service;
 
-import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.SemanticsOf;
 import org.apache.causeway.applib.events.metamodel.MetamodelListener;
 import org.apache.causeway.applib.id.LogicalType;
@@ -458,34 +457,6 @@ implements ApplicationFeatureRepository, MetamodelListener {
     public Map<String, ApplicationFeatureId> getFeatureIdentifiersByName() {
         initializeIfRequired();
         return featureIdentifiersByName;
-    }
-
-    @Override
-    public Optional<Identifier> asIdentifier(final @Nullable ApplicationFeatureId applicationFeatureId) {
-        return applicationFeatureId!=null
-            ? specificationLoader.specForLogicalTypeName(applicationFeatureId.getLogicalTypeName())
-                .map(ObjectSpecification::logicalType)
-                .map(logicalType->toIdentifier(applicationFeatureId, logicalType))
-            : Optional.empty();
-    }
-
-    // -- HELPER
-
-    private Identifier toIdentifier(final ApplicationFeatureId featureId, final LogicalType logicalType) {
-        return switch (featureId.getSort()) {
-            case MEMBER -> Optional.ofNullable(findMember(featureId))
-                .flatMap(ApplicationFeature::getMemberSort)
-                .map(memberSort->switch (memberSort) {
-                    case PROPERTY -> Identifier.propertyIdentifier(logicalType, featureId.getLogicalMemberName());
-                    case COLLECTION -> Identifier.collectionIdentifier(logicalType, featureId.getLogicalMemberName());
-                    case ACTION -> Identifier.actionIdentifier(logicalType, featureId.getLogicalMemberName());
-                    default -> null;
-                })
-                .orElse(null);
-            case TYPE -> Identifier.classIdentifier(logicalType);
-            case NAMESPACE -> null;
-            default -> null;
-        };
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/services/metamodel/MetaModelServiceDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/services/metamodel/MetaModelServiceDefault.java
@@ -352,10 +352,10 @@ public record MetaModelServiceDefault(
 	public void patchColumnOrder(final Identifier identifier, final Can<String> columnsInOrder) {
 		final ObjectSpecification elementType = switch (identifier.type()) {
 			case CLASS -> specificationLoader()
-				.specForLogicalType(identifier.logicalType())
-				.orElseThrow();
+                .specForLogicalType(identifier.logicalType())
+                .orElseThrow();
 			case COLLECTION -> specificationLoader()
-				.specForLogicalType(identifier.logicalType())
+                .specForLogicalType(identifier.logicalType())
 				.map(parentType->parentType.getCollectionElseFail(identifier.memberLogicalName()))
 				.map(OneToManyAssociation::getElementType)
 				.orElseThrow();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/feature/ObjectAssociationContainer.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/feature/ObjectAssociationContainer.java
@@ -167,6 +167,9 @@ public interface ObjectAssociationContainer {
     				|| memberIdentifier.type().isClass()
     				|| memberIdentifier.type().isAction();
     	}
+        public ColumnQuery toStandalone() {
+            return forStandaloneTable(mode);
+        }
     }
 
     /**

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/impl/_MembersAsColumns.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/impl/_MembersAsColumns.java
@@ -182,7 +182,7 @@ record _MembersAsColumns(
 
     	var patchedColumnOrder = elementType
 			.lookupFacet(ColumnOrderPatchingFacet.class)
-			.flatMap(it->it.lookupColumnOrder(columnQuery.memberIdentifier()))
+			.flatMap(it->it.lookupColumnOrder(identifier))
 			.orElse(null);
     	if(patchedColumnOrder==null)
     		return false;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/impl/_MembersAsColumns.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/impl/_MembersAsColumns.java
@@ -184,8 +184,15 @@ record _MembersAsColumns(
 			.lookupFacet(ColumnOrderPatchingFacet.class)
 			.flatMap(it->it.lookupColumnOrder(identifier))
 			.orElse(null);
-    	if(patchedColumnOrder==null)
-    		return false;
+
+    	if(patchedColumnOrder==null) {
+    	    // for the standalone case we are done
+    	    if(columnQuery.isStandalone())
+    	        return false;
+            // if the parented case is not patched, but we find a patch for the corresponding element-type,
+            // then use that as a fallback
+    	    return sortColumnsUsingPatch(columnQuery.toStandalone(), assocIdsInOrder, elementType);
+    	}
 
     	// intersect 'assocIdsInOrder' with 'patchedColumnOrder' while preserving order as given by the latter
     	var available = new HashSet<>(assocIdsInOrder);
@@ -223,7 +230,6 @@ record _MembersAsColumns(
                 assocIdsInOrder.clear();
                 assocIdsInOrder.addAll(assocReorderedIds);
             });
-
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/SpecificationLoader.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/SpecificationLoader.java
@@ -165,17 +165,14 @@ public interface SpecificationLoader {
     // -- FEATURE RECOVERY
 
     default Optional<ObjectFeature> loadFeature(final @Nullable Identifier featureIdentifier) {
-        if(featureIdentifier==null) {
+        if(featureIdentifier==null)
             return Optional.empty();
-        }
         var typeSpec = specForLogicalType(featureIdentifier.logicalType()).orElse(null);
-        if(typeSpec==null) {
+        if(typeSpec==null)
             return Optional.empty();
-        }
         var member = typeSpec.getMember(featureIdentifier.memberLogicalName()).orElse(null);
-        if(member==null) {
+        if(member==null)
             return Optional.empty();
-        }
 
         final int paramIndex = featureIdentifier.parameterIndex();
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IdentifierValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IdentifierValueSemantics.java
@@ -1,0 +1,148 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.core.metamodel.valuesemantics;
+
+import java.lang.reflect.Modifier;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Named;
+
+import org.springframework.stereotype.Component;
+
+import org.apache.causeway.applib.Identifier;
+import org.apache.causeway.applib.Identifier.Type;
+import org.apache.causeway.applib.annotation.PriorityPrecedence;
+import org.apache.causeway.applib.fa.FontAwesomeLayers;
+import org.apache.causeway.applib.id.LogicalType;
+import org.apache.causeway.applib.util.schema.CommonDtoUtils;
+import org.apache.causeway.applib.value.semantics.Renderer;
+import org.apache.causeway.applib.value.semantics.ValueDecomposition;
+import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
+import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
+import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.base._Strings;
+import org.apache.causeway.commons.internal.context._Context;
+import org.apache.causeway.schema.common.v2.ValueType;
+
+import lombok.SneakyThrows;
+
+@Component
+@Named("causeway.metamodel.value.IdentifierValueSemantics")
+@Priority(PriorityPrecedence.LATE)
+public class IdentifierValueSemantics
+extends ValueSemanticsAbstract<Identifier>
+implements
+    Renderer<Identifier> {
+
+    @Override
+    public Class<Identifier> getCorrespondingClass() {
+        return Identifier.class;
+    }
+
+    @Override
+    public ValueType getSchemaValueType() {
+        return ValueType.COMPOSITE;
+    }
+
+    // -- COMPOSER
+
+    @Override
+    public ValueDecomposition decompose(final Identifier value) {
+        return CommonDtoUtils.typedTupleBuilder(value)
+            .addFundamentalType(ValueType.STRING, "logicalName", it->it.logicalType().logicalName())
+            .addFundamentalType(ValueType.STRING, "className", it->it.logicalType().className())
+            .addFundamentalType(ValueType.STRING, "memberLogicalName", Identifier::memberLogicalName)
+            .addFundamentalType(ValueType.STRING, "memberParameterClassNames", it->it.memberParameterClassNames().join(","))
+            .addFundamentalType(ValueType.ENUM, "type", Identifier::type)
+            .addFundamentalType(ValueType.INT, "parameterIndex", Identifier::parameterIndex)
+            .buildAsDecomposition();
+    }
+
+    @Override @SneakyThrows
+    public Identifier compose(final ValueDecomposition decomposition) {
+
+        var elementMap = CommonDtoUtils.typedTupleAsMap(decomposition.composite());
+
+        LogicalType logicalType = new LogicalType(
+                (String)elementMap.get("logicalName"),
+                _Context.loadClass((String)elementMap.get("className")));
+        String memberLogicalName = (String)elementMap.get("memberLogicalName");
+        Can<String> memberParameterClassNames = _Strings.splitThenStream((String)elementMap.get("memberParameterClassNames"), ",")
+                .collect(Can.toCan());
+        Type type = (Type)elementMap.get("type");
+        int parameterIndex = (int)elementMap.get("parameterIndex");
+
+        return new Identifier(logicalType, memberLogicalName, memberParameterClassNames, type, parameterIndex);
+    }
+
+    // -- RENDERER
+
+    @Override
+    public String titlePresentation(final ValueSemanticsProvider.Context context, final Identifier value) {
+        return value == null ? "" : value.getFullIdentityString();
+    }
+
+    @Override
+    public String htmlPresentation(final ValueSemanticsProvider.Context context, final Identifier value) {
+        return renderHtml(value, this::iconify);
+    }
+
+    // uses font-awesome
+    private String iconify(final Identifier identifier) {
+        var faQuickNotation = switch (identifier.type()) {
+            case CLASS -> switch(TypeVariant.valueOf(identifier.logicalType().correspondingClass())) {
+                case CONCRETE -> "solid copyright .col-green"; // resembling the class symbol from Eclipse IDE
+                case INTERFACE -> "solid circle .col-steelblue, solid i .col-white .font-size-60"; // blue circle with inscribed I
+                case ABSTRACT -> "solid circle .col-green, solid a .col-white .font-size-60"; // green circle with inscribed A
+            };
+            case ACTION -> "solid star .col-red";
+            case ACTION_PARAMETER -> "regular star .col-red";
+            case PROPERTY -> "solid square .col-green";
+            case COLLECTION -> "solid list .col-gold";
+        };
+        var faLayers = FontAwesomeLayers.fromQuickNotation(faQuickNotation);
+        return faIconAndTitle(faLayers, toMonospace(identifier.getFullIdentityString()));
+    }
+
+
+    @Override
+    public Can<Identifier> getExamples() {
+        return Can.of(
+                // these are just stubs, not actually valid
+                Identifier.classIdentifier(new LogicalType("java.Object", Object.class)),
+                Identifier.propertyIdentifier(new LogicalType("java.Object", Object.class), "example")
+            );
+    }
+
+    // -- HELPER
+
+    private enum TypeVariant {
+        CONCRETE,
+        ABSTRACT,
+        INTERFACE;
+        static TypeVariant valueOf(final Class<?> cls) {
+            return cls.isInterface()
+                ? INTERFACE
+                : Modifier.isAbstract(cls.getModifiers())
+                    ? ABSTRACT
+                    : CONCRETE;
+        }
+    }
+
+}

--- a/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_MixinDomainWithPdfJsViewer_IntegTest.dump_facets.approved.xml
+++ b/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_MixinDomainWithPdfJsViewer_IntegTest.dump_facets.approved.xml
@@ -1047,7 +1047,7 @@
             <mml:attr name="facet" value="ActionInvocationFacetForAction"/>
             <mml:attr name="intent.act" value="EXECUTE"/>
             <mml:attr name="isPostable" value="true"/>
-            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId,java.lang.String)"/>
+            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.Identifier,java.lang.String)"/>
             <mml:attr name="precedence" value="DEFAULT"/>
             <mml:attr name="returnType" value="java.lang.Object"/>
           </mml:facet>
@@ -1187,7 +1187,7 @@
                 <mml:attr name="value" value="RESET"/>
               </mml:facet>
             </mml:facets>
-            <mml:type>org.apache.causeway.applib.services.appfeat.ApplicationFeatureId</mml:type>
+            <mml:type>org.apache.causeway.applib.Identifier</mml:type>
           </mml:param>
           <mml:param id="columnListing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="mml:scalarParam">
             <mml:facets>
@@ -1230,7 +1230,7 @@
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.defaults.ActionParameterDefaultsFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.defaults.methodnum.ActionParameterDefaultsFacetViaMethod">
                 <mml:attr name="facet" value="ActionParameterDefaultsFacetViaMethod"/>
                 <mml:attr name="intent.defaultColumnListing" value="DEFAULTS"/>
-                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId)"/>
+                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.Identifier)"/>
                 <mml:attr name="precedence" value="DEFAULT"/>
               </mml:facet>
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacetForParameterAnnotation">

--- a/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_MixinDomain_IntegTest.dump_facets.approved.xml
+++ b/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_MixinDomain_IntegTest.dump_facets.approved.xml
@@ -1040,7 +1040,7 @@
             <mml:attr name="facet" value="ActionInvocationFacetForAction"/>
             <mml:attr name="intent.act" value="EXECUTE"/>
             <mml:attr name="isPostable" value="true"/>
-            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId,java.lang.String)"/>
+            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.Identifier,java.lang.String)"/>
             <mml:attr name="precedence" value="DEFAULT"/>
             <mml:attr name="returnType" value="java.lang.Object"/>
           </mml:facet>
@@ -1180,7 +1180,7 @@
                 <mml:attr name="value" value="RESET"/>
               </mml:facet>
             </mml:facets>
-            <mml:type>org.apache.causeway.applib.services.appfeat.ApplicationFeatureId</mml:type>
+            <mml:type>org.apache.causeway.applib.Identifier</mml:type>
           </mml:param>
           <mml:param id="columnListing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="mml:scalarParam">
             <mml:facets>
@@ -1223,7 +1223,7 @@
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.defaults.ActionParameterDefaultsFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.defaults.methodnum.ActionParameterDefaultsFacetViaMethod">
                 <mml:attr name="facet" value="ActionParameterDefaultsFacetViaMethod"/>
                 <mml:attr name="intent.defaultColumnListing" value="DEFAULTS"/>
-                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId)"/>
+                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.Identifier)"/>
                 <mml:attr name="precedence" value="DEFAULT"/>
               </mml:facet>
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacetForParameterAnnotation">

--- a/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_PropDomainWithPdfjsViewer_IntegTest.dump_facets.approved.xml
+++ b/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_PropDomainWithPdfjsViewer_IntegTest.dump_facets.approved.xml
@@ -1036,7 +1036,7 @@
             <mml:attr name="facet" value="ActionInvocationFacetForAction"/>
             <mml:attr name="intent.act" value="EXECUTE"/>
             <mml:attr name="isPostable" value="true"/>
-            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId,java.lang.String)"/>
+            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.Identifier,java.lang.String)"/>
             <mml:attr name="precedence" value="DEFAULT"/>
             <mml:attr name="returnType" value="java.lang.Object"/>
           </mml:facet>
@@ -1176,7 +1176,7 @@
                 <mml:attr name="value" value="RESET"/>
               </mml:facet>
             </mml:facets>
-            <mml:type>org.apache.causeway.applib.services.appfeat.ApplicationFeatureId</mml:type>
+            <mml:type>org.apache.causeway.applib.Identifier</mml:type>
           </mml:param>
           <mml:param id="columnListing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="mml:scalarParam">
             <mml:facets>
@@ -1219,7 +1219,7 @@
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.defaults.ActionParameterDefaultsFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.defaults.methodnum.ActionParameterDefaultsFacetViaMethod">
                 <mml:attr name="facet" value="ActionParameterDefaultsFacetViaMethod"/>
                 <mml:attr name="intent.defaultColumnListing" value="DEFAULTS"/>
-                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId)"/>
+                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.Identifier)"/>
                 <mml:attr name="precedence" value="DEFAULT"/>
               </mml:facet>
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacetForParameterAnnotation">

--- a/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_PropDomain_IntegTest.dump_facets.approved.xml
+++ b/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_PropDomain_IntegTest.dump_facets.approved.xml
@@ -1029,7 +1029,7 @@
             <mml:attr name="facet" value="ActionInvocationFacetForAction"/>
             <mml:attr name="intent.act" value="EXECUTE"/>
             <mml:attr name="isPostable" value="true"/>
-            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId,java.lang.String)"/>
+            <mml:attr name="methods" value="public java.lang.Object org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.act(org.apache.causeway.applib.Identifier,java.lang.String)"/>
             <mml:attr name="precedence" value="DEFAULT"/>
             <mml:attr name="returnType" value="java.lang.Object"/>
           </mml:facet>
@@ -1169,7 +1169,7 @@
                 <mml:attr name="value" value="RESET"/>
               </mml:facet>
             </mml:facets>
-            <mml:type>org.apache.causeway.applib.services.appfeat.ApplicationFeatureId</mml:type>
+            <mml:type>org.apache.causeway.applib.Identifier</mml:type>
           </mml:param>
           <mml:param id="columnListing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="mml:scalarParam">
             <mml:facets>
@@ -1212,7 +1212,7 @@
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.defaults.ActionParameterDefaultsFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.defaults.methodnum.ActionParameterDefaultsFacetViaMethod">
                 <mml:attr name="facet" value="ActionParameterDefaultsFacetViaMethod"/>
                 <mml:attr name="intent.defaultColumnListing" value="DEFAULTS"/>
-                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.services.appfeat.ApplicationFeatureId)"/>
+                <mml:attr name="methods" value="public java.lang.String org.apache.causeway.applib.services.columnorder.Object_patchColumnOrder.defaultColumnListing(org.apache.causeway.applib.Identifier)"/>
                 <mml:attr name="precedence" value="DEFAULT"/>
               </mml:facet>
               <mml:facet id="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacet" fqcn="org.apache.causeway.core.metamodel.facets.param.parameter.precpol.PrecedingParametersPolicyFacetForParameterAnnotation">

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/model/valuetypes/ValueTypeExample.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/model/valuetypes/ValueTypeExample.java
@@ -37,10 +37,12 @@ import java.util.stream.Stream;
 
 import jakarta.inject.Named;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+
+import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Action;
 import org.apache.causeway.applib.annotation.Collection;
 import org.apache.causeway.applib.annotation.DomainObject;
@@ -69,6 +71,7 @@ import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Temporals;
 import org.apache.causeway.commons.io.TextUtils;
 import org.apache.causeway.core.metamodel.valuesemantics.ApplicationFeatureIdValueSemantics;
+import org.apache.causeway.core.metamodel.valuesemantics.IdentifierValueSemantics;
 import org.apache.causeway.core.metamodel.valuesemantics.MarkupValueSemantics;
 import org.apache.causeway.extensions.fullcalendar.applib.value.CalendarEvent;
 import org.apache.causeway.extensions.fullcalendar.applib.value.CalendarEventSemantics;
@@ -124,7 +127,7 @@ public abstract class ValueTypeExample<T> {
     public Can<T> getParserRoundtripExamples() {
         return Can.ofCollection(semanticsList)
         .getFirst()
-        .map(semantics->semantics.getExamples())
+        .map(ValueSemanticsAbstract::getExamples)
         .orElseGet(()->Can.of(getValue(), getUpdateValue()));
     }
 
@@ -171,9 +174,8 @@ public abstract class ValueTypeExample<T> {
     // -- HELPER
 
     private static Optional<String> extractSuffix(final String name) {
-        if(!name.contains("_")) {
+        if(!name.contains("_"))
             return Optional.empty();
-        }
         return Optional.of(TextUtils.cutter(name)
                 .keepBefore("_")
                 .getValue());
@@ -695,6 +697,19 @@ public abstract class ValueTypeExample<T> {
         private ApplicationFeatureId updateValue = new ApplicationFeatureIdValueSemantics().getExamples().getElseFail(1);
         @Action @Override
         public ApplicationFeatureId sampleAction(@Parameter final @Nullable ApplicationFeatureId value) { return value; }
+    }
+
+    @Named("causeway.testdomain.valuetypes.ValueTypeExampleIdentifier")
+    @DomainObject(
+            nature = Nature.BEAN) @Scope("prototype")
+    public static class ValueTypeExampleIdentifier
+    extends ValueTypeExample<Identifier> {
+        @Property @Getter @Setter
+        private Identifier value = new IdentifierValueSemantics().getExamples().getElseFail(0);
+        @Getter
+        private Identifier updateValue = new IdentifierValueSemantics().getExamples().getElseFail(1);
+        @Action @Override
+        public Identifier sampleAction(@Parameter final @Nullable Identifier value) { return value; }
     }
 
     // -- EXAMPLES - DATA STRUCTURE

--- a/viewers/commons/model/src/main/java/org/apache/causeway/viewer/commons/model/css/causeway-supplemental.css
+++ b/viewers/commons/model/src/main/java/org/apache/causeway/viewer/commons/model/css/causeway-supplemental.css
@@ -58,6 +58,14 @@ i.ov-bottom-85 {
   top: 0.85em;
 }
 
+/* named font sizes */
+
+i.font-size-50 { font-size: 0.5em; }
+i.font-size-60 { font-size: 0.6em; }
+i.font-size-70 { font-size: 0.7em; }
+i.font-size-80 { font-size: 0.8em; }
+i.font-size-90 { font-size: 0.9em; }
+
 /* named colors */
 
 i.col-aliceblue { color: aliceblue; }


### PR DESCRIPTION
- [x] fix for lookup for standalone col.order patching info
- [x] if parented case  is not patched, also lookup for a fallback patch on element-type
- [x] potential identifier ambiguity (abstract and concrete type undistinguishable)

Task-Url: https://issues.apache.org/jira/browse/CAUSEWAY-3997