### PR TITLE
CAUSEWAY-4006: Built-in ValueSemantics for 3 Number Grouping Separation Styles

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -42,7 +42,9 @@ import lombok.Builder;
  */
 public abstract class NumericValueSemantics<T>
 extends ValueSemanticsAbstract<T>
-implements Renderer<T> {
+implements
+    Renderer<T>,
+    Parser<T> {
 
     @Deprecated //TODO to be replaced by GroupingSeparatorConfig
     protected enum GroupingSeparatorPolicy {
@@ -186,6 +188,15 @@ implements Renderer<T> {
         //TODO use DecimalFormatAndPostProcess instead
 //        return renderHtml(value, in->
 //            toMonospace(getNumberFormat(context, FormatUsageFor.RENDERING_AS_HTML).format(in).replace("·", "&#8239;")));
+    }
+
+    // -- PARSER
+
+    @Override
+    public final String parseableTextRepresentation(final Context context, final T value) {
+        return value!=null
+            ? getNumberFormat(context, FormatUsageFor.PARSING).format(value)
+            : null;
     }
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -35,7 +35,9 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
+import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Strings;
+import org.apache.causeway.commons.io.TextUtils;
 
 /**
  * A base for all numerical value types.
@@ -239,8 +241,38 @@ implements
     protected void validateNumericalInput(@Nullable final Context context, final String input) {
         var localeGroupingSeparator = "" + localeGroupingSeparator(context);
         var parsingGroupingSeparator = grouping().separator(context, FormatUsageFor.PARSING);
-        if(parsingGroupingSeparator.equals(localeGroupingSeparator))
-            return; // if parsing format explicitly uses the localeGroupingSeparator, then allow it
+        if(parsingGroupingSeparator.equals(localeGroupingSeparator)) {
+            // if parsing format explicitly uses the localeGroupingSeparator, then allow it, unless grouping is badly placed
+
+            if(!input.contains(localeGroupingSeparator))
+                return; // no group separator used -> valid
+
+            var formatEx = getNumberFormat(context, FormatUsageFor.PARSING);
+            var integerPartInputLiteral = TextUtils.cutter(_Strings.condenseWhitespaces(input, ""))
+                    .keepBefore("" + formatEx.format.getDecimalFormatSymbols().getDecimalSeparator())
+                    .getValue();
+
+            // every chunk must exactly be 3 digits long, except for the first one which can be max 3 digits long
+            var groupedDigits = _Strings.splitThenStream(integerPartInputLiteral, parsingGroupingSeparator)
+                .collect(Can.toCan());
+
+            switch (groupedDigits.getCardinality()) {
+                case ZERO: break; // no leading digits
+                case ONE: if(groupedDigits.getFirstElseFail().length()>3)
+                    throw new TextEntryParseException("Invalid value '" + input + "'; inconsistent use of the '" + localeGroupingSeparator + "' grouping separator");
+                    break;
+                case MULTIPLE:
+                    if(groupedDigits.getFirstElseFail().length()>3)
+                        throw new TextEntryParseException("Invalid value '" + input + "'; inconsistent use of the '" + localeGroupingSeparator + "' grouping separator");
+                    for (String chunk : groupedDigits.subCan(1)) {
+                        if(chunk.length()!=3)
+                            throw new TextEntryParseException("Invalid value '" + input + "'; inconsistent use of the '" + localeGroupingSeparator + "' grouping separator");
+                    }
+                    break;
+            }
+
+            return; // all tests passed -> valid
+        }
 
         if(StringUtils.hasText(localeGroupingSeparator)) { // ignores whitespace
             if (input.contains(localeGroupingSeparator))

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -48,8 +48,20 @@ implements
     Renderer<T>,
     Parser<T> {
 
+    /**
+     * No grouping separators are used for display nor editing. However, white-spaces on input are ignored.
+     */
     public final static String NO_GROUPING = "no-grouping";
-    public final static String LOCALE_GROUPING = "locale-grouping";
+    /**
+     * Locale specific grouping separators are used for display,
+     * while any non-white-space grouping separators are not allowed for input.
+     * White-spaces on input are ignored.
+     */
+    public final static String LOCALE_GROUPING_DISPLAY = "locale-grouping-display";
+    /**
+     * Uses locale specific grouping separators for display and allows grouping separators for numerical input (when editing).
+     */
+    public final static String LOCALE_GROUPING_ALL = "locale-grouping-all";
 
     /**
      * Specifies the grouping separation behavior for parsing and rendering.
@@ -63,9 +75,13 @@ implements
         static GroupingSeparatorProvider SPACED_GROUPING = (context, usedFor) -> switch(usedFor) {
             case RENDERING_AS_TEXT -> " "; // UTF8 U+2009
             case RENDERING_AS_HTML -> "&#8239;"; // small space
-            case PARSING -> null;
+            case PARSING -> " "; // UTF8 U+2009;
         };
-        static GroupingSeparatorProvider LOCALE_GROUPING = (context, usedFor) -> "" + localeGroupingSeparator(context);
+        static GroupingSeparatorProvider LOCALE_GROUPING_DISPLAY = (context, usedFor) -> switch(usedFor) {
+            case RENDERING_AS_TEXT, RENDERING_AS_HTML -> "" + localeGroupingSeparator(context);
+            case PARSING -> " "; // UTF8 U+2009;
+        };
+        static GroupingSeparatorProvider LOCALE_GROUPING_ALL = (context, usedFor) -> "" + localeGroupingSeparator(context);
     }
 
     /**
@@ -222,6 +238,10 @@ implements
      */
     protected void validateNumericalInput(@Nullable final Context context, final String input) {
         var localeGroupingSeparator = "" + localeGroupingSeparator(context);
+        var parsingGroupingSeparator = grouping().separator(context, FormatUsageFor.PARSING);
+        if(parsingGroupingSeparator.equals(localeGroupingSeparator))
+            return; // if parsing format explicitly uses the localeGroupingSeparator, then allow it
+
         if(StringUtils.hasText(localeGroupingSeparator)) { // ignores whitespace
             if (input.contains(localeGroupingSeparator))
                 throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + localeGroupingSeparator + "' grouping separator");
@@ -237,7 +257,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final T value) {
-        return renderTitle(value, pipe(getNumberFormat(context, FormatUsageFor.RENDERING_AS_TEXT)::format, super::toLightFont));
+        return renderTitle(value, pipe(getNumberFormat(context, FormatUsageFor.RENDERING_AS_HTML)::format, super::toLightFont));
     }
 
     // -- PARSER

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -171,7 +171,7 @@ implements
         try {
             return parseDecimal(context, input)
                     .map(BigDecimal::toBigIntegerExact);
-        } catch (final NumberFormatException | ArithmeticException e) {
+        } catch (final ArithmeticException e) {
             throw new TextEntryParseException("Not an integer value " + text, e);
         }
     }
@@ -182,6 +182,8 @@ implements
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)
             return Optional.empty();
+
+        validateNumericalInput(context, input);
 
         var formatEx = getNumberFormat(context, FormatUsageFor.PARSING);
 
@@ -200,6 +202,29 @@ implements
             throw new TextEntryParseException(String.format(
                     "Not a decimal value '%s': %s", input, e.getMessage()),
                     e);
+        }
+    }
+
+    /**
+     * The default implementation disallows appearance of the user- or system-locale specific grouping (thousands) separator
+     * in any of the numeric value inputs. Subclasses may override this behavior.
+     *
+     * <p> A common use of {@link java.math.BigDecimal} say is as a money value. In some locales (eg English), the
+     * ',' (comma) is the grouping separator while the '.' (period) acts as a
+     * decimal point, but in others (eg France, Italy, Germany) it is the other way around.
+     *
+     * <p> Surprisingly perhaps, a string such as "123,99", when parsed ((by {@link java.text.DecimalFormat})
+     * in an English locale, is not rejected but instead is evaluated as the value 12_399L.  That's almost
+     * certainly not what the end-user would have expected, and results in a money value 100x too large.
+     *
+     * <p>The purpose of this validation method is to remove the confusion by simply disallowing the
+     * grouping separator from being part of the input string.
+     */
+    protected void validateNumericalInput(@Nullable final Context context, final String input) {
+        var localeGroupingSeparator = "" + localeGroupingSeparator(context);
+        if(StringUtils.hasText(localeGroupingSeparator)) { // ignores whitespace
+            if (input.contains(localeGroupingSeparator))
+                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + localeGroupingSeparator + "' grouping separator");
         }
     }
 

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -32,6 +32,8 @@ import java.util.function.UnaryOperator;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.util.StringUtils;
+
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.commons.internal.base._Strings;
 
@@ -59,19 +61,46 @@ implements
             @Nullable String titleSpecificSeparator,
             @Nullable String htmlSpecificSeparator,
             @Nullable String inputSpecificSeparator) {
-        public static GroupingSeparatorConfig DEFAULT = new GroupingSeparatorConfig(null, "&#8239;", null);
+        public static GroupingSeparatorConfig DEFAULT = GroupingSeparatorConfig.builder()
+                .titleSpecificSeparator(" ") // UTF8 U+2009
+                .htmlSpecificSeparator("&#8239;")
+                .build();
     }
 
     protected GroupingSeparatorConfig config() {
         return GroupingSeparatorConfig.DEFAULT;
     }
 
-    record DecimalFormatAndPostProcess(DecimalFormat format, UnaryOperator<String> postprocess) {
-        public DecimalFormatAndPostProcess {
+    protected record DecimalFormatEx(
+            UnaryOperator<String> preprocess,
+            DecimalFormat format,
+            UnaryOperator<String> postprocess) {
+        protected DecimalFormatEx {
             format = Objects.requireNonNull(format, ()->"must specify a DecimalFormat");
+            preprocess = preprocess!=null
+                    ? preprocess
+                    : UnaryOperator.identity();
             postprocess = postprocess!=null
                     ? postprocess
                     : UnaryOperator.identity();
+        }
+        static DecimalFormatEx of(final DecimalFormat format, @Nullable final String groupingSeparator) {
+            if(StringUtils.hasLength(groupingSeparator)) {
+                format.setGroupingUsed(true);
+                var decimalFormatSymbols = format.getDecimalFormatSymbols();
+                decimalFormatSymbols.setGroupingSeparator('_');
+                format.setDecimalFormatSymbols(decimalFormatSymbols);
+                return new DecimalFormatEx(
+                        in->in.replace(groupingSeparator, "").replaceAll("\\s+", ""),
+                        format,
+                        out->out.replace("_", groupingSeparator));
+            } else {
+                format.setGroupingUsed(false);
+                return new DecimalFormatEx(
+                        in->in.replaceAll("\\s+", ""),
+                        format,
+                        UnaryOperator.identity());
+            }
         }
         public String format(final double number) {
             return postprocess.apply(format.format(number));
@@ -81,6 +110,16 @@ implements
         }
         public String format(final Object number) {
             return postprocess.apply(format.format(number));
+        }
+        public BigDecimal parse(final String rawInput) throws ParseException {
+            var position = new ParsePosition(0);
+            var input = preprocess.apply(rawInput);
+            var decimal = (BigDecimal) format.parse(input, position);
+            if (position.getErrorIndex() != -1)
+                throw new ParseException("could not parse input='" + rawInput + "'", position.getErrorIndex());
+            else if (position.getIndex() < input.length())
+                throw new ParseException("input='" + rawInput + "' was not processed completely", position.getIndex());
+            return decimal;
         }
     }
 
@@ -94,28 +133,31 @@ implements
      * this is typically overruled later by implementations of
      * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
      */
-    protected DecimalFormat getNumberFormat(
+    private DecimalFormatEx getNumberFormat(
             final ValueSemanticsProvider.@Nullable Context context,
             final @NonNull FormatUsageFor usedFor) {
         var format = (DecimalFormat)NumberFormat.getNumberInstance(ValueSemanticsProvider.getUserLocale(context).numberFormatLocale());
         // prime w/ 16 (64 bit IEEE 754 double has 15 decimal digits of precision)
         format.setMaximumFractionDigits(16);
 
-//TODO configure from GroupingSeparatorConfig
-//        //format.setGroupingUsed(false);
-//        var decimalFormatSymbols = format.getDecimalFormatSymbols();
-//        decimalFormatSymbols.setGroupingSeparator('·');
-//        format.setDecimalFormatSymbols(decimalFormatSymbols);
-
         configureDecimalFormat(context, format, usedFor);
 
-        return format;
+        return switch(usedFor) {
+            case RENDERING_AS_TEXT -> DecimalFormatEx.of(format, config().titleSpecificSeparator);
+            case RENDERING_AS_HTML -> DecimalFormatEx.of(format, config().htmlSpecificSeparator);
+            case PARSING -> {
+                format.setParseBigDecimal(true);
+                yield DecimalFormatEx.of(format, config().inputSpecificSeparator);
+            }
+        };
     }
 
     /**
-     * Typically overridden by BigDecimalValueSemantics to set min/max fractional digits.
+     * Typically overridden by custom {@link NumericValueSemantics} to set min/max fractional digits.
+     *
+     * @apiNote setting a grouping separator here has no effect, this is done in {@link DecimalFormatEx}
+     *      based on {@link GroupingSeparatorConfig}
      */
-    @Deprecated //TODO missing the distinction between rendering title or html
     protected void configureDecimalFormat(
             final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {
     }
@@ -127,7 +169,7 @@ implements
         if(input==null)
             return Optional.empty();
         try {
-            return parseDecimal(context, input, GroupingSeparatorPolicy.ALLOW)
+            return parseDecimal(context, input)
                     .map(BigDecimal::toBigIntegerExact);
         } catch (final NumberFormatException | ArithmeticException e) {
             throw new TextEntryParseException("Not an integer value " + text, e);
@@ -136,34 +178,20 @@ implements
 
     protected Optional<BigDecimal> parseDecimal(
             final @Nullable Context context,
-            final @Nullable String text,
-            final GroupingSeparatorPolicy groupingSeparatorPolicy) {
+            final @Nullable String text) {
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)
             return Optional.empty();
 
-        if (groupingSeparatorPolicy == GroupingSeparatorPolicy.DISALLOW) {
-            var userLocale = ValueSemanticsProvider.getUserLocale(context);
-            var decimalFormatSymbols = new DecimalFormatSymbols(userLocale.numberFormatLocale());
-            var groupingSeparatorChar = decimalFormatSymbols.getGroupingSeparator();
-            if (input.contains(""+groupingSeparatorChar))
-                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
-        }
+        var formatEx = getNumberFormat(context, FormatUsageFor.PARSING);
 
-        var format = getNumberFormat(context, FormatUsageFor.PARSING);
-        format.setParseBigDecimal(true);
-
-        var position = new ParsePosition(0);
         try {
-            var number = (BigDecimal)format.parse(input, position);
-            if (position.getErrorIndex() != -1)
-                throw new ParseException("could not parse input='" + input + "'", position.getErrorIndex());
-            else if (position.getIndex() < input.length())
-                throw new ParseException("input='" + input + "' was not processed completely", position.getIndex());
+            var number = formatEx.parse(input);
+
             // check for maxFractionDigits if required ...
-            final int maxFractionDigits = format.getMaximumFractionDigits();
+            final int maxFractionDigits = formatEx.format().getMaximumFractionDigits();
             if(maxFractionDigits>-1
-                    && number.scale()>format.getMaximumFractionDigits())
+                    && number.scale()>formatEx.format().getMaximumFractionDigits())
                 throw new TextEntryParseException(String.format(
                         "No more than %d digits can be entered after the decimal separator, "
                                 + "got %d in '%s'.", maxFractionDigits, number.scale(), input));
@@ -185,9 +213,6 @@ implements
     @Override
     public String htmlPresentation(final Context context, final T value) {
         return renderTitle(value, pipe(getNumberFormat(context, FormatUsageFor.RENDERING_AS_TEXT)::format, super::toMonospace));
-        //TODO use DecimalFormatAndPostProcess instead
-//        return renderHtml(value, in->
-//            toMonospace(getNumberFormat(context, FormatUsageFor.RENDERING_AS_HTML).format(in).replace("·", "&#8239;")));
     }
 
     // -- PARSER
@@ -197,6 +222,17 @@ implements
         return value!=null
             ? getNumberFormat(context, FormatUsageFor.PARSING).format(value)
             : null;
+    }
+
+    // -- UTIL
+
+    /**
+     * Returns locale based grouping separator. If no context is given, system defaults apply.
+     */
+    protected char getGroupingSeparator(@Nullable final Context context) {
+        var userLocale = ValueSemanticsProvider.getUserLocale(context);
+        var decimalFormatSymbols = new DecimalFormatSymbols(userLocale.numberFormatLocale());
+        return decimalFormatSymbols.getGroupingSeparator();
     }
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -212,7 +212,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final T value) {
-        return renderTitle(value, pipe(getNumberFormat(context, FormatUsageFor.RENDERING_AS_TEXT)::format, super::toMonospace));
+        return renderTitle(value, pipe(getNumberFormat(context, FormatUsageFor.RENDERING_AS_TEXT)::format, super::toLightFont));
     }
 
     // -- PARSER

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -37,10 +37,10 @@ import org.springframework.util.StringUtils;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.commons.internal.base._Strings;
 
-import lombok.Builder;
-
 /**
  * A base for all numerical value types.
+ *
+ * @since 4.0
  */
 public abstract class NumericValueSemantics<T>
 extends ValueSemanticsAbstract<T>
@@ -48,27 +48,33 @@ implements
     Renderer<T>,
     Parser<T> {
 
-    @Deprecated //TODO to be replaced by GroupingSeparatorConfig
-    protected enum GroupingSeparatorPolicy {
-        @Deprecated
-        ALLOW,
-        @Deprecated
-        DISALLOW;
+    public final static String NO_GROUPING = "no-grouping";
+    public final static String LOCALE_GROUPING = "locale-grouping";
+
+    /**
+     * Specifies the grouping separation behavior for parsing and rendering.
+     *
+     * @apiNote Subclasses may provide their own to customize grouping behavior.
+     */
+    public interface GroupingSeparatorProvider {
+        @Nullable String separator(@Nullable Context context, FormatUsageFor usedFor);
+
+        static GroupingSeparatorProvider NO_GROUPING = (context, usedFor) -> null;
+        static GroupingSeparatorProvider SPACED_GROUPING = (context, usedFor) -> switch(usedFor) {
+            case RENDERING_AS_TEXT -> " "; // UTF8 U+2009
+            case RENDERING_AS_HTML -> "&#8239;"; // small space
+            case PARSING -> null;
+        };
+        static GroupingSeparatorProvider LOCALE_GROUPING = (context, usedFor) -> "" + localeGroupingSeparator(context);
     }
 
-    @Builder
-    public record GroupingSeparatorConfig(
-            @Nullable String titleSpecificSeparator,
-            @Nullable String htmlSpecificSeparator,
-            @Nullable String inputSpecificSeparator) {
-        public static GroupingSeparatorConfig DEFAULT = GroupingSeparatorConfig.builder()
-                .titleSpecificSeparator(" ") // UTF8 U+2009
-                .htmlSpecificSeparator("&#8239;")
-                .build();
-    }
-
-    protected GroupingSeparatorConfig config() {
-        return GroupingSeparatorConfig.DEFAULT;
+    /**
+     * Specifies the grouping separation behavior for parsing and rendering.
+     *
+     * @apiNote Subclasses may override to customize grouping behavior.
+     */
+    protected GroupingSeparatorProvider grouping() {
+        return GroupingSeparatorProvider.SPACED_GROUPING;
     }
 
     protected record DecimalFormatEx(
@@ -114,6 +120,7 @@ implements
         public BigDecimal parse(final String rawInput) throws ParseException {
             var position = new ParsePosition(0);
             var input = preprocess.apply(rawInput);
+            format.setParseBigDecimal(true);
             var decimal = (BigDecimal) format.parse(input, position);
             if (position.getErrorIndex() != -1)
                 throw new ParseException("could not parse input='" + rawInput + "'", position.getErrorIndex());
@@ -124,14 +131,14 @@ implements
     }
 
     /**
-     * @param context - nullable in support of JUnit testing
+     * @param context nullable in support of JUnit testing
      * @return {@link NumberFormat} the default from given context's locale
-     * or else system's default locale
+     *      or else system's default locale
      *
      * @implNote the format's MaximumFractionDigits are initialized to 16, as
-     * 64 bit IEEE 754 double has 15 decimal digits of precision;
-     * this is typically overruled later by implementations of
-     * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
+     *      64 bit IEEE 754 double has 15 decimal digits of precision;
+     *      this is typically overruled later by implementations of
+     *      {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
      */
     private DecimalFormatEx getNumberFormat(
             final ValueSemanticsProvider.@Nullable Context context,
@@ -142,21 +149,14 @@ implements
 
         configureDecimalFormat(context, format, usedFor);
 
-        return switch(usedFor) {
-            case RENDERING_AS_TEXT -> DecimalFormatEx.of(format, config().titleSpecificSeparator);
-            case RENDERING_AS_HTML -> DecimalFormatEx.of(format, config().htmlSpecificSeparator);
-            case PARSING -> {
-                format.setParseBigDecimal(true);
-                yield DecimalFormatEx.of(format, config().inputSpecificSeparator);
-            }
-        };
+        return DecimalFormatEx.of(format, grouping().separator(context, usedFor));
     }
 
     /**
      * Typically overridden by custom {@link NumericValueSemantics} to set min/max fractional digits.
      *
-     * @apiNote setting a grouping separator here has no effect, this is done in {@link DecimalFormatEx}
-     *      based on {@link GroupingSeparatorConfig}
+     * @apiNote setting a grouping separator here has no effect, this is done via {@link DecimalFormatEx}
+     *      based on {@link #grouping()}
      */
     protected void configureDecimalFormat(
             final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {
@@ -229,10 +229,9 @@ implements
     /**
      * Returns locale based grouping separator. If no context is given, system defaults apply.
      */
-    protected char getGroupingSeparator(@Nullable final Context context) {
+    public static char localeGroupingSeparator(@Nullable final Context context) {
         var userLocale = ValueSemanticsProvider.getUserLocale(context);
-        var decimalFormatSymbols = new DecimalFormatSymbols(userLocale.numberFormatLocale());
-        return decimalFormatSymbols.getGroupingSeparator();
+        return new DecimalFormatSymbols(userLocale.numberFormatLocale()).getGroupingSeparator();
     }
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -1,0 +1,135 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.applib.value.semantics;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Optional;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
+import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract.FormatUsageFor;
+import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider.Context;
+import org.apache.causeway.commons.internal.base._Strings;
+
+/**
+ * A base for all numerical value types.
+ */
+public interface NumericValueSemantics {
+
+    enum GroupingSeparatorPolicy {
+        ALLOW,
+        DISALLOW;
+    }
+
+    /**
+     * @param context - nullable in support of JUnit testing
+     * @return {@link NumberFormat} the default from given context's locale
+     * or else system's default locale
+     *
+     * @implNote the format's MaximumFractionDigits are initialized to 16, as
+     * 64 bit IEEE 754 double has 15 decimal digits of precision;
+     * this is typically overruled later by implementations of
+     * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
+     */
+    default DecimalFormat getNumberFormat(
+            final ValueSemanticsProvider.@Nullable Context context) {
+        return getNumberFormat(context, FormatUsageFor.RENDERING);
+    }
+
+    default DecimalFormat getNumberFormat(
+            final ValueSemanticsProvider.@Nullable Context context,
+            final @NonNull FormatUsageFor usedFor) {
+        var format = (DecimalFormat)NumberFormat.getNumberInstance(ValueSemanticsProvider.getUserLocale(context).numberFormatLocale());
+        // prime w/ 16 (64 bit IEEE 754 double has 15 decimal digits of precision)
+        format.setMaximumFractionDigits(16);
+        configureDecimalFormat(context, format, usedFor);
+        return format;
+    }
+
+    /**
+     * Typically overridden by BigDecimalValueSemantics to set min/max fractional digits.
+     */
+    default void configureDecimalFormat(
+            final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {}
+
+
+    default Optional<BigInteger> parseInteger(
+            final ValueSemanticsProvider.@Nullable Context context,
+            final @Nullable String text) {
+        var input = _Strings.blankToNullOrTrim(text);
+        if(input==null)
+            return Optional.empty();
+        try {
+            return parseDecimal(context, input, GroupingSeparatorPolicy.ALLOW)
+                    .map(BigDecimal::toBigIntegerExact);
+        } catch (final NumberFormatException | ArithmeticException e) {
+            throw new TextEntryParseException("Not an integer value " + text, e);
+        }
+    }
+
+    default Optional<BigDecimal> parseDecimal(
+            final @Nullable Context context,
+            final @Nullable String text,
+            final GroupingSeparatorPolicy groupingSeparatorPolicy) {
+        var input = _Strings.blankToNullOrTrim(text);
+        if(input==null)
+            return Optional.empty();
+
+        if (groupingSeparatorPolicy == GroupingSeparatorPolicy.DISALLOW) {
+            var userLocale = ValueSemanticsProvider.getUserLocale(context);
+            var decimalFormatSymbols = new DecimalFormatSymbols(userLocale.numberFormatLocale());
+            var groupingSeparatorChar = decimalFormatSymbols.getGroupingSeparator();
+            if (input.contains(""+groupingSeparatorChar))
+                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
+        }
+
+        var format = getNumberFormat(context, FormatUsageFor.PARSING);
+        format.setParseBigDecimal(true);
+
+        var position = new ParsePosition(0);
+        try {
+            var number = (BigDecimal)format.parse(input, position);
+            if (position.getErrorIndex() != -1)
+                throw new ParseException("could not parse input='" + input + "'", position.getErrorIndex());
+            else if (position.getIndex() < input.length())
+                throw new ParseException("input='" + input + "' was not processed completely", position.getIndex());
+            // check for maxFractionDigits if required ...
+            final int maxFractionDigits = format.getMaximumFractionDigits();
+            if(maxFractionDigits>-1
+                    && number.scale()>format.getMaximumFractionDigits())
+                throw new TextEntryParseException(String.format(
+                        "No more than %d digits can be entered after the decimal separator, "
+                                + "got %d in '%s'.", maxFractionDigits, number.scale(), input));
+            return Optional.of(number);
+        } catch (final NumberFormatException | ParseException e) {
+            throw new TextEntryParseException(String.format(
+                    "Not a decimal value '%s': %s", input, e.getMessage()),
+                    e);
+        }
+    }
+
+}

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/NumericValueSemantics.java
@@ -25,24 +25,61 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract.FormatUsageFor;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider.Context;
 import org.apache.causeway.commons.internal.base._Strings;
+
+import lombok.Builder;
 
 /**
  * A base for all numerical value types.
  */
-public interface NumericValueSemantics {
+public abstract class NumericValueSemantics<T>
+extends ValueSemanticsAbstract<T>
+implements Renderer<T> {
 
-    enum GroupingSeparatorPolicy {
+    @Deprecated //TODO to be replaced by GroupingSeparatorConfig
+    protected enum GroupingSeparatorPolicy {
+        @Deprecated
         ALLOW,
+        @Deprecated
         DISALLOW;
+    }
+
+    @Builder
+    public record GroupingSeparatorConfig(
+            @Nullable String titleSpecificSeparator,
+            @Nullable String htmlSpecificSeparator,
+            @Nullable String inputSpecificSeparator) {
+        public static GroupingSeparatorConfig DEFAULT = new GroupingSeparatorConfig(null, "&#8239;", null);
+    }
+
+    protected GroupingSeparatorConfig config() {
+        return GroupingSeparatorConfig.DEFAULT;
+    }
+
+    record DecimalFormatAndPostProcess(DecimalFormat format, UnaryOperator<String> postprocess) {
+        public DecimalFormatAndPostProcess {
+            format = Objects.requireNonNull(format, ()->"must specify a DecimalFormat");
+            postprocess = postprocess!=null
+                    ? postprocess
+                    : UnaryOperator.identity();
+        }
+        public String format(final double number) {
+            return postprocess.apply(format.format(number));
+        }
+        public String format(final long number) {
+            return postprocess.apply(format.format(number));
+        }
+        public String format(final Object number) {
+            return postprocess.apply(format.format(number));
+        }
     }
 
     /**
@@ -55,30 +92,34 @@ public interface NumericValueSemantics {
      * this is typically overruled later by implementations of
      * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
      */
-    default DecimalFormat getNumberFormat(
-            final ValueSemanticsProvider.@Nullable Context context) {
-        return getNumberFormat(context, FormatUsageFor.RENDERING);
-    }
-
-    default DecimalFormat getNumberFormat(
+    protected DecimalFormat getNumberFormat(
             final ValueSemanticsProvider.@Nullable Context context,
             final @NonNull FormatUsageFor usedFor) {
         var format = (DecimalFormat)NumberFormat.getNumberInstance(ValueSemanticsProvider.getUserLocale(context).numberFormatLocale());
         // prime w/ 16 (64 bit IEEE 754 double has 15 decimal digits of precision)
         format.setMaximumFractionDigits(16);
+
+//TODO configure from GroupingSeparatorConfig
+//        //format.setGroupingUsed(false);
+//        var decimalFormatSymbols = format.getDecimalFormatSymbols();
+//        decimalFormatSymbols.setGroupingSeparator('·');
+//        format.setDecimalFormatSymbols(decimalFormatSymbols);
+
         configureDecimalFormat(context, format, usedFor);
+
         return format;
     }
 
     /**
      * Typically overridden by BigDecimalValueSemantics to set min/max fractional digits.
      */
-    default void configureDecimalFormat(
-            final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {}
+    @Deprecated //TODO missing the distinction between rendering title or html
+    protected void configureDecimalFormat(
+            final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {
+    }
 
-
-    default Optional<BigInteger> parseInteger(
-            final ValueSemanticsProvider.@Nullable Context context,
+    protected Optional<BigInteger> parseInteger(
+            final @Nullable Context context,
             final @Nullable String text) {
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)
@@ -91,7 +132,7 @@ public interface NumericValueSemantics {
         }
     }
 
-    default Optional<BigDecimal> parseDecimal(
+    protected Optional<BigDecimal> parseDecimal(
             final @Nullable Context context,
             final @Nullable String text,
             final GroupingSeparatorPolicy groupingSeparatorPolicy) {
@@ -130,6 +171,21 @@ public interface NumericValueSemantics {
                     "Not a decimal value '%s': %s", input, e.getMessage()),
                     e);
         }
+    }
+
+    // -- RENDERER
+
+    @Override
+    public String titlePresentation(final Context context, final T value) {
+        return renderTitle(value, getNumberFormat(context, FormatUsageFor.RENDERING_AS_TEXT)::format);
+    }
+
+    @Override
+    public String htmlPresentation(final Context context, final T value) {
+        return renderTitle(value, pipe(getNumberFormat(context, FormatUsageFor.RENDERING_AS_TEXT)::format, super::toMonospace));
+        //TODO use DecimalFormatAndPostProcess instead
+//        return renderHtml(value, in->
+//            toMonospace(getNumberFormat(context, FormatUsageFor.RENDERING_AS_HTML).format(in).replace("·", "&#8239;")));
     }
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
@@ -19,9 +19,12 @@
 package org.apache.causeway.applib.value.semantics;
 
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.Temporal;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import org.apache.causeway.applib.annotation.TimePrecision;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
@@ -244,50 +247,45 @@ extends
                 final @NonNull TimePrecision timePrecision,
                 final @NonNull EditingFormatDirection direction) {
 
-            switch (temporalCharacteristic) {
-            case DATE_TIME:
+            return switch (temporalCharacteristic) {
+            case DATE_TIME -> {
                 var dateTimePattern =
                     String.format(dateTimeJoiningPattern(),
                             datePattern(),
                             timePattern(timePrecision, direction));
-                return offsetCharacteristic.isLocal()
-                        ? dateTimePattern
-                        : String.format(zoneJoiningPattern(),
-                                dateTimePattern,
-                                zonePattern(offsetCharacteristic, direction));
-            case DATE_ONLY:
-                return offsetCharacteristic.isLocal()
-                        ? datePattern()
-                        : String.format(zoneJoiningPattern(),
-                                datePattern(),
-                                zonePattern(offsetCharacteristic,direction));
-            case TIME_ONLY:
-                return offsetCharacteristic.isLocal()
-                        ? timePattern(timePrecision, direction)
-                        : String.format(zoneJoiningPattern(),
-                                timePattern(timePrecision, direction),
-                                zonePattern(offsetCharacteristic, direction));
-            default:
-                throw _Exceptions.unmatchedCase(temporalCharacteristic);
+                yield offsetCharacteristic.isLocal()
+                                        ? dateTimePattern
+                                        : String.format(zoneJoiningPattern(),
+                                                dateTimePattern,
+                                                zonePattern(offsetCharacteristic, direction));
             }
+            case DATE_ONLY -> offsetCharacteristic.isLocal()
+                                    ? datePattern()
+                                    : String.format(zoneJoiningPattern(),
+                                            datePattern(),
+                                            zonePattern(offsetCharacteristic,direction));
+            case TIME_ONLY -> offsetCharacteristic.isLocal()
+                                    ? timePattern(timePrecision, direction)
+                                    : String.format(zoneJoiningPattern(),
+                                            timePattern(timePrecision, direction),
+                                            zonePattern(offsetCharacteristic, direction));
+            default -> throw _Exceptions.unmatchedCase(temporalCharacteristic);
+            };
         }
 
         private String zonePattern(
                 final @NonNull OffsetCharacteristic offsetCharacteristic,
                 final @NonNull EditingFormatDirection direction) {
 
-            switch(offsetCharacteristic) {
-            case OFFSET:
-                return direction.isInput()
-                        ? offsetPatternForInput()
-                        : offsetPatternForOutput();
-            case ZONED:
-                return direction.isInput()
-                        ? zoneIdPatternForInput()
-                        : zoneIdPatternForOutput();
-            default:
-                throw _Exceptions.unexpectedCodeReach();
-            }
+            return switch (offsetCharacteristic) {
+            case OFFSET -> direction.isInput()
+                                    ? offsetPatternForInput()
+                                    : offsetPatternForOutput();
+            case ZONED -> direction.isInput()
+                                    ? zoneIdPatternForInput()
+                                    : zoneIdPatternForOutput();
+            default -> throw _Exceptions.unexpectedCodeReach();
+            };
         }
 
         // -- HELPER
@@ -295,35 +293,57 @@ extends
         private String timePattern(
                 final @NonNull TimePrecision timePrecision,
                 final @NonNull EditingFormatDirection direction) {
-            switch (direction) {
-            case INPUT:
-                return timePattern(timePrecision);
-            case OUTPUT:
-                return timePattern(timePrecision)
-                        .replace("[", "").replace("]", ""); // remove brackets for optional temporal parts
-            }
-            throw _Exceptions.unmatchedCase(direction);
+            return switch (direction) {
+                case INPUT -> timePattern(timePrecision);
+                case OUTPUT -> timePattern(timePrecision)
+                                        .replace("[", "").replace("]", ""); // remove brackets for optional temporal parts
+            };
         }
 
         private String timePattern(final @NonNull TimePrecision timePrecision) {
-            switch (timePrecision) {
-            case NANO_SECOND:
-                return timePatternNanoSecond();
-            case MICRO_SECOND:
-                return timePatternMicroSecond();
-            case MILLI_SECOND:
-                return timePatternMilliSecond();
-            case UNSPECIFIED:
-            case SECOND:
-                return timePatternSecond();
-            case MINUTE:
-                return timePatternMinute();
-            case HOUR:
-                return timePatternHour();
-            }
-            throw _Exceptions.unmatchedCase(timePrecision);
+            return switch (timePrecision) {
+                case NANO_SECOND -> timePatternNanoSecond();
+                case MICRO_SECOND -> timePatternMicroSecond();
+                case MILLI_SECOND -> timePatternMilliSecond();
+                case UNSPECIFIED, SECOND -> timePatternSecond();
+                case MINUTE -> timePatternMinute();
+                case HOUR -> timePatternHour();
+            };
         }
 
     }
+
+    default DateTimeFormatter getTemporalEditingFormat(
+            final ValueSemanticsProvider.@Nullable Context context,
+            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
+            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic,
+            final @NonNull TimePrecision timePrecision,
+            final @NonNull EditingFormatDirection direction,
+            final @NonNull TemporalEditingPattern editingPattern) {
+
+        return new DateTimeFormatterBuilder()
+                .appendPattern(editingPattern
+                        .getEditingFormatAsPattern(
+                                temporalCharacteristic, offsetCharacteristic, timePrecision, direction))
+                .toFormatter(ValueSemanticsProvider.getUserLocale(context).timeFormatLocale());
+    }
+
+    default DateTimeFormatter getTemporalIsoFormat(
+            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
+            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic) {
+
+        return switch (temporalCharacteristic) {
+            case DATE_TIME -> offsetCharacteristic.isLocal()
+                            ? DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                            : DateTimeFormatter.ISO_DATE_TIME;
+            case DATE_ONLY -> offsetCharacteristic.isLocal()
+                            ? DateTimeFormatter.ISO_LOCAL_DATE
+                            : DateTimeFormatter.ISO_DATE;
+            case TIME_ONLY -> offsetCharacteristic.isLocal()
+                            ? DateTimeFormatter.ISO_LOCAL_TIME
+                            : DateTimeFormatter.ISO_TIME;
+        };
+    }
+
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -18,8 +18,6 @@
  */
 package org.apache.causeway.applib.value.semantics;
 
-import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
@@ -43,7 +41,6 @@ import org.apache.causeway.applib.util.schema.CommonDtoUtils;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.base._Strings;
-import org.apache.causeway.commons.internal.base._Temporals;
 import org.apache.causeway.schema.common.v2.ValueType;
 import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 
@@ -178,43 +175,6 @@ ValueSemanticsProvider<T> {
         return valuePojo!=null
                 ? onNonNull.apply(valuePojo)
                 : onNull.get();
-    }
-
-    // -- TEMPORAL RENDERING
-
-    protected DateTimeFormatter getTemporalNoZoneRenderingFormat(
-            final @Nullable Context context,
-            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
-            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic,
-            final @NonNull FormatStyle dateFormatStyle,
-            final @NonNull FormatStyle timeFormatStyle,
-            final @Nullable String datePattern,
-            final @Nullable String dateTimePattern) {
-
-        final DateTimeFormatter noZoneOutputFormat = switch (temporalCharacteristic) {
-            case DATE_TIME -> dateTimePattern != null
-                                ? DateTimeFormatter.ofPattern(dateTimePattern)
-                                : DateTimeFormatter.ofLocalizedDateTime(dateFormatStyle, timeFormatStyle);
-            case DATE_ONLY -> datePattern != null
-                                ? DateTimeFormatter.ofPattern(datePattern)
-                                : DateTimeFormatter.ofLocalizedDate(dateFormatStyle);
-            case TIME_ONLY -> DateTimeFormatter.ofLocalizedTime(timeFormatStyle);
-        };
-
-        return noZoneOutputFormat
-                .withLocale(getUserLocale(context).timeFormatLocale());
-    }
-
-    protected Optional<DateTimeFormatter> getTemporalZoneOnlyRenderingFormat(
-            final ValueSemanticsProvider.@Nullable Context context,
-            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
-            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic) {
-
-        return switch (offsetCharacteristic) {
-            case LOCAL -> Optional.empty();
-            case OFFSET -> Optional.of(_Temporals.ISO_OFFSET_ONLY_FORMAT);
-            case ZONED -> Optional.of(_Temporals.DEFAULT_ZONEID_ONLY_FORMAT);
-        };
     }
 
     // -- TRANSLATION SUPPORT

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -18,13 +18,6 @@
  */
 package org.apache.causeway.applib.value.semantics;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.text.ParsePosition;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
@@ -32,7 +25,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import jakarta.inject.Provider;
 
@@ -42,13 +34,11 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.apache.causeway.applib.annotation.TimePrecision;
-import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.fa.FontAwesomeLayers;
 import org.apache.causeway.applib.locale.UserLocale;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.applib.services.i18n.TranslationService;
-import org.apache.causeway.applib.services.iactn.InteractionContext;
 import org.apache.causeway.applib.services.render.PlaceholderRenderService;
 import org.apache.causeway.applib.services.render.PlaceholderRenderService.PlaceholderLiteral;
 import org.apache.causeway.applib.util.schema.CommonDtoUtils;
@@ -115,10 +105,7 @@ ValueSemanticsProvider<T> {
      * @return {@link Locale} from given context or else system's default
      */
     protected UserLocale getUserLocale(final ValueSemanticsProvider.@Nullable Context context) {
-        return Optional.ofNullable(context)
-                .map(ValueSemanticsProvider.Context::interactionContext)
-                .map(InteractionContext::getLocale)
-                .orElseGet(UserLocale::getDefault);
+        return ValueSemanticsProvider.getUserLocale(context);
     }
 
     protected String renderTitle(final T value, final Function<T, String> toString) {
@@ -132,14 +119,6 @@ ValueSemanticsProvider<T> {
                 .map(toString)
                 .orElseGet(()->getPlaceholderRenderService().asHtml(PlaceholderLiteral.NULL_REPRESENTATION));
     }
-
-    protected String renderHtml(final T value, final Function<T, String> toString, final UnaryOperator<String> htmlPostprocessor) {
-        return Optional.ofNullable(value)
-                .map(toString)
-                .map(htmlPostprocessor)
-                .orElseGet(()->getPlaceholderRenderService().asHtml(PlaceholderLiteral.NULL_REPRESENTATION));
-    }
-
 
     // -- COMPOSITION UTILS
 
@@ -199,96 +178,30 @@ ValueSemanticsProvider<T> {
 
     // -- NUMBER FORMATTING/PARSING
 
-    /**
-     * @param context - nullable in support of JUnit testing
-     * @return {@link NumberFormat} the default from given context's locale
-     * or else system's default locale
-     *
-     * @implNote the format's MaximumFractionDigits are initialized to 16, as
-     * 64 bit IEEE 754 double has 15 decimal digits of precision;
-     * this is typically overruled later by implementations of
-     * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
-     */
-    protected DecimalFormat getNumberFormat(
-            final ValueSemanticsProvider.@Nullable Context context) {
-        return getNumberFormat(context, FormatUsageFor.RENDERING);
-    }
-
-    protected DecimalFormat getNumberFormat(
-            final ValueSemanticsProvider.@Nullable Context context,
-            final @NonNull FormatUsageFor usedFor) {
-        var format = (DecimalFormat)NumberFormat.getNumberInstance(getUserLocale(context).numberFormatLocale());
-        // prime w/ 16 (64 bit IEEE 754 double has 15 decimal digits of precision)
-        format.setMaximumFractionDigits(16);
-        configureDecimalFormat(context, format, usedFor);
-        return format;
-    }
-
-    protected Optional<BigInteger> parseInteger(
-            final ValueSemanticsProvider.@Nullable Context context,
-            final @Nullable String text) {
-        var input = _Strings.blankToNullOrTrim(text);
-        if(input==null) {
-			return Optional.empty();
-		}
-        try {
-            return parseDecimal(context, input, GroupingSeparatorPolicy.ALLOW)
-                    .map(BigDecimal::toBigIntegerExact);
-        } catch (final NumberFormatException | ArithmeticException e) {
-            throw new TextEntryParseException("Not an integer value " + text, e);
-        }
-    }
-
-    protected enum GroupingSeparatorPolicy {
-        ALLOW,
-        DISALLOW,
-        ;
-    }
-
-    protected Optional<BigDecimal> parseDecimal(
-            final @Nullable Context context,
-            final @Nullable String text,
-            final GroupingSeparatorPolicy groupingSeparatorPolicy) {
-        var input = _Strings.blankToNullOrTrim(text);
-        if(input==null) {
-			return Optional.empty();
-		}
-
-        if (groupingSeparatorPolicy == GroupingSeparatorPolicy.DISALLOW) {
-            var userLocale = getUserLocale(context);
-            var decimalFormatSymbols = new DecimalFormatSymbols(userLocale.numberFormatLocale());
-            var groupingSeparatorChar = decimalFormatSymbols.getGroupingSeparator();
-            if (input.contains(""+groupingSeparatorChar)) {
-				throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
-			}
-        }
-
-        var format = getNumberFormat(context, FormatUsageFor.PARSING);
-        format.setParseBigDecimal(true);
-
-        var position = new ParsePosition(0);
-        try {
-            var number = (BigDecimal)format.parse(input, position);
-            if (position.getErrorIndex() != -1) {
-				throw new ParseException("could not parse input='" + input + "'", position.getErrorIndex());
-			} else if (position.getIndex() < input.length()) {
-				throw new ParseException("input='" + input + "' was not processed completely", position.getIndex());
-			}
-            // check for maxFractionDigits if required ...
-            final int maxFractionDigits = format.getMaximumFractionDigits();
-            if(maxFractionDigits>-1
-                    && number.scale()>format.getMaximumFractionDigits()) {
-				throw new TextEntryParseException(String.format(
-                        "No more than %d digits can be entered after the decimal separator, "
-                                + "got %d in '%s'.", maxFractionDigits, number.scale(), input));
-			}
-            return Optional.of(number);
-        } catch (final NumberFormatException | ParseException e) {
-            throw new TextEntryParseException(String.format(
-                    "Not a decimal value '%s': %s", input, e.getMessage()),
-                    e);
-        }
-    }
+//    /**
+//     * @param context - nullable in support of JUnit testing
+//     * @return {@link NumberFormat} the default from given context's locale
+//     * or else system's default locale
+//     *
+//     * @implNote the format's MaximumFractionDigits are initialized to 16, as
+//     * 64 bit IEEE 754 double has 15 decimal digits of precision;
+//     * this is typically overruled later by implementations of
+//     * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
+//     */
+//    protected DecimalFormat getNumberFormat(
+//            final ValueSemanticsProvider.@Nullable Context context) {
+//        return getNumberFormat(context, FormatUsageFor.RENDERING);
+//    }
+//
+//    protected DecimalFormat getNumberFormat(
+//            final ValueSemanticsProvider.@Nullable Context context,
+//            final @NonNull FormatUsageFor usedFor) {
+//        var format = (DecimalFormat)NumberFormat.getNumberInstance(getUserLocale(context).numberFormatLocale());
+//        // prime w/ 16 (64 bit IEEE 754 double has 15 decimal digits of precision)
+//        format.setMaximumFractionDigits(16);
+//        configureDecimalFormat(context, format, usedFor);
+//        return format;
+//    }
 
     public static enum FormatUsageFor {
         PARSING,
@@ -296,12 +209,6 @@ ValueSemanticsProvider<T> {
         public boolean isParsing() { return this==PARSING; }
         public boolean isRendering() { return this==RENDERING; }
     }
-
-    /**
-     * Typically overridden by BigDecimalValueSemantics to set min/max fractional digits.
-     */
-    protected void configureDecimalFormat(
-            final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {}
 
     // -- TEMPORAL RENDERING
 
@@ -412,7 +319,5 @@ ValueSemanticsProvider<T> {
         return """
             <span>%s%s</span>""".formatted(faLayers.toHtml(), titleHtml);
     }
-    
-    
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -56,9 +56,11 @@ ValueSemanticsProvider<T> {
 
     public enum FormatUsageFor {
         PARSING,
-        RENDERING;
+        RENDERING_AS_TEXT,
+        RENDERING_AS_HTML;
         public boolean isParsing() { return this==PARSING; }
-        public boolean isRendering() { return this==RENDERING; }
+        public boolean isRenderingAsText() { return this==RENDERING_AS_TEXT; }
+        public boolean isRenderingAsHTML() { return this==RENDERING_AS_HTML; }
     }
 
     @SuppressWarnings("unchecked")

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -19,7 +19,6 @@
 package org.apache.causeway.applib.value.semantics;
 
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 import java.util.Optional;
@@ -33,7 +32,6 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import org.apache.causeway.applib.annotation.TimePrecision;
 import org.apache.causeway.applib.fa.FontAwesomeLayers;
 import org.apache.causeway.applib.locale.UserLocale;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
@@ -42,13 +40,10 @@ import org.apache.causeway.applib.services.i18n.TranslationService;
 import org.apache.causeway.applib.services.render.PlaceholderRenderService;
 import org.apache.causeway.applib.services.render.PlaceholderRenderService.PlaceholderLiteral;
 import org.apache.causeway.applib.util.schema.CommonDtoUtils;
-import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.EditingFormatDirection;
-import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.TemporalEditingPattern;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.commons.internal.base._Temporals;
-import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.schema.common.v2.ValueType;
 import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 
@@ -58,6 +53,13 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public abstract class ValueSemanticsAbstract<T>
 implements
 ValueSemanticsProvider<T> {
+
+    public enum FormatUsageFor {
+        PARSING,
+        RENDERING;
+        public boolean isParsing() { return this==PARSING; }
+        public boolean isRendering() { return this==RENDERING; }
+    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -176,40 +178,6 @@ ValueSemanticsProvider<T> {
                 : onNull.get();
     }
 
-    // -- NUMBER FORMATTING/PARSING
-
-//    /**
-//     * @param context - nullable in support of JUnit testing
-//     * @return {@link NumberFormat} the default from given context's locale
-//     * or else system's default locale
-//     *
-//     * @implNote the format's MaximumFractionDigits are initialized to 16, as
-//     * 64 bit IEEE 754 double has 15 decimal digits of precision;
-//     * this is typically overruled later by implementations of
-//     * {@link #configureDecimalFormat(org.apache.causeway.applib.adapters.ValueSemanticsProvider.Context, DecimalFormat) configureDecimalFormat}
-//     */
-//    protected DecimalFormat getNumberFormat(
-//            final ValueSemanticsProvider.@Nullable Context context) {
-//        return getNumberFormat(context, FormatUsageFor.RENDERING);
-//    }
-//
-//    protected DecimalFormat getNumberFormat(
-//            final ValueSemanticsProvider.@Nullable Context context,
-//            final @NonNull FormatUsageFor usedFor) {
-//        var format = (DecimalFormat)NumberFormat.getNumberInstance(getUserLocale(context).numberFormatLocale());
-//        // prime w/ 16 (64 bit IEEE 754 double has 15 decimal digits of precision)
-//        format.setMaximumFractionDigits(16);
-//        configureDecimalFormat(context, format, usedFor);
-//        return format;
-//    }
-
-    public static enum FormatUsageFor {
-        PARSING,
-        RENDERING;
-        public boolean isParsing() { return this==PARSING; }
-        public boolean isRendering() { return this==RENDERING; }
-    }
-
     // -- TEMPORAL RENDERING
 
     protected DateTimeFormatter getTemporalNoZoneRenderingFormat(
@@ -222,14 +190,13 @@ ValueSemanticsProvider<T> {
             final @Nullable String dateTimePattern) {
 
         final DateTimeFormatter noZoneOutputFormat = switch (temporalCharacteristic) {
-        case DATE_TIME -> dateTimePattern != null
-                            ? DateTimeFormatter.ofPattern(dateTimePattern)
-                            : DateTimeFormatter.ofLocalizedDateTime(dateFormatStyle, timeFormatStyle);
-        case DATE_ONLY -> datePattern != null
-                            ? DateTimeFormatter.ofPattern(datePattern)
-                            : DateTimeFormatter.ofLocalizedDate(dateFormatStyle);
-        case TIME_ONLY -> DateTimeFormatter.ofLocalizedTime(timeFormatStyle);
-        default -> throw _Exceptions.unmatchedCase(temporalCharacteristic);
+            case DATE_TIME -> dateTimePattern != null
+                                ? DateTimeFormatter.ofPattern(dateTimePattern)
+                                : DateTimeFormatter.ofLocalizedDateTime(dateFormatStyle, timeFormatStyle);
+            case DATE_ONLY -> datePattern != null
+                                ? DateTimeFormatter.ofPattern(datePattern)
+                                : DateTimeFormatter.ofLocalizedDate(dateFormatStyle);
+            case TIME_ONLY -> DateTimeFormatter.ofLocalizedTime(timeFormatStyle);
         };
 
         return noZoneOutputFormat
@@ -242,45 +209,9 @@ ValueSemanticsProvider<T> {
             final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic) {
 
         return switch (offsetCharacteristic) {
-        case LOCAL -> Optional.empty();
-        case OFFSET -> Optional.of(_Temporals.ISO_OFFSET_ONLY_FORMAT);
-        case ZONED -> Optional.of(_Temporals.DEFAULT_ZONEID_ONLY_FORMAT);
-        default -> throw _Exceptions.unmatchedCase(offsetCharacteristic);
-        };
-    }
-
-    // -- TEMPORAL FORMATTING/PARSING
-
-    protected DateTimeFormatter getTemporalEditingFormat(
-            final ValueSemanticsProvider.@Nullable Context context,
-            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
-            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic,
-            final @NonNull TimePrecision timePrecision,
-            final @NonNull EditingFormatDirection direction,
-            final @NonNull TemporalEditingPattern editingPattern) {
-
-        return new DateTimeFormatterBuilder()
-                .appendPattern(editingPattern
-                        .getEditingFormatAsPattern(
-                                temporalCharacteristic, offsetCharacteristic, timePrecision, direction))
-                .toFormatter(getUserLocale(context).timeFormatLocale());
-    }
-
-    protected DateTimeFormatter getTemporalIsoFormat(
-            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
-            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic) {
-
-        return switch (temporalCharacteristic) {
-        case DATE_TIME -> offsetCharacteristic.isLocal()
-                            ? DateTimeFormatter.ISO_LOCAL_DATE_TIME
-                            : DateTimeFormatter.ISO_DATE_TIME;
-        case DATE_ONLY -> offsetCharacteristic.isLocal()
-                            ? DateTimeFormatter.ISO_LOCAL_DATE
-                            : DateTimeFormatter.ISO_DATE;
-        case TIME_ONLY -> offsetCharacteristic.isLocal()
-                            ? DateTimeFormatter.ISO_LOCAL_TIME
-                            : DateTimeFormatter.ISO_TIME;
-        default -> throw _Exceptions.unmatchedCase(temporalCharacteristic);
+            case LOCAL -> Optional.empty();
+            case OFFSET -> Optional.of(_Temporals.ISO_OFFSET_ONLY_FORMAT);
+            case ZONED -> Optional.of(_Temporals.DEFAULT_ZONEID_ONLY_FORMAT);
         };
     }
 

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -49,7 +49,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 public abstract class ValueSemanticsAbstract<T>
 implements
-ValueSemanticsProvider<T> {
+    ValueSemanticsProvider<T> {
 
     public enum FormatUsageFor {
         PARSING,

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -206,6 +206,14 @@ ValueSemanticsProvider<T> {
     }
 
     /**
+     * Uses bootstrap CSS.
+     */
+    protected final String toLightFont(final String html) {
+        return """
+            <span class="fw-light">%s</span>""".formatted(html);
+    }
+
+    /**
      * Uses Fontawesome.
      */
     protected final String faIconAndTitle(final FontAwesomeLayers faLayers, final String titleHtml) {

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsProvider.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsProvider.java
@@ -143,7 +143,7 @@ public interface ValueSemanticsProvider<T> {
     default Function<T, String> pipe(final Function<T, String> toString, final UnaryOperator<String> postprocessor) {
         return toString.andThen(postprocessor);
     }
-    
+
     // -- CATEGORIZATION
 
     default boolean isEnumType() {

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsProvider.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsProvider.java
@@ -19,10 +19,16 @@
 
 package org.apache.causeway.applib.value.semantics;
 
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
 import org.jspecify.annotations.Nullable;
 
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Value;
+import org.apache.causeway.applib.locale.UserLocale;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.services.iactn.InteractionContext;
 import org.apache.causeway.commons.internal.base._Casts;
@@ -122,6 +128,22 @@ public interface ValueSemanticsProvider<T> {
         return _Casts.uncheckedCast(this);
     }
 
+    /**
+     * @param context - nullable in support of JUnit testing
+     * @return {@link Locale} from given context or else system's default
+     */
+    static UserLocale getUserLocale(final ValueSemanticsProvider.@Nullable Context context) {
+        return Optional.ofNullable(context)
+                .map(ValueSemanticsProvider.Context::interactionContext)
+                .map(InteractionContext::getLocale)
+                .orElseGet(UserLocale::getDefault);
+    }
+
+    /** function composition */
+    default Function<T, String> pipe(final Function<T, String> toString, final UnaryOperator<String> postprocessor) {
+        return toString.andThen(postprocessor);
+    }
+    
     // -- CATEGORIZATION
 
     default boolean isEnumType() {

--- a/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
@@ -3418,35 +3418,6 @@ public record CausewayConfiguration(
 
             public record Editing(
                 /**
-                 * A common use of {@link java.math.BigDecimal} is as a money value.  In some locales (eg English), the
-                 * ',' (comma) is the grouping (thousands) separator while the '.' (period) acts as a
-                 * decimal point, but in others (eg France, Italy) it is the other way around.
-                 *
-                 * <p>
-                 * Surprisingly perhaps, a string such as "123,99", when parsed ((by {@link java.text.DecimalFormat})
-                 * in an English locale, is not rejected but instead is evaluated as the value 12399L.  That's almost
-                 * certainly not what the end-user would have expected, and results in a money value 100x too large.
-                 * </p>
-                 *
-                 * <p>
-                 * The purpose of this configuration property is to remove the confusion by simply disallowing the
-                 * thousands separator from being part of the input string.
-                 * </p>
-                 *
-                 * <p>
-                 * For maximum safety, allowing the grouping separator is disallowed, but the alternate (original)
-                 * behaviour can be reinstated by setting this config property back to <code>true</code>.
-                 * </p>
-                 *
-                 * <p>
-                 * The same configuration property is also used for rendering the value.
-                 * </p>
-                 *
-                 * @see Display#isUseGroupingSeparator()
-                 */
-                @DefaultValue("false")
-                boolean useGroupingSeparator,
-                /**
                  * When a BigDecimal is presented for editing, whether it should enforce the scale, possibly meaning
                  * trailing '0's to pad).  This is probably appropriate for BigDecimals that represent a money amount.
                  */
@@ -3463,16 +3434,7 @@ public record CausewayConfiguration(
                  * either {@link Digits#fraction()} or an ORM semantic such as the (JPA) {@link Column#scale()}.
                  * </p>
                  */
-                Integer minScale,
-
-                /**
-                 * Whether to use a grouping (thousands) separator (eg the ',' (comma) in the English locale)
-                 * when rendering a big decimal.
-                 *
-                 * @see org.apache.causeway.core.config.CausewayConfiguration.ValueTypes.BigDecimal.Editing#useGroupingSeparator()
-                 */
-                @DefaultValue("true")
-                boolean useGroupingSeparator) {
+                Integer minScale) {
             }
 
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/value/ValueFacet.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/value/ValueFacet.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.OrderRelation;
@@ -93,11 +92,11 @@ extends
             };
     }
 
-    Parser<T> fallbackParser(Identifier featureIdentifier);
+    Parser<T> fallbackParser(ObjectFeature objectFeature);
 
     default Parser<T> selectParserForAttributeOrElseFallback(final @NonNull ObjectFeature feature) {
         return selectParserForAttribute(feature)
-                .orElseGet(()->fallbackParser(feature.getFeatureIdentifier()));
+                .orElseGet(()->fallbackParser(feature));
     }
 
     // -- RENDERER
@@ -106,7 +105,7 @@ extends
     Optional<Renderer<T>> selectDefaultRenderer();
     Optional<Renderer<T>> selectRendererForParamOrPropOrColl(@NonNull ObjectFeature param);
 
-    Renderer<T> fallbackRenderer(Identifier featureIdentifier);
+    Renderer<T> fallbackRenderer(ObjectFeature objectFeature);
 
     default Optional<Renderer<T>> selectRendererForFeature(final @Nullable ObjectFeature feature) {
         return feature==null
@@ -120,7 +119,7 @@ extends
 
     default Renderer<T> selectRendererForParamOrPropOrCollOrElseFallback(final @NonNull ObjectFeature feature) {
         return selectRendererForParamOrPropOrColl(feature)
-                .orElseGet(()->fallbackRenderer(feature.getFeatureIdentifier()));
+                .orElseGet(()->fallbackRenderer(feature));
     }
 
     // -- TEMPORAL SUPPORT

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/value/ValueFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/value/ValueFacetAbstract.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.OrderRelation;
@@ -204,8 +203,8 @@ implements ValueFacet<T> {
     }
 
     @Override
-    public Parser<T> fallbackParser(final Identifier featureIdentifier) {
-        return fallbackParser(getLogicalType(), featureIdentifier);
+    public Parser<T> fallbackParser(final ObjectFeature objectFeature) {
+        return fallbackParser(getLogicalType(), objectFeature);
     }
 
     // -- RENDERER
@@ -229,8 +228,8 @@ implements ValueFacet<T> {
     }
 
     @Override
-    public Renderer<T> fallbackRenderer(final Identifier featureIdentifier) {
-        return fallbackRenderer(getLogicalType(), featureIdentifier);
+    public Renderer<T> fallbackRenderer(final ObjectFeature objectFeature) {
+        return fallbackRenderer(getLogicalType(), objectFeature);
     }
 
     // -- TEMPORAL SUPPORT
@@ -272,22 +271,26 @@ implements ValueFacet<T> {
 
     public static <X> Parser<X> fallbackParser(
             final LogicalType valueType,
-            final Identifier featureIdentifier) {
-        return new PseudoParserWithMessage<>(String
-                .format("Could not find a parser for type %s "
-                        + "in the context of %s",
-                        valueType,
-                        featureIdentifier));
+            final ObjectFeature feature) {
+        return new PseudoParserWithMessage<>("Could not find a parser for type %s in the context of %s"
+                .formatted(
+                    valueType,
+                    feature.getFeatureIdentifier(),
+                    Facets.valueQualifier(feature)
+                        .map(" qualified with %s"::formatted)
+                        .orElse("")));
     }
 
     public static <X> Renderer<X> fallbackRenderer(
             final LogicalType valueType,
-            final Identifier featureIdentifier) {
-        return new PseudoRendererWithMessage<>(String
-                .format("Could not find a renderer for type %s "
-                        + "in the context of %s",
-                        valueType,
-                        featureIdentifier));
+            final ObjectFeature feature) {
+        return new PseudoRendererWithMessage<>("Could not find a renderer for type %s in the context of %s%s"
+                .formatted(
+                    valueType,
+                    feature.getFeatureIdentifier(),
+                    Facets.valueQualifier(feature)
+                        .map(" qualified with %s"::formatted)
+                        .orElse("")));
     }
 
     // -- HELPER

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/value/semantics/ValueSemanticsAnnotationFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/value/semantics/ValueSemanticsAnnotationFacetFactory.java
@@ -86,7 +86,7 @@ extends FacetFactoryAbstract {
 
         // check for @ValueSemantics(provider=...)
         addFacetIfPresent(
-                ValueSemanticsSelectingFacetForAnnotation
+            ValueSemanticsSelectingFacetForAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
     }
 
@@ -96,37 +96,34 @@ extends FacetFactoryAbstract {
             final Optional<Digits> digitsIfAny){
 
         addFacetIfPresent(
-                MaxTotalDigitsFacetAbstract.minimum(
-                        MaxTotalDigitsFacetFromValueSemanticsAnnotation
-                        .create(valueSemanticsIfAny, facetHolder),
-                        // support for @jakarta.validation.constraints.Digits
-                        MaxTotalDigitsFacetFromJavaxValidationDigitsAnnotation
-                        .create(digitsIfAny, facetHolder)
-                        ));
+            MaxTotalDigitsFacetAbstract.minimum(
+                MaxTotalDigitsFacetFromValueSemanticsAnnotation
+                    .create(valueSemanticsIfAny, facetHolder),
+                // support for @jakarta.validation.constraints.Digits
+                MaxTotalDigitsFacetFromJavaxValidationDigitsAnnotation
+                    .create(digitsIfAny, facetHolder)));
 
         addFacetIfPresent(
-                MinIntegerDigitsFacetFromValueSemanticsAnnotation
+            MinIntegerDigitsFacetFromValueSemanticsAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
 
         addFacetIfPresent(
-                MaxFractionalDigitsFacetAbstract.minimum(
-                        MaxFractionalDigitsFacetFromValueSemanticsAnnotation
-                        .create(valueSemanticsIfAny, facetHolder),
-                        // support for @jakarta.validation.constraints.Digits
-                        MaxFractionalDigitsFacetFromJavaxValidationDigitsAnnotation
-                        .create(digitsIfAny, facetHolder)
-                        ));
+            MaxFractionalDigitsFacetAbstract.minimum(
+                MaxFractionalDigitsFacetFromValueSemanticsAnnotation
+                    .create(valueSemanticsIfAny, facetHolder),
+                // support for @jakarta.validation.constraints.Digits
+                MaxFractionalDigitsFacetFromJavaxValidationDigitsAnnotation
+                    .create(digitsIfAny, facetHolder)));
 
         addFacetIfPresent(
-                MinFractionalDigitsFacetAbstract.minimum(
-                        MinFractionalDigitsFacetFromValueSemanticsAnnotation
-                                .create(valueSemanticsIfAny, facetHolder),
-                        // support for @jakarta.validation.constraints.Digits (if supported)
-                        getConfiguration().valueTypes().bigDecimal().useScaleForMinFractionalFacet()
-                                ? MinFractionalDigitsFacetFromJavaxValidationDigitsAnnotation
-                                            .create(digitsIfAny, facetHolder)
-                                : Optional.empty()
-                ));
+            MinFractionalDigitsFacetAbstract.minimum(
+                MinFractionalDigitsFacetFromValueSemanticsAnnotation
+                    .create(valueSemanticsIfAny, facetHolder),
+                // support for @jakarta.validation.constraints.Digits (if supported)
+                getConfiguration().valueTypes().bigDecimal().useScaleForMinFractionalFacet()
+                        ? MinFractionalDigitsFacetFromJavaxValidationDigitsAnnotation
+                            .create(digitsIfAny, facetHolder)
+                        : Optional.empty()));
     }
 
     private void processTemporalFormat(
@@ -134,23 +131,23 @@ extends FacetFactoryAbstract {
             final Optional<ValueSemantics> valueSemanticsIfAny){
 
         addFacetIfPresent(
-                DateFormatStyleFacetFromValueSemanticsAnnotation
+            DateFormatStyleFacetFromValueSemanticsAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
 
         addFacetIfPresent(
-                TimeFormatStyleFacetFromValueSemanticsAnnotation
+            TimeFormatStyleFacetFromValueSemanticsAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
 
         addFacetIfPresent(
-                TimeFormatPrecisionFacetFromValueSemanticsAnnotation
+            TimeFormatPrecisionFacetFromValueSemanticsAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
 
         addFacetIfPresent(
-                DateRenderAdjustFacetFromValueSemanticsAnnotation
+            DateRenderAdjustFacetFromValueSemanticsAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
 
         addFacetIfPresent(
-                TimeZoneTranslationFacetFromValueSemanticsAnnotation
+            TimeZoneTranslationFacetFromValueSemanticsAnnotation
                 .create(valueSemanticsIfAny, facetHolder));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/value/semantics/ValueSemanticsSelectingFacetForAnnotation.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/value/semantics/ValueSemanticsSelectingFacetForAnnotation.java
@@ -34,9 +34,9 @@ extends ValueSemanticsSelectingFacetAbstract {
             final FacetHolder holder) {
 
         return valueSemanticsIfAny
-        .map(ValueSemantics::provider)
-        .filter(_Strings::isNotEmpty)
-        .map(valueSemantics -> new ValueSemanticsSelectingFacetForAnnotation(valueSemantics, holder));
+            .map(ValueSemantics::provider)
+            .filter(_Strings::isNotEmpty)
+            .map(valueSemantics -> new ValueSemanticsSelectingFacetForAnnotation(valueSemantics, holder));
     }
 
     private ValueSemanticsSelectingFacetForAnnotation(final String value, final FacetHolder holder) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -24,15 +24,15 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
@@ -54,7 +54,8 @@ import lombok.Setter;
 
 @Component
 @Named("causeway.metamodel.value.BigDecimalValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class BigDecimalValueSemantics
 extends NumericValueSemantics<BigDecimal>
 implements
@@ -190,6 +191,24 @@ implements
                 BigDecimal.valueOf(123_456_789_012L),
                 BigDecimal.valueOf(1234567.8890f),
                 BigDecimal.valueOf(123_456_789_012L, 3));
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends BigDecimalValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends BigDecimalValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -57,6 +58,7 @@ import lombok.Setter;
 public class BigDecimalValueSemantics
 extends ValueSemanticsAbstract<BigDecimal>
 implements
+    NumericValueSemantics,
     DefaultsProvider<BigDecimal>,
     Parser<BigDecimal>,
     Renderer<BigDecimal>,
@@ -114,7 +116,7 @@ implements
 
     @Override
     public String htmlPresentation(final ValueSemanticsProvider.Context context, final BigDecimal value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -132,7 +134,7 @@ implements
         var parsePolicy = isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())
                                 ? GroupingSeparatorPolicy.ALLOW
                                 : GroupingSeparatorPolicy.DISALLOW;
-        return super.parseDecimal(context, text, parsePolicy)
+        return parseDecimal(context, text, parsePolicy)
                 .orElse(null);
     }
 
@@ -146,7 +148,7 @@ implements
     }
 
     @Override
-    protected void configureDecimalFormat(
+    public void configureDecimalFormat(
             final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {
 
         var specificationLoader = MetaModelContext.instanceElseFail().getSpecificationLoader();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -33,6 +33,7 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
 
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
+import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
@@ -40,6 +41,7 @@ import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.core.config.CausewayConfiguration;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.util.Facets;
@@ -107,10 +109,21 @@ implements
 
     @Override
     public BigDecimal parseTextRepresentation(final ValueSemanticsProvider.Context context, final String text) {
-        var parsePolicy = isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())
-                                ? GroupingSeparatorPolicy.ALLOW
-                                : GroupingSeparatorPolicy.DISALLOW;
-        return parseDecimal(context, text, parsePolicy)
+        var input = _Strings.blankToNullOrTrim(text);
+        if(input==null)
+            return null;
+
+        var groupingSeparatorPolicy = isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())
+            ? GroupingSeparatorPolicy.ALLOW
+            : GroupingSeparatorPolicy.DISALLOW;
+
+        if (groupingSeparatorPolicy == GroupingSeparatorPolicy.DISALLOW) {
+            var groupingSeparatorChar = getGroupingSeparator(context);
+            if (input.contains(""+groupingSeparatorChar))
+                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
+        }
+
+        return parseDecimal(context, text)
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -179,10 +179,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends BigDecimalValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends BigDecimalValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends BigDecimalValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -106,14 +106,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final ValueSemanticsProvider.Context context, final BigDecimal value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, PARSING)
-                    .format(value);
-    }
-
-    @Override
     public BigDecimal parseTextRepresentation(final ValueSemanticsProvider.Context context, final String text) {
         var parsePolicy = isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())
                                 ? GroupingSeparatorPolicy.ALLOW

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -37,9 +37,7 @@ import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.core.config.CausewayConfiguration;
@@ -56,12 +54,10 @@ import lombok.Setter;
 @Named("causeway.metamodel.value.BigDecimalValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class BigDecimalValueSemantics
-extends ValueSemanticsAbstract<BigDecimal>
+extends NumericValueSemantics<BigDecimal>
 implements
-    NumericValueSemantics,
     DefaultsProvider<BigDecimal>,
     Parser<BigDecimal>,
-    Renderer<BigDecimal>,
     IdStringifier.EntityAgnostic<BigDecimal> {
 
     @Setter @Inject
@@ -105,18 +101,6 @@ implements
     @Override
     public BigDecimal destring(final @NonNull String stringified) {
         return new BigDecimal(stringified);
-    }
-
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final ValueSemanticsProvider.Context context, final BigDecimal value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final ValueSemanticsProvider.Context context, final BigDecimal value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -173,7 +157,7 @@ implements
         // we skip this when PARSING,
         // because we want to firstly parse any number value into a BigDecimal,
         // no matter the minimumFractionDigits, which can always be filled up with '0' digits later
-        if(usedFor.isRendering() || bigDecimalConfig.editing().preserveScale()) {
+        if(!usedFor.isParsing() || bigDecimalConfig.editing().preserveScale()) {
 
             // if there is a facet specifying minFractionalDigits (ie the scale), then apply it
             OptionalInt optionalInt = Facets.minFractionalDigits(feature);

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -33,7 +33,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
@@ -47,8 +46,6 @@ import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.util.Facets;
 import org.apache.causeway.schema.common.v2.ValueType;
 import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
-
-import static org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract.FormatUsageFor.PARSING;
 
 import lombok.Setter;
 
@@ -113,20 +110,8 @@ implements
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)
             return null;
-
-        //FIXME remove
-        if (!isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())) {
-            var groupingSeparatorChar = localeGroupingSeparator(context);
-            if (input.contains(""+groupingSeparatorChar))
-                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
-        }
-
         return parseDecimal(context, text)
-                .orElse(null);
-    }
-
-    private boolean isUseGroupingSeparatorFrom(final CausewayConfiguration.ValueTypes.BigDecimal bigDecimalConfig) {
-        return bigDecimalConfig.editing().useGroupingSeparator() || bigDecimalConfig.display().useGroupingSeparator();
+            .orElse(null);
     }
 
     @Override
@@ -138,25 +123,20 @@ implements
     public void configureDecimalFormat(
             final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {
 
+        if(context==null)
+            return;
+
         var specificationLoader = MetaModelContext.instanceElseFail().getSpecificationLoader();
-
-        var bigDecimalConfig = causewayConfiguration.valueTypes().bigDecimal();
-        format.setGroupingUsed(
-                usedFor == PARSING
-                    ? bigDecimalConfig.editing().useGroupingSeparator()
-                    : bigDecimalConfig.display().useGroupingSeparator()
-        );
-
-        if(context==null) return;
-
         var feature = specificationLoader.loadFeature(context.featureIdentifier())
                 .orElse(null);
-        if(feature==null) return;
+        if(feature==null)
+            return;
 
         // evaluate any facets that provide the MaximumFractionDigits
         Facets.maxFractionalDigits(feature)
                 .ifPresent(newValue -> format.setMaximumFractionDigits(newValue));
 
+        var bigDecimalConfig = causewayConfiguration.valueTypes().bigDecimal();
         // we skip this when PARSING,
         // because we want to firstly parse any number value into a BigDecimal,
         // no matter the minimumFractionDigits, which can always be filled up with '0' digits later
@@ -168,15 +148,10 @@ implements
                 format.setMinimumFractionDigits(optionalInt.getAsInt());
             } else {
                 // otherwise, apply a minScale if configured.
-                minScaleFrom(bigDecimalConfig)
-                        .ifPresent(format::setMinimumFractionDigits);
+                Optional.ofNullable(bigDecimalConfig.display().minScale())
+                    .ifPresent(format::setMinimumFractionDigits);
             }
         }
-    }
-
-    private static Optional<Integer> minScaleFrom(final CausewayConfiguration.ValueTypes.BigDecimal bigDecimalConfig) {
-        return Optional.ofNullable(bigDecimalConfig.display().minScale())
-                       .or(() -> Optional.ofNullable(bigDecimalConfig.display().minScale()));
     }
 
     @Override
@@ -197,7 +172,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends BigDecimalValueSemantics {
+    public static class NoGrouping extends BigDecimalValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -205,7 +180,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends BigDecimalValueSemantics {
+    public static class LocaleGrouping extends BigDecimalValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -113,12 +113,9 @@ implements
         if(input==null)
             return null;
 
-        var groupingSeparatorPolicy = isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())
-            ? GroupingSeparatorPolicy.ALLOW
-            : GroupingSeparatorPolicy.DISALLOW;
-
-        if (groupingSeparatorPolicy == GroupingSeparatorPolicy.DISALLOW) {
-            var groupingSeparatorChar = getGroupingSeparator(context);
+        //FIXME remove
+        if (!isUseGroupingSeparatorFrom(causewayConfiguration.valueTypes().bigDecimal())) {
+            var groupingSeparatorChar = localeGroupingSeparator(context);
             if (input.contains(""+groupingSeparatorChar))
                 throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
@@ -91,14 +91,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final BigInteger value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value);
-    }
-
-    @Override
     public BigInteger parseTextRepresentation(final Context context, final String text) {
         return parseInteger(context, text)
                 .orElse(null);

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
@@ -33,9 +33,7 @@ import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.schema.common.v2.ValueType;
 import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
@@ -44,12 +42,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.BigIntegerValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class BigIntegerValueSemantics
-extends ValueSemanticsAbstract<BigInteger>
+extends NumericValueSemantics<BigInteger>
 implements
-    NumericValueSemantics,
     DefaultsProvider<BigInteger>,
     Parser<BigInteger>,
-    Renderer<BigInteger>,
     IdStringifier.EntityAgnostic<BigInteger> {
 
     @Override
@@ -80,18 +76,6 @@ implements
                 decomposition, ValueWithTypeDto::getBigInteger, UnaryOperator.identity(), ()->null);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final BigInteger value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final BigInteger value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- ID STRINGIFIER
 
     @Override
@@ -110,7 +94,7 @@ implements
     public String parseableTextRepresentation(final Context context, final BigInteger value) {
         return value==null
                 ? null
-                : getNumberFormat(context)
+                : getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
@@ -118,7 +118,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends BigIntegerValueSemantics {
+    public static class NoGrouping extends BigIntegerValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -126,7 +126,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends BigIntegerValueSemantics {
+    public static class LocaleGrouping extends BigIntegerValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
@@ -21,14 +21,14 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 import java.math.BigInteger;
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
@@ -40,7 +40,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 
 @Component
 @Named("causeway.metamodel.value.BigIntegerValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class BigIntegerValueSemantics
 extends NumericValueSemantics<BigInteger>
 implements
@@ -111,6 +112,24 @@ implements
                 BigInteger.TEN,
                 BigInteger.valueOf(123_456_789_012L)
                 );
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends BigIntegerValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends BigIntegerValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
@@ -125,10 +125,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends BigIntegerValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends BigIntegerValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends BigIntegerValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigIntegerValueSemantics.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component;
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -45,6 +46,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public class BigIntegerValueSemantics
 extends ValueSemanticsAbstract<BigInteger>
 implements
+    NumericValueSemantics,
     DefaultsProvider<BigInteger>,
     Parser<BigInteger>,
     Renderer<BigInteger>,
@@ -87,7 +89,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final BigInteger value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- ID STRINGIFIER
@@ -114,7 +116,7 @@ implements
 
     @Override
     public BigInteger parseTextRepresentation(final Context context, final String text) {
-        return super.parseInteger(context, text)
+        return parseInteger(context, text)
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
@@ -96,14 +96,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final Byte value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value);
-    }
-
-    @Override
     public Byte parseTextRepresentation(final Context context, final String text) {
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
@@ -142,10 +142,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends ByteValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends ByteValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends ByteValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
@@ -135,7 +135,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends ByteValueSemantics {
+    public static class NoGrouping extends ByteValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -143,7 +143,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends ByteValueSemantics {
+    public static class LocaleGrouping extends ByteValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
@@ -32,6 +32,7 @@ import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -50,6 +51,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public class ByteValueSemantics
 extends ValueSemanticsAbstract<Byte>
 implements
+    NumericValueSemantics,
     DefaultsProvider<Byte>,
     Parser<Byte>,
     Renderer<Byte>,
@@ -104,7 +106,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Byte value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -123,7 +125,7 @@ implements
         if(input==null)
             return null;
         try {
-            return super.parseInteger(context, input)
+            return parseInteger(context, input)
                     .map(BigInteger::byteValueExact)
                     .orElse(null);
         } catch (final NumberFormatException | ArithmeticException e) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
@@ -34,9 +34,7 @@ import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.schema.common.v2.ValueType;
@@ -49,12 +47,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.ByteValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class ByteValueSemantics
-extends ValueSemanticsAbstract<Byte>
+extends NumericValueSemantics<Byte>
 implements
-    NumericValueSemantics,
     DefaultsProvider<Byte>,
     Parser<Byte>,
-    Renderer<Byte>,
     IdStringifier.EntityAgnostic<Byte> {
 
     @Override
@@ -97,25 +93,13 @@ implements
         return Byte.parseByte(stringified);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final Byte value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final Byte value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- PARSER
 
     @Override
     public String parseableTextRepresentation(final Context context, final Byte value) {
         return value==null
                 ? null
-                : getNumberFormat(context)
+                : getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ByteValueSemantics.java
@@ -21,14 +21,14 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 import java.math.BigInteger;
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
@@ -45,7 +45,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 @Component
 @Named("causeway.metamodel.value.ByteValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class ByteValueSemantics
 extends NumericValueSemantics<Byte>
 implements
@@ -126,6 +127,26 @@ implements
         return Can.of(
                 Byte.MIN_VALUE,
                 Byte.MAX_VALUE);
+    }
+
+    // -- GROUPING VARIANTS
+    //
+    //NOTE: grouping will never be used for bytes; however, providing those variants anyway
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends ByteValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends ByteValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/CharacterValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/CharacterValueSemantics.java
@@ -126,7 +126,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Character value) {
-        return renderHtml(value, c->""+c, super::toMonospace);
+        return renderHtml(value, pipe(c->""+c, super::toMonospace));
     }
 
     // -- PARSER

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -112,10 +112,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends DoubleValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends DoubleValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends DoubleValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -105,7 +105,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends DoubleValueSemantics {
+    public static class NoGrouping extends DoubleValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -113,7 +113,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends DoubleValueSemantics {
+    public static class LocaleGrouping extends DoubleValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -20,12 +20,12 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
@@ -40,7 +40,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 @Component
 @Named("causeway.metamodel.value.DoubleValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class DoubleValueSemantics
 extends NumericValueSemantics<Double>
 implements
@@ -98,6 +99,24 @@ implements
     @Override
     public Can<Double> getExamples() {
         return Can.of(1.0d, 0.1d, Math.PI, Double.MIN_VALUE, Double.MAX_VALUE);
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends DoubleValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends DoubleValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -29,9 +29,7 @@ import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.primitives._Doubles;
 import org.apache.causeway.schema.common.v2.ValueType;
@@ -44,12 +42,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.DoubleValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class DoubleValueSemantics
-extends ValueSemanticsAbstract<Double>
+extends NumericValueSemantics<Double>
 implements
-    NumericValueSemantics,
     DefaultsProvider<Double>,
-    Parser<Double>,
-    Renderer<Double> {
+    Parser<Double> {
 
     @Override
     public Class<Double> getCorrespondingClass() {
@@ -79,24 +75,12 @@ implements
                 decomposition, ValueWithTypeDto::getDouble, UnaryOperator.identity(), ()->null);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final Double value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final Double value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- PARSER
 
     @Override
     public String parseableTextRepresentation(final Context context, final Double value) {
         return value!=null
-                ? getNumberFormat(context)
+                ? getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value)
                 : null;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -79,7 +79,7 @@ implements
 
     @Override
     public Double parseTextRepresentation(final Context context, final String text) {
-        return _Doubles.convertToDouble(parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
+        return _Doubles.convertToDouble(parseDecimal(context, text))
                 .orElse(null);
     }
 
@@ -97,7 +97,7 @@ implements
 
     @Override
     public Can<Double> getExamples() {
-        return Can.of(Double.MIN_VALUE, Double.MAX_VALUE);
+        return Can.of(1.0d, 0.1d, Math.PI, Double.MIN_VALUE, Double.MAX_VALUE);
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -45,6 +46,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public class DoubleValueSemantics
 extends ValueSemanticsAbstract<Double>
 implements
+    NumericValueSemantics,
     DefaultsProvider<Double>,
     Parser<Double>,
     Renderer<Double> {
@@ -86,7 +88,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Double value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -101,7 +103,7 @@ implements
 
     @Override
     public Double parseTextRepresentation(final Context context, final String text) {
-        return _Doubles.convertToDouble(super.parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
+        return _Doubles.convertToDouble(parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -78,14 +78,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final Double value) {
-        return value!=null
-                ? getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value)
-                : null;
-    }
-
-    @Override
     public Double parseTextRepresentation(final Context context, final String text) {
         return _Doubles.convertToDouble(parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
                 .orElse(null);

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -78,14 +78,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final Float value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value);
-    }
-
-    @Override
     public Float parseTextRepresentation(final Context context, final String text) {
         return _Floats.convertToFloat(parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
                 .orElse(null);

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -29,9 +29,7 @@ import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.primitives._Floats;
 import org.apache.causeway.schema.common.v2.ValueType;
@@ -44,12 +42,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.FloatValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class FloatValueSemantics
-extends ValueSemanticsAbstract<Float>
+extends NumericValueSemantics<Float>
 implements
-    NumericValueSemantics,
     DefaultsProvider<Float>,
-    Parser<Float>,
-    Renderer<Float> {
+    Parser<Float> {
 
     @Override
     public Class<Float> getCorrespondingClass() {
@@ -79,25 +75,13 @@ implements
                 decomposition, ValueWithTypeDto::getFloat, UnaryOperator.identity(), ()->null);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final Float value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final Float value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- PARSER
 
     @Override
     public String parseableTextRepresentation(final Context context, final Float value) {
         return value==null
                 ? null
-                : getNumberFormat(context)
+                : getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -20,12 +20,12 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
@@ -40,7 +40,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 @Component
 @Named("causeway.metamodel.value.FloatValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class FloatValueSemantics
 extends NumericValueSemantics<Float>
 implements
@@ -98,6 +99,24 @@ implements
     @Override
     public Can<Float> getExamples() {
         return Can.of(Float.MIN_VALUE, Float.MAX_VALUE);
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends FloatValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends FloatValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -112,10 +112,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends FloatValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends FloatValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends FloatValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -105,7 +105,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends FloatValueSemantics {
+    public static class NoGrouping extends FloatValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -113,7 +113,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends FloatValueSemantics {
+    public static class LocaleGrouping extends FloatValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -79,7 +79,7 @@ implements
 
     @Override
     public Float parseTextRepresentation(final Context context, final String text) {
-        return _Floats.convertToFloat(parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
+        return _Floats.convertToFloat(parseDecimal(context, text))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -45,6 +46,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public class FloatValueSemantics
 extends ValueSemanticsAbstract<Float>
 implements
+    NumericValueSemantics,
     DefaultsProvider<Float>,
     Parser<Float>,
     Renderer<Float> {
@@ -86,7 +88,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Float value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -101,7 +103,7 @@ implements
 
     @Override
     public Float parseTextRepresentation(final Context context, final String text) {
-        return _Floats.convertToFloat(super.parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
+        return _Floats.convertToFloat(parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
@@ -138,10 +138,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends IntValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends IntValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends IntValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
@@ -32,6 +32,7 @@ import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -50,6 +51,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public class IntValueSemantics
 extends ValueSemanticsAbstract<Integer>
 implements
+    NumericValueSemantics,
     DefaultsProvider<Integer>,
     Parser<Integer>,
     Renderer<Integer>,
@@ -104,7 +106,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Integer value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -123,7 +125,7 @@ implements
         if(input==null)
             return null;
         try {
-            return super.parseInteger(context, input)
+            return parseInteger(context, input)
                     .map(BigInteger::intValueExact)
                     .orElse(null);
         } catch (final NumberFormatException | ArithmeticException e) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
@@ -96,14 +96,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final Integer value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value);
-    }
-
-    @Override
     public Integer parseTextRepresentation(final Context context, final String text) {
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
@@ -131,7 +131,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends IntValueSemantics {
+    public static class NoGrouping extends IntValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -139,7 +139,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends IntValueSemantics {
+    public static class LocaleGrouping extends IntValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
@@ -21,14 +21,14 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 import java.math.BigInteger;
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
@@ -45,7 +45,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 @Component
 @Named("causeway.metamodel.value.IntValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class IntValueSemantics
 extends NumericValueSemantics<Integer>
 implements
@@ -123,7 +124,25 @@ implements
 
     @Override
     public Can<Integer> getExamples() {
-        return Can.of(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        return Can.of(0, 1, 2026, Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends IntValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends IntValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/IntValueSemantics.java
@@ -34,9 +34,7 @@ import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.schema.common.v2.ValueType;
@@ -49,12 +47,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.IntValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class IntValueSemantics
-extends ValueSemanticsAbstract<Integer>
+extends NumericValueSemantics<Integer>
 implements
-    NumericValueSemantics,
     DefaultsProvider<Integer>,
     Parser<Integer>,
-    Renderer<Integer>,
     IdStringifier.EntityAgnostic<Integer>{
 
     @Override
@@ -97,25 +93,13 @@ implements
         return Integer.parseInt(stringified);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final Integer value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final Integer value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- PARSER
 
     @Override
     public String parseableTextRepresentation(final Context context, final Integer value) {
         return value==null
                 ? null
-                : getNumberFormat(context)
+                : getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
@@ -34,9 +34,7 @@ import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.schema.common.v2.ValueType;
@@ -49,12 +47,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.LongValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class LongValueSemantics
-extends ValueSemanticsAbstract<Long>
+extends NumericValueSemantics<Long>
 implements
-    NumericValueSemantics,
     DefaultsProvider<Long>,
     Parser<Long>,
-    Renderer<Long>,
     IdStringifier.EntityAgnostic<Long>{
 
     @Override
@@ -97,25 +93,13 @@ implements
         return Long.parseLong(stringified);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final Long value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final Long value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- PARSER
 
     @Override
     public String parseableTextRepresentation(final Context context, final Long value) {
         return value==null
                 ? null
-                : getNumberFormat(context)
+                : getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
@@ -131,7 +131,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends LongValueSemantics {
+    public static class NoGrouping extends LongValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -139,7 +139,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends LongValueSemantics {
+    public static class LocaleGrouping extends LongValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
@@ -138,10 +138,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends LongValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends LongValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends LongValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
@@ -24,12 +24,15 @@ import java.util.function.UnaryOperator;
 import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
+import org.jspecify.annotations.NonNull;
+
 import org.springframework.stereotype.Component;
 
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -38,8 +41,6 @@ import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.schema.common.v2.ValueType;
 import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
-
-import org.jspecify.annotations.NonNull;
 
 /**
  * due to auto-boxing also handles the primitive variant
@@ -50,6 +51,7 @@ import org.jspecify.annotations.NonNull;
 public class LongValueSemantics
 extends ValueSemanticsAbstract<Long>
 implements
+    NumericValueSemantics,
     DefaultsProvider<Long>,
     Parser<Long>,
     Renderer<Long>,
@@ -104,7 +106,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Long value) {
-        return renderHtml(value, getNumberFormat(context)::format);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -120,11 +122,10 @@ implements
     @Override
     public Long parseTextRepresentation(final Context context, final String text) {
         var input = _Strings.blankToNullOrTrim(text);
-        if(input==null) {
+        if(input==null)
             return null;
-        }
         try {
-            return super.parseInteger(context, input)
+            return parseInteger(context, input)
                     .map(BigInteger::longValueExact)
                     .orElse(null);
         } catch (final NumberFormatException | ArithmeticException e) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
@@ -21,14 +21,14 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 import java.math.BigInteger;
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
@@ -45,7 +45,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 @Component
 @Named("causeway.metamodel.value.LongValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class LongValueSemantics
 extends NumericValueSemantics<Long>
 implements
@@ -123,7 +124,25 @@ implements
 
     @Override
     public Can<Long> getExamples() {
-        return Can.of(Long.MIN_VALUE, Long.MAX_VALUE);
+        return Can.of(0L, 1L, 2026L, Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends LongValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends LongValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/LongValueSemantics.java
@@ -96,14 +96,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final Long value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value);
-    }
-
-    @Override
     public Long parseTextRepresentation(final Context context, final String text) {
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
@@ -143,10 +143,18 @@ implements
     }
 
     @Component
-    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public static class LocaleGrouping extends ShortValueSemantics {
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
+    public static class LocaleGroupingDisplay extends ShortValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
-            return GroupingSeparatorProvider.LOCALE_GROUPING;
+            return GroupingSeparatorProvider.LOCALE_GROUPING_DISPLAY;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING_ALL)
+    public static class LocaleGroupingAll extends ShortValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING_ALL;
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
@@ -21,14 +21,14 @@ package org.apache.causeway.core.metamodel.valuesemantics;
 import java.math.BigInteger;
 import java.util.function.UnaryOperator;
 
-import jakarta.annotation.Priority;
 import jakarta.inject.Named;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
@@ -45,7 +45,8 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
  */
 @Component
 @Named("causeway.metamodel.value.ShortValueSemantics")
-@Priority(PriorityPrecedence.LATE)
+@Primary
+//has no effect @Priority(PriorityPrecedence.LATE)
 public class ShortValueSemantics
 extends NumericValueSemantics<Short>
 implements
@@ -124,8 +125,29 @@ implements
     @Override
     public Can<Short> getExamples() {
         return Can.of(
+                (short)0,
+                (short)1,
+                (short)2026,
                 Short.MIN_VALUE,
                 Short.MAX_VALUE);
+    }
+
+    // -- GROUPING VARIANTS
+
+    @Component
+    @Qualifier(NumericValueSemantics.NO_GROUPING)
+    public class NoGrouping extends ShortValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.NO_GROUPING;
+        }
+    }
+
+    @Component
+    @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
+    public class LocaleGrouping extends ShortValueSemantics {
+        @Override protected GroupingSeparatorProvider grouping() {
+            return GroupingSeparatorProvider.LOCALE_GROUPING;
+        }
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
@@ -96,14 +96,6 @@ implements
     // -- PARSER
 
     @Override
-    public String parseableTextRepresentation(final Context context, final Short value) {
-        return value==null
-                ? null
-                : getNumberFormat(context, FormatUsageFor.PARSING)
-                    .format(value);
-    }
-
-    @Override
     public Short parseTextRepresentation(final Context context, final String text) {
         var input = _Strings.blankToNullOrTrim(text);
         if(input==null)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
@@ -32,6 +32,7 @@ import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
 import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
@@ -50,6 +51,7 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 public class ShortValueSemantics
 extends ValueSemanticsAbstract<Short>
 implements
+    NumericValueSemantics,
     DefaultsProvider<Short>,
     Parser<Short>,
     Renderer<Short>,
@@ -104,7 +106,7 @@ implements
 
     @Override
     public String htmlPresentation(final Context context, final Short value) {
-        return renderHtml(value, getNumberFormat(context)::format, super::toMonospace);
+        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
     }
 
     // -- PARSER
@@ -123,7 +125,7 @@ implements
         if(input==null)
             return null;
         try {
-            return super.parseInteger(context, input)
+            return parseInteger(context, input)
                     .map(BigInteger::shortValueExact)
                     .orElse(null);
         } catch (final NumberFormatException | ArithmeticException e) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
@@ -136,7 +136,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.NO_GROUPING)
-    public class NoGrouping extends ShortValueSemantics {
+    public static class NoGrouping extends ShortValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.NO_GROUPING;
         }
@@ -144,7 +144,7 @@ implements
 
     @Component
     @Qualifier(NumericValueSemantics.LOCALE_GROUPING)
-    public class LocaleGrouping extends ShortValueSemantics {
+    public static class LocaleGrouping extends ShortValueSemantics {
         @Override protected GroupingSeparatorProvider grouping() {
             return GroupingSeparatorProvider.LOCALE_GROUPING;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/ShortValueSemantics.java
@@ -34,9 +34,7 @@ import org.apache.causeway.applib.services.bookmark.IdStringifier;
 import org.apache.causeway.applib.value.semantics.DefaultsProvider;
 import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.applib.value.semantics.Parser;
-import org.apache.causeway.applib.value.semantics.Renderer;
 import org.apache.causeway.applib.value.semantics.ValueDecomposition;
-import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.schema.common.v2.ValueType;
@@ -49,12 +47,10 @@ import org.apache.causeway.schema.common.v2.ValueWithTypeDto;
 @Named("causeway.metamodel.value.ShortValueSemantics")
 @Priority(PriorityPrecedence.LATE)
 public class ShortValueSemantics
-extends ValueSemanticsAbstract<Short>
+extends NumericValueSemantics<Short>
 implements
-    NumericValueSemantics,
     DefaultsProvider<Short>,
     Parser<Short>,
-    Renderer<Short>,
     IdStringifier.EntityAgnostic<Short> {
 
     @Override
@@ -97,25 +93,13 @@ implements
         return Short.parseShort(stringified);
     }
 
-    // -- RENDERER
-
-    @Override
-    public String titlePresentation(final Context context, final Short value) {
-        return renderTitle(value, getNumberFormat(context)::format);
-    }
-
-    @Override
-    public String htmlPresentation(final Context context, final Short value) {
-        return renderHtml(value, pipe(getNumberFormat(context)::format, super::toMonospace));
-    }
-
     // -- PARSER
 
     @Override
     public String parseableTextRepresentation(final Context context, final Short value) {
         return value==null
                 ? null
-                : getNumberFormat(context)
+                : getNumberFormat(context, FormatUsageFor.PARSING)
                     .format(value);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/UUIDValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/UUIDValueSemantics.java
@@ -91,7 +91,7 @@ implements
 
     @Override
     public String htmlPresentation(final ValueSemanticsProvider.Context context, final UUID value) {
-        return renderHtml(value, UUID::toString, super::toMonospace);
+        return renderHtml(value, pipe(UUID::toString, super::toMonospace));
     }
 
     // -- PARSER

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/temporal/TemporalValueSemanticsProvider.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/temporal/TemporalValueSemanticsProvider.java
@@ -35,6 +35,7 @@ import java.util.function.UnaryOperator;
 
 import jakarta.inject.Inject;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import org.apache.causeway.applib.annotation.TimePrecision;
@@ -55,7 +56,6 @@ import org.apache.causeway.core.metamodel.facets.objectvalue.temporalformat.Time
 import org.apache.causeway.core.metamodel.facets.objectvalue.temporalformat.TimeZoneTranslationFacet;
 
 import lombok.Getter;
-import org.jspecify.annotations.NonNull;
 import lombok.experimental.Accessors;
 
 /**
@@ -126,12 +126,11 @@ implements TemporalValueSemantics<T> {
                 ? Duration.ofDays(a.until(b, ChronoUnit.DAYS))
                 : Duration.between(a, b);
 
-        if(epsilon.minus(delta.abs()).isNegative()) {
+        if(epsilon.minus(delta.abs()).isNegative())
             // negative delta means a > b => should return +1
             return delta.isNegative()
                     ? 1
                     : -1;
-        }
         return 0;
     }
 
@@ -180,17 +179,15 @@ implements TemporalValueSemantics<T> {
     @Override
     public final T parseTextRepresentation(final ValueSemanticsProvider.Context context, final String text) {
         var temporalString = _Strings.blankToNullOrTrim(text);
-        if(temporalString==null) {
+        if(temporalString==null)
             return null;
-        }
 
         T contextTemporal = null; //FIXME[CAUSEWAY-2882] not implemented yet
         if(contextTemporal != null) {
             var adjusted = TemporalAdjust
                     .parseAdjustment(adjuster, contextTemporal, temporalString);
-            if(adjusted!=null) {
+            if(adjusted!=null)
                 return adjusted;
-            }
         }
 
         var format = getEditingInputFormat(context);
@@ -280,6 +277,43 @@ implements TemporalValueSemantics<T> {
         };
     }
 
+    // -- FORMAT
+
+    protected DateTimeFormatter getTemporalNoZoneRenderingFormat(
+            final @Nullable Context context,
+            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
+            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic,
+            final @NonNull FormatStyle dateFormatStyle,
+            final @NonNull FormatStyle timeFormatStyle,
+            final @Nullable String datePattern,
+            final @Nullable String dateTimePattern) {
+
+        final DateTimeFormatter noZoneOutputFormat = switch (temporalCharacteristic) {
+            case DATE_TIME -> dateTimePattern != null
+                                ? DateTimeFormatter.ofPattern(dateTimePattern)
+                                : DateTimeFormatter.ofLocalizedDateTime(dateFormatStyle, timeFormatStyle);
+            case DATE_ONLY -> datePattern != null
+                                ? DateTimeFormatter.ofPattern(datePattern)
+                                : DateTimeFormatter.ofLocalizedDate(dateFormatStyle);
+            case TIME_ONLY -> DateTimeFormatter.ofLocalizedTime(timeFormatStyle);
+        };
+
+        return noZoneOutputFormat
+                .withLocale(getUserLocale(context).timeFormatLocale());
+    }
+
+    protected Optional<DateTimeFormatter> getTemporalZoneOnlyRenderingFormat(
+            final ValueSemanticsProvider.@Nullable Context context,
+            final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
+            final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic) {
+
+        return switch (offsetCharacteristic) {
+            case LOCAL -> Optional.empty();
+            case OFFSET -> Optional.of(_Temporals.ISO_OFFSET_ONLY_FORMAT);
+            case ZONED -> Optional.of(_Temporals.DEFAULT_ZONEID_ONLY_FORMAT);
+        };
+    }
+
 //    /**
 //     * Converts given {@link Temporal} when offset,
 //     * to a temporal that is local to the user's (client's) time-zone.
@@ -310,18 +344,15 @@ implements TemporalValueSemantics<T> {
      * In other words, this conversion preserves the time {@link Instant}.
      */
     private Temporal translateToUserLocalTimeZone(final ValueSemanticsProvider.Context context, final Temporal t) {
-        if(t instanceof ZonedDateTime zonedDateTime) {
+        if(t instanceof ZonedDateTime zonedDateTime)
             return _Temporals.translateToTimeZone(zonedDateTime,
                     context.interactionContext().getTimeZone());
-        }
-        if(t instanceof OffsetDateTime offsetDateTime) {
+        if(t instanceof OffsetDateTime offsetDateTime)
             return _Temporals.translateToTimeZone(offsetDateTime,
                     context.interactionContext().getTimeZone());
-        }
-        if(t instanceof OffsetTime offsetTime) {
+        if(t instanceof OffsetTime offsetTime)
             return _Temporals.translateToTimeOffset(offsetTime,
                     context.interactionContext().getTimeZoneOffsetNow());
-        }
         return t; // otherwise acts as identity operator
     }
 

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
@@ -19,12 +19,12 @@
 package org.apache.causeway.core.metamodel.facets.value;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -80,9 +80,9 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
             .test(causewayConfiguration->{
                 value.setCausewayConfiguration(causewayConfiguration);
 
-                BigDecimal bd = value.parseTextRepresentation(null, "123,999.01");
-
-                assertThat(bd).isEqualTo(new BigDecimal("123999.01").setScale(2, RoundingMode.HALF_EVEN));
+              //FIXME test various qualified ValueSemanticsProviders specifically
+//                BigDecimal bd = value.parseTextRepresentation(null, "123,999.01");
+//                assertThat(bd).isEqualTo(new BigDecimal("123999.01").setScale(2, RoundingMode.HALF_EVEN));
             });
     }
 
@@ -90,19 +90,16 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
     void demonstrateTheRiskOfAllowingGroupingSeparatorIfConfiguredToAllow() throws Exception {
 
         // default disallows grouping separator
-        try {
-            value.parseTextRepresentation(null, "1239,99");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1239,99"));
 
         // but if we allow it...
         new ConfigurationTester(TestPropertyValues.of("causeway.valueTypes.bigDecimal.editing.useGroupingSeparator=true"))
             .test(causewayConfiguration->{
                 value.setCausewayConfiguration(causewayConfiguration);
 
-                BigDecimal bigDecimal = value.parseTextRepresentation(null, "1239,99");
-                assertThat(bigDecimal).isEqualTo(new BigDecimal(123999));
+                //FIXME test various qualified ValueSemanticsProviders specifically
+//                BigDecimal bigDecimal = value.parseTextRepresentation(null, "1239,99");
+//                assertThat(bigDecimal).isEqualTo(new BigDecimal(123999));
             });
     }
 
@@ -112,18 +109,19 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
     }
 
     @Test
-    void titleOf() {
-        assertEquals("34,132.199", value.titlePresentation(null, bigDecimal));
+    void title() {
+        assertEquals("34 132.199", value.titlePresentation(null, bigDecimal));
     }
 
-    @Test
-    void titleOfWhenUseGroupingSeparator() {
-        new ConfigurationTester(TestPropertyValues.of("causeway.valueTypes.bigDecimal.display.useGroupingSeparator=true"))
-        .test(causewayConfiguration->{
-            value.setCausewayConfiguration(causewayConfiguration);
-            assertEquals("34,132.199", value.titlePresentation(null, bigDecimal));
-        });
-    }
+//FIXME test various qualified ValueSemanticsProviders specifically
+//    @Test
+//    void titleOfWhenUseGroupingSeparator() {
+//        new ConfigurationTester(TestPropertyValues.of("causeway.valueTypes.bigDecimal.display.useGroupingSeparator=true"))
+//        .test(causewayConfiguration->{
+//            value.setCausewayConfiguration(causewayConfiguration);
+//            assertEquals("34,132.199", value.titlePresentation(null, bigDecimal));
+//        });
+//    }
 
     @Override
     protected BigDecimal getSample() {

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
@@ -19,19 +19,20 @@
 package org.apache.causeway.core.metamodel.facets.value;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import org.springframework.boot.test.util.TestPropertyValues;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
+import org.apache.causeway.core.config.CausewayConfiguration;
 import org.apache.causeway.core.metamodel.valuesemantics.BigDecimalValueSemantics;
-import org.apache.causeway.core.mmtestsupport.ConfigurationTester;
 
 class BigDecimalValueSemanticsProviderTest
 extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
@@ -39,89 +40,104 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
     private BigDecimalValueSemantics value;
     private BigDecimal bigDecimal;
 
+    enum Scenario {
+        DEFAULT,
+        NO_GROUPING,
+        LOCALE_GROUPING_DISPLAY,
+        LOCALE_GROUPING_ALL;
+
+        BigDecimalValueSemantics valueSemantics(final CausewayConfiguration causewayConfiguration) {
+            BigDecimalValueSemantics valSem = switch (this) {
+                case DEFAULT -> new BigDecimalValueSemantics();
+                case NO_GROUPING -> new BigDecimalValueSemantics.NoGrouping();
+                case LOCALE_GROUPING_DISPLAY -> new BigDecimalValueSemantics.LocaleGroupingDisplay();
+                case LOCALE_GROUPING_ALL -> new BigDecimalValueSemantics.LocaleGroupingAll();
+            };
+            valSem.setCausewayConfiguration(causewayConfiguration);
+            return valSem;
+        }
+    }
+
     @BeforeEach
-    void setUpObjects() throws Exception {
+    void setUpObjects() {
         bigDecimal = new BigDecimal("34132.199");
         allowMockAdapterToReturn(bigDecimal);
 
-        var valueSemantics = new BigDecimalValueSemantics();
-        valueSemantics.setCausewayConfiguration(causewayConfiguration);
-        setSemantics(value = valueSemantics);
+        setSemantics(value = Scenario.DEFAULT.valueSemantics(causewayConfiguration));
     }
 
     @Test
-    void parseValidString() throws Exception {
+    void parseValidString() {
         final Object newValue = value.parseTextRepresentation(null, "2142342334");
         assertEquals(new BigDecimal(2142342334L), newValue);
     }
 
     @Test
-    void parseInvalidString() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "214xxx2342334");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+    void parseInvalidString() {
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "214xxx2342334"));
     }
 
     @Test
-    void parseInvalidStringWithGroupingSeparator() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "123,999.01");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+    void parseInvalidStringWithGroupingSeparator() {
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "123,999.01"));
     }
 
     @Test
-    void parseValidStringWithGroupingSeparatorIfConfiguredToAllow() throws Exception {
+    void parseValidStringWithGroupingSeparatorIfConfiguredToAllow() {
+        setSemantics(value = Scenario.LOCALE_GROUPING_ALL.valueSemantics(causewayConfiguration));
 
-        new ConfigurationTester(TestPropertyValues.of("causeway.valueTypes.bigDecimal.editing.useGroupingSeparator=true"))
-            .test(causewayConfiguration->{
-                value.setCausewayConfiguration(causewayConfiguration);
-
-              //FIXME test various qualified ValueSemanticsProviders specifically
-//                BigDecimal bd = value.parseTextRepresentation(null, "123,999.01");
-//                assertThat(bd).isEqualTo(new BigDecimal("123999.01").setScale(2, RoundingMode.HALF_EVEN));
-            });
+        BigDecimal bd = value.parseTextRepresentation(null, "123,999.01");
+        assertThat(bd).isEqualTo(new BigDecimal("123999.01").setScale(2, RoundingMode.HALF_EVEN));
     }
 
     @Test
-    void demonstrateTheRiskOfAllowingGroupingSeparatorIfConfiguredToAllow() throws Exception {
+    void demonstrateTheRiskOfAllowingGroupingSeparatorIfConfiguredToAllow() {
 
         // default disallows grouping separator
         assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1239,99"));
 
         // but if we allow it...
-        new ConfigurationTester(TestPropertyValues.of("causeway.valueTypes.bigDecimal.editing.useGroupingSeparator=true"))
-            .test(causewayConfiguration->{
-                value.setCausewayConfiguration(causewayConfiguration);
+        setSemantics(value = Scenario.LOCALE_GROUPING_ALL.valueSemantics(causewayConfiguration));
 
-                //FIXME test various qualified ValueSemanticsProviders specifically
-//                BigDecimal bigDecimal = value.parseTextRepresentation(null, "1239,99");
-//                assertThat(bigDecimal).isEqualTo(new BigDecimal(123999));
-            });
+        //FIXME fail on invalid input like this
+        BigDecimal bigDecimal = value.parseTextRepresentation(null, "1239,99");
+        assertThat(bigDecimal).isEqualTo(new BigDecimal(123999));
     }
 
     @Test
-    void parseValidStringWithNoGroupingSeparator() throws Exception {
+    void parseValidStringWithNoGroupingSeparator() {
         value.parseTextRepresentation(null, "123999.01");
     }
 
-    @Test
-    void title() {
-        assertEquals("34 132.199", value.titlePresentation(null, bigDecimal));
+    @ParameterizedTest
+    @EnumSource(Scenario.class)
+    void title(final Scenario scenario) {
+        setSemantics(value = scenario.valueSemantics(causewayConfiguration));
+        var actual = value.titlePresentation(null, bigDecimal);
+        switch (scenario) {
+            case DEFAULT -> assertEquals("34 132.199", actual);
+            case NO_GROUPING -> assertEquals("34132.199", actual);
+            case LOCALE_GROUPING_DISPLAY -> assertEquals("34,132.199", actual);
+            case LOCALE_GROUPING_ALL -> assertEquals("34,132.199", actual);
+        }
     }
 
-//FIXME test various qualified ValueSemanticsProviders specifically
-//    @Test
-//    void titleOfWhenUseGroupingSeparator() {
-//        new ConfigurationTester(TestPropertyValues.of("causeway.valueTypes.bigDecimal.display.useGroupingSeparator=true"))
-//        .test(causewayConfiguration->{
-//            value.setCausewayConfiguration(causewayConfiguration);
-//            assertEquals("34,132.199", value.titlePresentation(null, bigDecimal));
-//        });
-//    }
+    @ParameterizedTest
+    @EnumSource(Scenario.class)
+    void html(final Scenario scenario) {
+        setSemantics(value = scenario.valueSemantics(causewayConfiguration));
+        var actual = value.htmlPresentation(null, bigDecimal);
+        switch (scenario) {
+            case DEFAULT -> assertEquals("""
+                    <span class="fw-light">34&#8239;132.199</span>""", actual);
+            case NO_GROUPING -> assertEquals("""
+                    <span class="fw-light">34132.199</span>""", actual);
+            case LOCALE_GROUPING_DISPLAY -> assertEquals("""
+                    <span class="fw-light">34,132.199</span>""", actual);
+            case LOCALE_GROUPING_ALL -> assertEquals("""
+                    <span class="fw-light">34,132.199</span>""", actual);
+        }
+    }
 
     @Override
     protected BigDecimal getSample() {

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
@@ -83,25 +83,30 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
     }
 
     @Test
-    void parseValidStringWithGroupingSeparatorIfConfiguredToAllow() {
+    void parseValidStringWithGroupingSeparatorIfAllowed() {
         setSemantics(value = Scenario.LOCALE_GROUPING_ALL.valueSemantics(causewayConfiguration));
 
-        BigDecimal bd = value.parseTextRepresentation(null, "123,999.01");
-        assertThat(bd).isEqualTo(new BigDecimal("123999.01").setScale(2, RoundingMode.HALF_EVEN));
+        assertThat(value.parseTextRepresentation(null, "123,999.01"))
+            .isEqualTo(new BigDecimal("123999.01").setScale(2, RoundingMode.HALF_EVEN));
     }
 
     @Test
-    void demonstrateTheRiskOfAllowingGroupingSeparatorIfConfiguredToAllow() {
-
-        // default disallows grouping separator
-        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1239,99"));
-
-        // but if we allow it...
+    void parseInvalidStringWithGroupingSeparatorIfAllowed() {
         setSemantics(value = Scenario.LOCALE_GROUPING_ALL.valueSemantics(causewayConfiguration));
 
-        //FIXME fail on invalid input like this
-        BigDecimal bigDecimal = value.parseTextRepresentation(null, "1239,99");
-        assertThat(bigDecimal).isEqualTo(new BigDecimal(123999));
+        // valid cases should pass, that is, use separators consistently or not at all
+        assertThat(value.parseTextRepresentation(null, "1234567")).isEqualTo(new BigDecimal(1234567));
+        assertThat(value.parseTextRepresentation(null, "1234567.0")).isEqualTo(new BigDecimal(1234567).setScale(1, RoundingMode.HALF_EVEN));
+        assertThat(value.parseTextRepresentation(null, "1,234,567")).isEqualTo(new BigDecimal(1234567));
+        assertThat(value.parseTextRepresentation(null, "1,234,567.0")).isEqualTo(new BigDecimal(1234567).setScale(1, RoundingMode.HALF_EVEN));
+
+        // inconsistent use of separators
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "239,99"));
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "239,99.0"));
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1234,567"));
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1234,567.0"));
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,234567"));
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,234567.0"));
     }
 
     @Test

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigIntValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigIntValueSemanticsProviderTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.core.metamodel.valuesemantics.BigIntegerValueSemantics;
@@ -49,17 +49,13 @@ extends ValueSemanticsProviderAbstractTestCase<BigInteger> {
     }
 
     @Test
-    void parseInvalidString() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "214xxx2342334");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+    void invalidParse() {
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "214xxx2342334"));
     }
 
     @Test
     void title() throws Exception {
-        assertEquals("132,199", value.titlePresentation(null, bigInt));
+        assertEquals("132 199", value.titlePresentation(null, bigInt));
     }
 
     @Override

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigIntValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigIntValueSemanticsProviderTest.java
@@ -58,6 +58,12 @@ extends ValueSemanticsProviderAbstractTestCase<BigInteger> {
         assertEquals("132 199", value.titlePresentation(null, bigInt));
     }
 
+    @Test
+    void html() {
+        assertEquals("""
+            <span class="fw-light">132&#8239;199</span>""", value.htmlPresentation(null, bigInt));
+    }
+
     @Override
     protected BigInteger getSample() {
         return bigInt;

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/DoubleValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/DoubleValueSemanticsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.core.metamodel.valuesemantics.DoubleValueSemantics;
@@ -48,16 +48,12 @@ extends ValueSemanticsProviderAbstractTestCase<Double> {
 
     @Test
     void invalidParse() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "one");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "one"));
     }
 
     @Test
-    void titleOf() {
-        assertEquals("35,000,000", value.titlePresentation(null, Double.valueOf(35000000.0)));
+    void title() {
+        assertEquals("35 000 000", value.titlePresentation(null, Double.valueOf(35000000.0)));
     }
 
     @Test
@@ -68,8 +64,7 @@ extends ValueSemanticsProviderAbstractTestCase<Double> {
 
     @Test
     void parse2() throws Exception {
-        final Object newValue = value.parseTextRepresentation(null, "1,20.0");
-        assertEquals(120, ((Double) newValue).doubleValue(), 0.0);
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,20.0"));
     }
 
     @Override

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/DoubleValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/DoubleValueSemanticsProviderTest.java
@@ -53,7 +53,13 @@ extends ValueSemanticsProviderAbstractTestCase<Double> {
 
     @Test
     void title() {
-        assertEquals("35 000 000", value.titlePresentation(null, Double.valueOf(35000000.0)));
+        assertEquals("35 000 000.0001", value.titlePresentation(null, Double.valueOf(35000000.0001)));
+    }
+
+    @Test
+    void html() {
+        assertEquals("""
+            <span class="fw-light">35&#8239;000&#8239;000.0001</span>""", value.htmlPresentation(null, Double.valueOf(35000000.0001)));
     }
 
     @Test

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/FloatValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/FloatValueSemanticsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.core.metamodel.valuesemantics.FloatValueSemantics;
@@ -43,11 +43,7 @@ extends ValueSemanticsProviderAbstractTestCase<Float> {
 
     @Test
     void invalidParse() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "one");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "one"));
     }
 
     @Test
@@ -63,8 +59,7 @@ extends ValueSemanticsProviderAbstractTestCase<Float> {
 
     @Test
     void parseBadlyFormatedEntry() throws Exception {
-        final Object parsed = value.parseTextRepresentation(null, "1,20.0");
-        assertEquals(120.0f, ((Float) parsed).floatValue(), 0.0);
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,20.0"));
     }
 
     @Override

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/FloatValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/FloatValueSemanticsProviderTest.java
@@ -47,7 +47,7 @@ extends ValueSemanticsProviderAbstractTestCase<Float> {
     }
 
     @Test
-    void titleOf() {
+    void title() {
         assertEquals("32.5", value.titlePresentation(null, float1));
     }
 

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/IntValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/IntValueSemanticsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.core.metamodel.valuesemantics.IntValueSemantics;
@@ -43,11 +43,7 @@ extends ValueSemanticsProviderAbstractTestCase<Integer> {
 
     @Test
     void invalidParse() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "one");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "one"));
     }
 
     @Test
@@ -63,8 +59,7 @@ extends ValueSemanticsProviderAbstractTestCase<Integer> {
 
     @Test
     void parseOddlyFormedEntry() throws Exception {
-        final Object newValue = value.parseTextRepresentation(null, "1,20.0");
-        assertEquals(Integer.valueOf(120), newValue);
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,20.0"));
     }
 
     @Override

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/IntValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/IntValueSemanticsProviderTest.java
@@ -47,7 +47,7 @@ extends ValueSemanticsProviderAbstractTestCase<Integer> {
     }
 
     @Test
-    void titleString() {
+    void title() {
         assertEquals("32", value.titlePresentation(null, integer));
     }
 

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/JavaUtilDateValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/JavaUtilDateValueSemanticsProviderTest.java
@@ -123,7 +123,7 @@ extends ValueSemanticsProviderAbstractTestCase<java.util.Date> {
 
         final ValueSemanticsAbstract<LocalDateTime> delegate =
                 new LocalDateTimeValueSemantics(metaModelContext) {
-            @Override protected DateTimeFormatter getTemporalEditingFormat(final Context context,
+            @Override public DateTimeFormatter getTemporalEditingFormat(final Context context,
                     final TemporalValueSemantics.@NonNull TemporalCharacteristic temporalCharacteristic,
                     final TemporalValueSemantics.@NonNull OffsetCharacteristic offsetCharacteristic,
                     final @NonNull TimePrecision _timePrecision,

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/LongValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/LongValueSemanticsProviderTest.java
@@ -53,6 +53,12 @@ extends ValueSemanticsProviderAbstractTestCase<Long> {
     }
 
     @Test
+    void html() {
+        assertEquals("""
+            <span class="fw-light">367&#8239;322</span>""", value.htmlPresentation(null, longObj));
+    }
+
+    @Test
     void parse() throws Exception {
         final Object parsed = value.parseTextRepresentation(null, "120");
         assertEquals("120", parsed.toString());

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/LongValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/LongValueSemanticsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.core.metamodel.valuesemantics.LongValueSemantics;
@@ -44,16 +44,12 @@ extends ValueSemanticsProviderAbstractTestCase<Long> {
 
     @Test
     void invalidParse() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "one");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "one"));
     }
 
     @Test
-    void outputAsString() {
-        assertEquals("367,322", value.titlePresentation(null, longObj));
+    void title() {
+        assertEquals("367 322", value.titlePresentation(null, longObj));
     }
 
     @Test
@@ -64,8 +60,7 @@ extends ValueSemanticsProviderAbstractTestCase<Long> {
 
     @Test
     void parseWithBadlyFormattedEntry() throws Exception {
-        final Object parsed = value.parseTextRepresentation(null, "1,20.0");
-        assertEquals("120", parsed.toString());
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,20.0"));
     }
 
     @Override

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/ShortValueSemanticsProviderTest.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/ShortValueSemanticsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
 import org.apache.causeway.core.metamodel.valuesemantics.ShortValueSemantics;
@@ -43,12 +43,8 @@ extends ValueSemanticsProviderAbstractTestCase<Short> {
     }
 
     @Test
-    void invalidParse() throws Exception {
-        try {
-            value.parseTextRepresentation(null, "one");
-            fail();
-        } catch (final TextEntryParseException expected) {
-        }
+    void invalidParse() {
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "one"));
     }
 
     @Test
@@ -69,8 +65,7 @@ extends ValueSemanticsProviderAbstractTestCase<Short> {
 
     @Test
     void parseOfOddEntry() throws Exception {
-        final Object newValue = value.parseTextRepresentation(null, "1,20.0");
-        assertEquals(Short.valueOf((short) 120), newValue);
+        assertThrows(TextEntryParseException.class, ()->value.parseTextRepresentation(null, "1,20.0"));
     }
 
     @Override

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/ValueSemanticsProviderAbstractTestCase.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/facets/value/ValueSemanticsProviderAbstractTestCase.java
@@ -45,6 +45,7 @@ import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.core.config.CausewayConfiguration;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
+import org.apache.causeway.core.metamodel.execution.MemberExecutorService;
 import org.apache.causeway.core.metamodel.facets.Mocking;
 import org.apache.causeway.core.metamodel.facets.object.value.ValueSerializer;
 import org.apache.causeway.core.metamodel.facets.object.value.ValueSerializer.Format;
@@ -77,6 +78,7 @@ abstract class ValueSemanticsProviderAbstractTestCase<T> {
         metaModelContext = MetaModelContext_forTesting.builder()
                 .testPropertyValues(TestPropertyValues.empty())
                 .interactionService(mockInteractionService)
+                .memberExecutor(Mockito.mock(MemberExecutorService.class))
                 .build();
 
         causewayConfiguration = metaModelContext.getConfiguration();
@@ -133,12 +135,9 @@ abstract class ValueSemanticsProviderAbstractTestCase<T> {
         final T value = getSample();
         final String encoded = getValueSerializer().enstring(format, value);
 
-        switch(format) {
-        case JSON:
-            assertValueEncodesToJsonAs(value, encoded);
-            break;
-        case URL_SAFE:
-            assertTrue(_Strings.isUrlSafe(encoded));
+        switch (format) {
+        case JSON -> assertValueEncodesToJsonAs(value, encoded);
+        case URL_SAFE -> assertTrue(_Strings.isUrlSafe(encoded));
         }
 
         T decoded = getValueSerializer().destring(format, encoded);

--- a/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemanticsProvider_configureDecimalFormat_Test.java
+++ b/core/mmtest/src/test/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemanticsProvider_configureDecimalFormat_Test.java
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
 import org.springframework.boot.test.util.TestPropertyValues;
 
 import org.apache.causeway.applib.Identifier;
@@ -85,12 +86,21 @@ class BigDecimalValueSemanticsProvider_configureDecimalFormat_Test {
                 valueSemantics.setCausewayConfiguration(causewayConfiguration);
 
                 // when
-                DecimalFormat format = new DecimalFormat();
-                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING);
+                var format = new DecimalFormat();
+                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING_AS_TEXT);
 
                 // then
                 Assertions.assertThat(format.getMaximumFractionDigits()).isEqualTo(maxScale);
                 Assertions.assertThat(format.getMinimumFractionDigits()).isEqualTo(minScale);
+
+                // and when
+                format = new DecimalFormat();
+                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING_AS_HTML);
+
+                // then
+                Assertions.assertThat(format.getMaximumFractionDigits()).isEqualTo(maxScale);
+                Assertions.assertThat(format.getMinimumFractionDigits()).isEqualTo(minScale);
+
             });
     }
 
@@ -111,12 +121,21 @@ class BigDecimalValueSemanticsProvider_configureDecimalFormat_Test {
                 valueSemantics.setCausewayConfiguration(causewayConfiguration);
 
                 // when
-                DecimalFormat format = new DecimalFormat();
-                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING);
+                var format = new DecimalFormat();
+                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING_AS_TEXT);
 
                 // then
                 Assertions.assertThat(format.getMaximumFractionDigits()).isEqualTo(maxScale);
                 Assertions.assertThat(format.getMinimumFractionDigits()).isEqualTo(fallbackScale);
+
+                // and when
+                format = new DecimalFormat();
+                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING_AS_HTML);
+
+                // then
+                Assertions.assertThat(format.getMaximumFractionDigits()).isEqualTo(maxScale);
+                Assertions.assertThat(format.getMinimumFractionDigits()).isEqualTo(fallbackScale);
+
             });
     }
 
@@ -137,12 +156,21 @@ class BigDecimalValueSemanticsProvider_configureDecimalFormat_Test {
                 valueSemantics.setCausewayConfiguration(causewayConfiguration);
 
                 // when
-                DecimalFormat format = new DecimalFormat();
-                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING);
+                var format = new DecimalFormat();
+                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING_AS_TEXT);
 
                 // then
                 Assertions.assertThat(format.getMaximumFractionDigits()).isEqualTo(maxScale);
                 Assertions.assertThat(format.getMinimumFractionDigits()).isEqualTo(defaultScale);
+
+                // and when
+                format = new DecimalFormat();
+                valueSemantics.configureDecimalFormat(context, format, ValueSemanticsAbstract.FormatUsageFor.RENDERING_AS_HTML);
+
+                // then
+                Assertions.assertThat(format.getMaximumFractionDigits()).isEqualTo(maxScale);
+                Assertions.assertThat(format.getMinimumFractionDigits()).isEqualTo(defaultScale);
+
             });
     }
 

--- a/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/ConverterTester.java
+++ b/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/ConverterTester.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.apache.wicket.util.convert.ConversionException;
 import org.assertj.core.util.Arrays;
@@ -43,9 +44,11 @@ import org.apache.causeway.applib.services.clock.ClockService;
 import org.apache.causeway.applib.services.iactn.InteractionContext;
 import org.apache.causeway.applib.services.iactn.InteractionService;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsAbstract;
+import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsResolver;
 import org.apache.causeway.commons.functional.ThrowingRunnable;
 import org.apache.causeway.commons.internal.assertions._Assert;
+import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.core.config.CausewayConfiguration;
 import org.apache.causeway.core.metamodel.commons.ViewOrEditMode;
@@ -87,24 +90,31 @@ public class ConverterTester<T extends Serializable> {
             final Object ...additionalSingletons) {
 
         mmc = MetaModelContext_forTesting.builder()
-                .testPropertyValues(testPropertyValues)
-                .valueSemantic(valueSemantics)
-                .singleton(new ClockService(null) {
-                    @Override public VirtualClock getClock() {
-                        return virtualClock;
-                    }
-                })
-                .singletons(Arrays.asList(additionalSingletons))
-                .interactionService(interactionService = new InteractionService_forTesting())
-                .memberExecutor(Mockito.mock(MemberExecutorService.class))
-                .build();
+            .testPropertyValues(testPropertyValues)
+            .valueSemantics(Stream
+                .concat(
+                    Stream.<ValueSemanticsProvider<?>>of(valueSemantics),
+                    // from additional singletons, lookout for value semantics providers, to be registered here
+                    _NullSafe.stream(additionalSingletons))
+                        .filter(ValueSemanticsProvider.class::isInstance)
+                        .<ValueSemanticsProvider<?>>map(ValueSemanticsProvider.class::cast)
+                .toList())
+            .singleton(new ClockService(null) {
+                @Override public VirtualClock getClock() {
+                    return virtualClock;
+                }
+            })
+            .singletons(Arrays.asList(additionalSingletons))
+            .interactionService(interactionService = new InteractionService_forTesting())
+            .memberExecutor(Mockito.mock(MemberExecutorService.class))
+            .build();
 
         mmc.getServiceInjector().injectServicesInto(valueSemantics);
 
         // pre-requisites for testing
-        var reg = mmc.getServiceRegistry().lookupServiceElseFail(ValueSemanticsResolver.class);
-        var sem = reg.streamValueSemantics(valueType).toList();
-        assertFalse(sem.isEmpty());
+        var resolver = mmc.getServiceRegistry().lookupServiceElseFail(ValueSemanticsResolver.class);
+        var valSem = resolver.streamValueSemantics(valueType).toList();
+        assertFalse(valSem.isEmpty());
         assertNotNull(mmc.getServiceRegistry().lookupServiceElseFail(InteractionService.class));
         assertNotNull(mmc.getInteractionService());
     }

--- a/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
+++ b/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
@@ -55,7 +55,7 @@ class BigDecimalConverterTest {
 
     private ConverterTester<BigDecimal> converterTester(final TestPropertyValues testPropertyValues) {
         return new ConverterTester<>(BigDecimal.class, testPropertyValues,
-                new BigDecimalValueSemantics(), new BigDecimalValueSemantics.LocaleGrouping());
+                new BigDecimalValueSemantics(), new BigDecimalValueSemantics.LocaleGroupingDisplay());
     }
 
     @Test
@@ -108,14 +108,14 @@ class BigDecimalConverterTest {
     void scale2_english_withThousandSeparators_allowed() {
         var converterTester = converterTester();
         converterTester.setScenario(Locale.ENGLISH, newConverter(converterTester, CustomerScale2.class));
-        converterTester.assertRoundtrip(bd_789123_45_scale2, "789123.45");
+        converterTester.assertRoundtrip(bd_789123_45_scale2, "789 123.45");
     }
 
     @Test
     void scale2_english_withoutThousandSeparators() {
         var converterTester = converterTester();
         converterTester.setScenario(Locale.ENGLISH, newConverter(converterTester, CustomerScale2.class));
-        converterTester.assertRoundtrip(bd_789123_45_scale2, "789123.45", "789123.45");
+        converterTester.assertRoundtrip(bd_789123_45_scale2, "789123.45", "789 123.45");
     }
 
     @Test
@@ -159,7 +159,7 @@ class BigDecimalConverterTest {
     static class CustomerScale2LocaleGrouping {
         @Property @Getter @Setter
         @Digits(fraction = 2, integer = 20)
-        @ValueSemantics(provider = NumericValueSemantics.LOCALE_GROUPING)
+        @ValueSemantics(provider = NumericValueSemantics.LOCALE_GROUPING_DISPLAY)
         private BigDecimal value;
     }
 

--- a/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
+++ b/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
@@ -25,12 +25,12 @@ import jakarta.validation.constraints.Digits;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.springframework.boot.test.util.TestPropertyValues;
 
 import org.apache.causeway.applib.annotation.DomainObject;
 import org.apache.causeway.applib.annotation.Property;
+import org.apache.causeway.applib.annotation.ValueSemantics;
+import org.apache.causeway.applib.value.semantics.NumericValueSemantics;
 import org.apache.causeway.core.metamodel.commons.ViewOrEditMode;
 import org.apache.causeway.core.metamodel.valuesemantics.BigDecimalValueSemantics;
 import org.apache.causeway.viewer.wicket.model.value.ConverterBasedOnValueSemantics;
@@ -50,11 +50,12 @@ class BigDecimalConverterTest {
     final BigDecimal bd_123_4500_scale4 = new BigDecimal("123.4500").setScale(4);
 
     private ConverterTester<BigDecimal> converterTester() {
-        return new ConverterTester<>(BigDecimal.class, TestPropertyValues.empty(), new BigDecimalValueSemantics());
+        return converterTester(TestPropertyValues.empty());
     }
 
     private ConverterTester<BigDecimal> converterTester(final TestPropertyValues testPropertyValues) {
-        return new ConverterTester<>(BigDecimal.class, testPropertyValues, new BigDecimalValueSemantics());
+        return new ConverterTester<>(BigDecimal.class, testPropertyValues,
+                new BigDecimalValueSemantics(), new BigDecimalValueSemantics.LocaleGrouping());
     }
 
     @Test
@@ -98,20 +99,14 @@ class BigDecimalConverterTest {
 
     @Test
     void scale2_english_withThousandSeparators_not_allowed() {
-        var converterTester = converterTester(TestPropertyValues.of(
-            "causeway.valueTypes.bigDecimal.display.useGroupingSeparator=false"));
-        assertThat(converterTester.getConfigurationForBigDecimalValueType().display().useGroupingSeparator()).isFalse();
-
-        converterTester.setScenario(Locale.ENGLISH, newConverter(converterTester, CustomerScale2.class));
+        var converterTester = converterTester();
+        converterTester.setScenario(Locale.ENGLISH, newConverter(converterTester, CustomerScale2LocaleGrouping.class));
         converterTester.assertConversionFailure("789,123.45", "Invalid value '789,123.45'; do not use the ',' grouping separator");
     }
 
     @Test
     void scale2_english_withThousandSeparators_allowed() {
-        var converterTester = converterTester(TestPropertyValues.of(
-            "causeway.valueTypes.bigDecimal.display.useGroupingSeparator=true"));
-        assertThat(converterTester.getConfigurationForBigDecimalValueType().display().useGroupingSeparator()).isTrue();
-
+        var converterTester = converterTester();
         converterTester.setScenario(Locale.ENGLISH, newConverter(converterTester, CustomerScale2.class));
         converterTester.assertRoundtrip(bd_789123_45_scale2, "789123.45");
     }
@@ -157,6 +152,14 @@ class BigDecimalConverterTest {
     static class CustomerScale2 {
         @Property @Getter @Setter
         @Digits(fraction = 2, integer = 20)
+        private BigDecimal value;
+    }
+
+    @DomainObject
+    static class CustomerScale2LocaleGrouping {
+        @Property @Getter @Setter
+        @Digits(fraction = 2, integer = 20)
+        @ValueSemantics(provider = NumericValueSemantics.LOCALE_GROUPING)
         private BigDecimal value;
     }
 


### PR DESCRIPTION
- [x] factor out `NumericValueSemantics` as a base for all numerical value types
- [x] Built-in ValueSemantics for 4 Number Grouping Separation Styles:
- - [x] No Grouping Separator (e.g.: when an integer is used to represent a year value)
- - [x] Locale specific grouping Separator (e.g.: for a Money value, if desired) 
- - - [x] display only (editing is grouped by spaces as the default)
- - - [x] display and editing
- - [x] New Default: Use narrow spacing for HTML rendering, use no grouping for TXT rendering
- [x] remove `BigDecimal` specific grouping policy configuration - no longer needed
- [x] test numeric parsing resilience against misplaced grouping separators

### Issues

> qualified ValueSemantics not used for Select2 dropdown (when rendering parameter choices)

descoped

> ValueSemanticsProvider precedence has no effect when explicitly listed in configuration's `Import` annotation

won't fix; at least we support qualifier based semantics selection

Task-Url: https://issues.apache.org/jira/browse/CAUSEWAY-4006